### PR TITLE
CVPN-956: renaming metric for consistency

### DIFF
--- a/lightway-app-utils/src/iouring.rs
+++ b/lightway-app-utils/src/iouring.rs
@@ -4,7 +4,7 @@ use bytes::{BufMut, BytesMut};
 use dashmap::DashMap;
 use thiserror::Error;
 
-use crate::metrics::tun_iouring_data_dropped;
+use crate::metrics::tun_iouring_packet_dropped;
 use io_uring::{
     cqueue::Entry as CEntry, opcode, squeue::Entry as SEntry, types::Fixed, CompletionQueue,
     IoUring,
@@ -197,7 +197,7 @@ impl<T: AsRawFd> IOUring<T> {
             Err(e) if e.is_full() => {
                 // it is effectively the same scenario as a buffer in a network
                 // switch/router filling up so dropping the traffic is appropriate
-                tun_iouring_data_dropped();
+                tun_iouring_packet_dropped();
                 Ok(())
             }
             Err(e) => Err(IOUringError::SendError(e)),

--- a/lightway-app-utils/src/metrics.rs
+++ b/lightway-app-utils/src/metrics.rs
@@ -1,8 +1,8 @@
 use metrics::counter;
 
-const METRIC_TUN_IOURING_DATA_DROPPED: &str = "tun_iouring_data_dropped";
+const METRIC_TUN_IOURING_PACKET_DROPPED: &str = "tun_iouring_packet_dropped";
 
 /// Counter for "sending into a full channel" type of error ([`async_channel::TrySendError::Full`])
-pub(crate) fn tun_iouring_data_dropped() {
-    counter!(METRIC_TUN_IOURING_DATA_DROPPED).increment(1);
+pub(crate) fn tun_iouring_packet_dropped() {
+    counter!(METRIC_TUN_IOURING_PACKET_DROPPED).increment(1);
 }


### PR DESCRIPTION
Using naming that is consistent with other metrics being produced

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
