### PR TITLE
tests: Add test cases with a single Tokio worker thread

### DIFF
--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -12,6 +12,9 @@ TEST:
     FUNCTION
     FROM ./e2e+build-container
 
+    ARG CLIENT_TOKIO_WORKER_THREADS
+    ARG SERVER_TOKIO_WORKER_THREADS
+
     ARG MODE
     ARG SERVER_PORT
     ARG SERVER_EXTRA_ARGS=""
@@ -21,8 +24,8 @@ TEST:
     ARG SERVER_ARGS="--config-file server_config.yaml --log-level trace --mode ${MODE} ${SERVER_EXTRA_ARGS} --bind-address 0.0.0.0:${SERVER_PORT}"
     ARG CLIENT_ARGS="--config-file client_config.yaml --log-level trace --mode ${MODE} ${CLIENT_EXTRA_ARGS} --server server:${SERVER_PORT}"
 
-    ARG CLIENT_IMAGE="(./client+build-container --debian=$debian)"
-    ARG SERVER_IMAGE="(./server+build-container --debian=$debian)"
+    ARG CLIENT_IMAGE="(./client+build-container --TOKIO_WORKER_THREADS=$CLIENT_TOKIO_WORKER_THREADS --debian=$debian)"
+    ARG SERVER_IMAGE="(./server+build-container --TOKIO_WORKER_THREADS=$SERVER_TOKIO_WORKER_THREADS --debian=$debian)"
     ARG NGINX_IMAGE="./base+build-test-nginx-container"
     ARG IPERF_IMAGE="(./base+build-test-iperf-container --debian=$debian)"
 
@@ -102,6 +105,14 @@ run-udp-keepalive-test:
 run-tcp-keepalive-test:
     DO +TEST --MODE=tcp --SERVER_PORT=443 --CLIENT_EXTRA_ARGS="--keepalive-interval=2s --keepalive-timeout=6s"
 
+# run-udp-single-threaded-test runs e2e test of UDP with server and client using a single Tokio worker thread
+run-udp-single-threaded-test:
+    DO +TEST --MODE=udp --SERVER_PORT=27690 --SERVER_TOKIO_WORKER_THREADS=1 --SERVER_EXTRA_ARGS="--enable-tun-iouring" --CLIENT_TOKIO_WORKER_THREADS=1 --CLIENT_EXTRA_ARGS="--keepalive-interval=2s --keepalive-timeout=6s --enable-tun-iouring --enable-pmtud"
+
+# run-tcp-single-threaded-test runs e2e test of TCP with server and client using a single Tokio worker thread
+run-tcp-single-threaded-test:
+    DO +TEST --MODE=tcp --SERVER_PORT=443 --SERVER_TOKIO_WORKER_THREADS=1 --CLIENT_TOKIO_WORKER_THREADS=1 --CLIENT_EXTRA_ARGS="--keepalive-interval=2s --keepalive-timeout=6s --enable-pmtud"
+
 # run-all-tests runs all tests
 run-all-tests:
     BUILD +run-tcp-aes256-test
@@ -121,3 +132,5 @@ run-all-tests:
     BUILD +run-tcp-max-inside-mtu-test
     BUILD +run-udp-keepalive-test
     BUILD +run-tcp-keepalive-test
+    BUILD +run-udp-single-threaded-test
+    BUILD +run-tcp-single-threaded-test

--- a/tests/client/Earthfile
+++ b/tests/client/Earthfile
@@ -2,11 +2,15 @@ VERSION 0.8
 ARG --global debian
 
 build-container:
+    ARG TOKIO_WORKER_THREADS
     FROM ../base+container --debian=$debian
     COPY (../..+build/lightway-client --debian=$debian) .
     COPY --dir ../certs+client/* certs/
     COPY --dir client_config.yaml docker-entrypoint.sh run-test-inside.sh .
     HEALTHCHECK --interval=1s --timeout=1s --start-period=0s --retries=30 CMD ping -c1 nginx
+    IF [ -n "$TOKIO_WORKER_THREADS" ]
+        ENV TOKIO_WORKER_THREADS=$TOKIO_WORKER_THREADS
+    END
     ENTRYPOINT ["/docker-entrypoint.sh"]
 
 save-container:

--- a/tests/server/Earthfile
+++ b/tests/server/Earthfile
@@ -2,11 +2,15 @@ VERSION 0.8
 ARG --global debian
 
 build-container:
+    ARG TOKIO_WORKER_THREADS
     FROM ../base+container --debian=$debian
     COPY (../..+build/lightway-server --debian=$debian) .
     COPY --dir ../certs+server/* certs/
     COPY --dir server_config.yaml docker-entrypoint.sh .
     HEALTHCHECK --interval=1s --timeout=1s --start-period=0s --retries=3 CMD [ -n "$(ss -HOlutn sport = :${SERVER_PORT:-443})" ]
+    IF [ -n "$TOKIO_WORKER_THREADS" ]
+        ENV TOKIO_WORKER_THREADS=$TOKIO_WORKER_THREADS
+    END
     ENTRYPOINT ["/docker-entrypoint.sh"]
 
 save-container:


### PR DESCRIPTION
The hope is that this will help catch potential deadlocks or other problems/interactions which do not manifest if there are multiple worker threads.

To facilitate this these tests enable PMTUD and keepalive so we have the large set of tasks.

Also enable io_uring in one of the tests but not the other, in principal this is independent of the tunnel mode so this allows us to test both io_uring and tun modes without exploding the test matrix any further.
