### PR TITLE
lightway-{client,server}: Add `--tls-debug` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,3 +245,9 @@ The resulting file can then be exported to Wireshark to decrypt data traffic. Th
 
 https://www.wireshark.org/docs/wsug_html_chunked/ChIOExportSection.html#ChIOExportTLSSessionKeys
 https://wiki.wireshark.org/TLS#using-the-pre-master-secret
+
+### WolfSSL debug logging
+
+Both `lightway-client` and `lightway-server` support a `--tls-debug`
+option when built with their respective `debug` feature enabled. This
+enables WolfSSL's debug logging.

--- a/lightway-client/src/args.rs
+++ b/lightway-client/src/args.rs
@@ -107,4 +107,9 @@ pub struct Config {
     #[cfg(feature = "debug")]
     #[clap(long, default_value = None)]
     pub keylog: Option<PathBuf>,
+
+    /// Enable WolfSSL debug logging
+    #[cfg(feature = "debug")]
+    #[clap(long)]
+    pub tls_debug: bool,
 }

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -18,6 +18,8 @@ use lightway_core::{
 };
 
 // re-export so client app does not need to depend on lightway-core
+#[cfg(feature = "debug")]
+pub use lightway_core::enable_tls_debug;
 pub use lightway_core::{
     AuthMethod, PluginFactoryError, PluginFactoryList, RootCertificate, Version, MAX_INSIDE_MTU,
     MAX_OUTSIDE_MTU,

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -43,6 +43,11 @@ async fn main() -> Result<()> {
         Layer::Clap(matches),
     ])?;
 
+    #[cfg(feature = "debug")]
+    if config.tls_debug {
+        enable_tls_debug();
+    }
+
     tracing_subscriber::fmt()
         .with_max_level(config.log_level)
         .init();

--- a/lightway-core/src/lib.rs
+++ b/lightway-core/src/lib.rs
@@ -86,6 +86,12 @@ pub const MIN_INSIDE_MTU: usize = 1250;
 /// The largest supported inside MTU.
 pub const MAX_INSIDE_MTU: usize = 1500;
 
+/// Enable debug logging from WolfSSL
+#[cfg(feature = "debug")]
+pub fn enable_tls_debug() {
+    wolfssl::enable_debugging(true)
+}
+
 #[cfg(feature = "fuzzing_api")]
 pub use wire::{FromWireError, FromWireResult};
 

--- a/lightway-server/Cargo.toml
+++ b/lightway-server/Cargo.toml
@@ -10,6 +10,7 @@ license = "GPL-2.0-only"
 
 [features]
 default = ["io-uring"]
+debug = ["lightway-core/debug"]
 io-uring = ["lightway-app-utils/io-uring"]
 
 [dependencies]

--- a/lightway-server/src/args.rs
+++ b/lightway-server/src/args.rs
@@ -91,4 +91,9 @@ pub struct Config {
     /// Address to listen to
     #[clap(long, default_value = "0.0.0.0:27690")]
     pub bind_address: SocketAddr,
+
+    /// Enable WolfSSL debug logging
+    #[cfg(feature = "debug")]
+    #[clap(long)]
+    pub tls_debug: bool,
 }

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -5,6 +5,9 @@ mod ip_manager;
 mod metrics;
 mod statistics;
 
+// re-export so server app does not need to depend on lightway-core
+#[cfg(feature = "debug")]
+pub use lightway_core::enable_tls_debug;
 pub use lightway_core::{
     PluginFactoryError, PluginFactoryList, ServerAuth, ServerAuthHandle, ServerAuthResult, Version,
 };

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -12,7 +12,7 @@ use twelf::Layer;
 
 use args::Config;
 use lightway_app_utils::{is_file_path_valid, TunConfig};
-use lightway_server::{server, ServerAuth, ServerAuthResult, ServerConfig};
+use lightway_server::*;
 
 struct Auth {
     user: String,
@@ -79,6 +79,11 @@ async fn main() -> Result<()> {
         Layer::Env(Some(String::from("LW_SERVER_"))),
         Layer::Clap(matches),
     ])?;
+
+    #[cfg(feature = "debug")]
+    if config.tls_debug {
+        enable_tls_debug();
+    }
 
     let fmt = tracing_subscriber::fmt().with_max_level(config.log_level);
 


### PR DESCRIPTION
## Description

This option enables debugging in WolfSSL, and therefore requires a debug build of wolfssl. Use the existing debug feature in the client and add a similar option for server.

## Motivation and Context

Without this one needs to enable  `lightway-core/debug` and manually add a call to `wolfssl::enable_debugging` somewhere, this is more convenient.

## How Has This Been Tested?

Built with and without the feature and tested with and without the option in the former case.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
