### PR TITLE
lightway-client: Register Ctrl-C handler later

### DIFF
--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -177,10 +177,6 @@ async fn handle_events(mut stream: EventStream, keepalive: Keepalive) {
 
 pub async fn client(config: ClientConfig) -> Result<()> {
     println!("Client starting with config:\n{:#?}", &config);
-    let (ctrlc_tx, mut ctrlc_rx) = tokio::sync::mpsc::channel(1);
-    ctrlc::set_handler(move || {
-        ctrlc_tx.blocking_send(()).expect("CtrlC handler failed");
-    })?;
 
     let root_ca_cert = RootCertificate::PemFileOrDirectory(&config.ca_cert);
 
@@ -361,6 +357,11 @@ pub async fn client(config: ClientConfig) -> Result<()> {
             }
         }
     });
+
+    let (ctrlc_tx, mut ctrlc_rx) = tokio::sync::mpsc::channel(1);
+    ctrlc::set_handler(move || {
+        ctrlc_tx.blocking_send(()).expect("CtrlC handler failed");
+    })?;
 
     tokio::select! {
         Some(_) = keepalive_task => Err(anyhow!("Keepalive timeout")),

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -116,11 +116,6 @@ pub async fn server<SA: ServerAuth + Sync + Send + 'static>(
 
     info!("Server starting with config:\n{:#?}", &config);
 
-    let (ctrlc_tx, mut ctrlc_rx) = tokio::sync::mpsc::channel(1);
-    ctrlc::set_handler(move || {
-        ctrlc_tx.blocking_send(()).expect("CtrlC handler failed");
-    })?;
-
     let tun_ip = match config.tun_ip {
         // Use the user specified IP
         Some(tun_ip) => {
@@ -234,6 +229,11 @@ pub async fn server<SA: ServerAuth + Sync + Send + 'static>(
             }
         }
     });
+
+    let (ctrlc_tx, mut ctrlc_rx) = tokio::sync::mpsc::channel(1);
+    ctrlc::set_handler(move || {
+        ctrlc_tx.blocking_send(()).expect("CtrlC handler failed");
+    })?;
 
     tokio::select! {
         err = server.run() => err.context("Outside IO loop exited"),


### PR DESCRIPTION
... right before the main event loop begins.

I used the wrong IP address in a test and was therefore blocking before reaching the mainloop, in `io::outside::Tcp::new`, I suppose TCP would eventually have timed out but in the meantime I was unable to Ctrl-C out of it since the handler had been registered but nothing was yet receiving from `ctrlc_rx`. By defering the registration we leave the default OS behaviour (term the process) in place until we are ready to deal with things ourselves.

It can be reproduced with the following if there is no server running:

```console
$ sudo ip netns exec lightway-client ./target/debug/lightway-client --config-file tests/client/client_config.yaml --mode tcp --ca-cert ca.crt --server 192.168.100.1:443
```

I don't think there is a similar failure mode for the server side, since it
receives rather than initiates connections, but make the same change there
nonetheless, there might be other similar issues with another step of the setup
process.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

