### PR TITLE
Earthly: copy artifacts locally from build container

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -47,8 +47,8 @@ build:
 
     DO lib-rust+CARGO --args="build --release --target=$target" --output="$target/release/lightway-(client|server)$"
 
-    SAVE ARTIFACT ./target/$target/release/lightway-client
-    SAVE ARTIFACT ./target/$target/release/lightway-server
+    SAVE ARTIFACT ./target/$target/release/lightway-client AS LOCAL ./target/$target/release/
+    SAVE ARTIFACT ./target/$target/release/lightway-server AS LOCAL ./target/$target/release/
 
 # build-arm64 build for arm64. Support building from an amd64 or arm64 host
 build-arm64:


### PR DESCRIPTION

## Description

Update Earthy target to copy binaries locally after building

## Motivation and Context

It makes it easier to use the binaries built using Earhtly.

## How Has This Been Tested?
Yes, verified the binaries copied locally.

```
❯ tree target/
target/
└── x86_64-unknown-linux-gnu
    └── release
        ├── lightway-client
        └── lightway-server

3 directories, 2 files
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
