### PR TITLE
lightway-{client,server}: Failure to send Ctrl-C signal is not fatal

### DIFF
--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -73,8 +73,8 @@ async fn main() -> Result<()> {
     let (ctrlc_tx, ctrlc_rx) = tokio::sync::oneshot::channel();
     let mut ctrlc_tx = Some(ctrlc_tx);
     ctrlc::set_handler(move || {
-        if let Some(tx) = ctrlc_tx.take() {
-            tx.send(()).expect("CtrlC handler failed");
+        if let Some(Err(err)) = ctrlc_tx.take().map(|tx| tx.send(())) {
+            tracing::warn!("Failed to send Ctrl-C signal: {err:?}");
         }
     })?;
 


### PR DESCRIPTION
Failing to send on a oneshot channel can only happen if the other end has died, which is already fatal (or soon will be).

Panicking in the Ctrl-C handler "will not be caught and will cause the signal handler thread to stop" according to [`ctrlc::set_handler` docs][], so the `.expect()` is not very useful.

[`ctrlc::set_handler` docs]: https://detegr.github.io/doc/ctrlc/fn.set_handler.html
