### PR TITLE
Really enable unsafe related lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,11 @@ resolver = "2"
 lto = true
 debug = 1
 
+[workspace.lints.rust]
+unsafe_code = "deny"
+
 [workspace.lints.clippy]
 undocumented_unsafe_blocks = "deny"
-unsafe_code = "deny"
 
 [workspace.dependencies]
 anyhow = "1.0.79"

--- a/lightway-app-utils/Cargo.toml
+++ b/lightway-app-utils/Cargo.toml
@@ -14,6 +14,9 @@ default = [ "tokio" ]
 io-uring = [ "dep:io-uring", "dep:async-channel", "dep:tokio", "dep:tokio-eventfd" ]
 tokio = [ "dep:tokio", "dep:tokio-stream" ]
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 async-channel = { workspace = true, optional = true }

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -14,6 +14,9 @@ debug = ["lightway-core/debug"]
 io-uring = ["lightway-app-utils/io-uring"]
 postquantum = ["lightway-core/postquantum"]
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/lightway-core/Cargo.toml
+++ b/lightway-core/Cargo.toml
@@ -16,6 +16,9 @@ debug = ["wolfssl/debug"]
 fuzzing_api = []
 postquantum = ["wolfssl/postquantum"]
 
+[lints]
+workspace = true
+
 [dependencies]
 bytes = { workspace = true }
 delegate = { workspace = true }

--- a/lightway-server/Cargo.toml
+++ b/lightway-server/Cargo.toml
@@ -13,6 +13,9 @@ default = ["io-uring"]
 debug = ["lightway-core/debug"]
 io-uring = ["lightway-app-utils/io-uring"]
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 async-channel = { workspace = true, optional = true }


### PR DESCRIPTION
## Description

A `workspace.lints.*` block in a workspace `Cargo.toml` does nothing unless the individual crates opt-in.

This omission let several issues creep in:

- `unsafe_code` is a rust lint not a clippy one
- iouring uses unsafe code, due to the nature of the underlying API this is reasonable. However:
  - we need to mark the usage sites as allowing unsafe (there are two so prefer local annotations over file-wide).
  - we were missing the required `SAFETY` comments.

@kp-mariappan-ramasamy please double check my SAFETY comments in particular...

## Motivation and Context

Ensure that we follow best practice when we use `unsafe`.

## How Has This Been Tested?

Compiling + running clippy

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
