### PR TITLE
CVPN-939 Sync Connection State Enum Values with Lightway C

### DIFF
--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -63,24 +63,25 @@ const WOLF_TICK_DTLS13_QUICK_TIMEOUT_DIVISOR: u32 = 4;
 
 /// Connection state
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[repr(u8)]
 pub enum State {
     /// Secure connection is being established.
-    Connecting,
+    Connecting = 2,
 
     /// Secure connection is established
-    LinkUp,
+    LinkUp = 6,
 
     /// Connection is established, client is authenticating
-    Authenticating,
+    Authenticating = 5,
     // Configuring,
     /// Tunnel is online
-    Online,
+    Online = 7,
 
     /// Disconnect is in progress
-    Disconnecting,
+    Disconnecting = 4,
 
     /// Connection has been disconnected
-    Disconnected,
+    Disconnected = 1,
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Explicitly specify the connection state enum values to maintain consistency between Lightway C and Rust.

State enum definition in Lightway C (under `he_conn_state`) can be found here:
https://github.com/expressvpn/lightway-core/blob/main/include/he.h

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CI tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
