### PR TITLE
CVPN-940: enable clone on EventStreamCallback

### DIFF
--- a/lightway-app-utils/src/event_stream.rs
+++ b/lightway-app-utils/src/event_stream.rs
@@ -6,6 +6,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 /// Helper to propagate events into an async stream. Pass this type to
 /// `with_event_cb`.
+#[derive(Clone)]
 pub struct EventStreamCallback(mpsc::Sender<Event>);
 
 /// A stream of [`Event`].


### PR DESCRIPTION
## Description

Event Stream callback uses mpsc as a backend channel. 
So it is possible to have multiple event listeners and one event handler by derive clone on `EventStreamCallback`

