### PR TITLE
CVPN-956: handling of Full error on tun io-uring send

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,6 +992,7 @@ dependencies = [
  "humantime",
  "io-uring",
  "lightway-core",
+ "metrics",
  "pnet",
  "serde",
  "serde_with",

--- a/lightway-app-utils/Cargo.toml
+++ b/lightway-app-utils/Cargo.toml
@@ -32,6 +32,7 @@ tokio-eventfd = "0.2.1"
 dashmap = "5.5.3"
 thiserror = "1.0.57"
 tokio-tun = "0.11.2"
+metrics = "0.23.0"
 
 [[example]]
 name = "udprelay"

--- a/lightway-app-utils/src/lib.rs
+++ b/lightway-app-utils/src/lib.rs
@@ -26,5 +26,6 @@ pub use iouring::IOUring;
 
 pub use tun::Tun;
 
+mod metrics;
 mod utils;
 pub use utils::is_file_path_valid;

--- a/lightway-app-utils/src/metrics.rs
+++ b/lightway-app-utils/src/metrics.rs
@@ -1,0 +1,8 @@
+use metrics::counter;
+
+const METRIC_TUN_IOURING_DATA_DROPPED: &str = "tun_iouring_data_dropped";
+
+/// Counter for "sending into a full channel" type of error ([`async_channel::TrySendError::Full`])
+pub(crate) fn tun_iouring_data_dropped() {
+    counter!(METRIC_TUN_IOURING_DATA_DROPPED).increment(1);
+}


### PR DESCRIPTION
Treating tun io-uring Full error as OK scenario.
It is effectively the same scenario as a buffer in a network switch/router filling up so dropping the traffic is appropriate, higher level protocols (e.g. TCP) running over the tunnel will use their congestion control algorithms to adjust their send rate.

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
