### PR TITLE
CVPN-939 Isolate io-uring as crate feature

### DIFF
--- a/lightway-app-utils/Cargo.toml
+++ b/lightway-app-utils/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = [ "tokio", "io-uring" ]
+default = [ "tokio" ]
 tokio = [ "dep:tokio", "dep:tokio-stream" ]
 io-uring = [ "dep:io-uring", "dep:async-channel", "dep:tokio", ]
 
@@ -43,4 +43,3 @@ async-trait = "0.1.77"
 pnet = "0.35.0"
 tokio-eventfd = "0.2.1"
 tokio-tun = "0.11.2"
-

--- a/lightway-app-utils/src/lib.rs
+++ b/lightway-app-utils/src/lib.rs
@@ -9,6 +9,7 @@ mod connection_ticker;
 mod dplpmtud_timer;
 #[cfg(feature = "tokio")]
 mod event_stream;
+#[cfg(feature = "io-uring")]
 mod iouring;
 mod tun;
 
@@ -26,6 +27,7 @@ pub use iouring::IOUring;
 
 pub use tun::Tun;
 
+#[cfg(feature = "io-uring")]
 mod metrics;
 mod utils;
 pub use utils::is_file_path_valid;

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -9,9 +9,10 @@ license = "GPL-2.0-only"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["postquantum"]
+default = ["postquantum", "io-uring"]
 debug = ["lightway-core/debug"]
 postquantum = ["lightway-core/postquantum"]
+io-uring = ["lightway-app-utils/io-uring"]
 
 [dependencies]
 lightway-core = { path = "../lightway-core" }

--- a/lightway-client/src/io/inside/tun.rs
+++ b/lightway-client/src/io/inside/tun.rs
@@ -26,12 +26,15 @@ impl Tun {
         ip: Ipv4Addr,
         dns_ip: Ipv4Addr,
         mtu: Option<i32>,
-        iouring: Option<usize>,
+        #[cfg(feature = "io-uring")] iouring: Option<usize>,
     ) -> Result<Self> {
+        #[cfg(feature = "io-uring")]
         let tun = match iouring {
             Some(ring_size) => AppUtilsTun::iouring(name, mtu, ring_size).await?,
             None => AppUtilsTun::direct(name, mtu).await?,
         };
+        #[cfg(not(feature = "io-uring"))]
+        let tun = AppUtilsTun::direct(name, mtu).await?;
         Ok(Tun { tun, ip, dns_ip })
     }
 

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -112,11 +112,13 @@ pub struct ClientConfig<'cert> {
     pub enable_pmtud: bool,
 
     /// Enable IO-uring interface for Tunnel
+    #[cfg(feature = "io-uring")]
     pub enable_tun_iouring: bool,
 
     /// IO-uring submission queue count. Only applicable when
     /// `enable_tun_iouring` is `true`
     // Any value more than 1024 negatively impact the throughput
+    #[cfg(feature = "io-uring")]
     pub iouring_entry_count: usize,
 
     /// Server domain name to validate
@@ -209,6 +211,7 @@ pub async fn client(config: ClientConfig<'_>) -> Result<()> {
         outside_io.set_recv_buffer_size(size.as_u64().try_into()?)?;
     }
 
+    #[cfg(feature = "io-uring")]
     let iouring = if config.enable_tun_iouring {
         Some(config.iouring_entry_count)
     } else {
@@ -221,6 +224,7 @@ pub async fn client(config: ClientConfig<'_>) -> Result<()> {
             config.tun_local_ip,
             config.tun_dns_ip,
             config.inside_mtu,
+            #[cfg(feature = "io-uring")]
             iouring,
         )
         .await?,

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -66,7 +66,9 @@ async fn main() -> Result<()> {
         sndbuf: config.sndbuf,
         rcvbuf: config.rcvbuf,
         enable_pmtud: config.enable_pmtud,
+        #[cfg(feature = "io-uring")]
         enable_tun_iouring: config.enable_tun_iouring,
+        #[cfg(feature = "io-uring")]
         iouring_entry_count: config.iouring_entry_count,
         server_dn: config.server_dn,
         server: config.server,

--- a/lightway-server/Cargo.toml
+++ b/lightway-server/Cargo.toml
@@ -8,6 +8,10 @@ license = "GPL-2.0-only"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["io-uring"]
+io-uring = ["lightway-app-utils/io-uring"]
+
 [dependencies]
 lightway-core = { path = "../lightway-core", features = ["postquantum"] }
 lightway-app-utils = { path = "../lightway-app-utils" }


### PR DESCRIPTION
## Description
io-uring is a linux-only feature. Isolating it would allow us to enable and disable at will for different platforms.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CI Tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
