### PR TITLE
lightway-client: Use a oneshot signal for the stop_signal (ctrl-c)

### DIFF
--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -35,7 +35,7 @@ use std::{
 };
 use tokio::{
     net::{TcpStream, UdpSocket},
-    sync::mpsc::Receiver,
+    sync::oneshot::Receiver,
     task::JoinHandle,
 };
 use tokio_stream::StreamExt;
@@ -405,7 +405,7 @@ pub async fn client<A: 'static + Send + EventCallback>(
         Some(_) = keepalive_task => Err(anyhow!("Keepalive timeout")),
         io = outside_io_loop => Err(anyhow!("Outside IO loop exited: {io:?}")),
         io = inside_io_loop => Err(anyhow!("Inside IO loop exited: {io:?}")),
-        _ = config.stop_signal.recv() => {
+        _ = config.stop_signal => {
             info!("client shutting down ..");
             let _ = conn.lock().unwrap().disconnect();
             Ok(())


### PR DESCRIPTION
The receiver immediate exits when the channel is received, sending more ctrl-c's will do nothing.

The `ctrlc::set_handler` API requires a `FnMut`, which is incompatible with direct use of `oneshot::Sender` since `send` consumes, meaning the closure would be `FnOnce`. We can use an `Option` and `take` since we only need to send on the first Ctrl-C we get.
