### PR TITLE
Exit with status 0 (Ok) on graceful exit on from `SIG{INT,TERM}`

### DIFF
--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -405,7 +405,7 @@ pub async fn client<A: 'static + Send + EventCallback>(
         _ = ctrlc_rx.recv(), if config.exit_on_ctrlc => {
             info!("sigint/sigterm received, gracefully shutting down");
             let _ = conn.lock().unwrap().disconnect();
-            Err(anyhow!("sigint/sigterm received"))
+            Ok(())
         }
     }
 }

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -241,7 +241,7 @@ pub async fn server<SA: ServerAuth + Sync + Send + 'static>(
         _ = ctrlc_rx.recv() => {
             info!("Sigterm or Sigint received");
             conn_manager.close_all_connections();
-            Err(anyhow!("sigint/sigterm received"))
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
When a process is killed by SIGINT or SIGTERM etc it is expected that it will exit with status code zero rather than a non-zero value indicating failure.

## Motivation and Context

A service monitor (e.g. systemd) which runs lightway would expect a clean exit after sending the correct signal, returning with a failure causes things to appear to have "failed".

## How Has This Been Tested?

Built it, ran it, killed it and observed exit status.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
