### PR TITLE
Revert "[auto] Update Rust toolchain to 1.80.1"

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -6,7 +6,7 @@ ARG --global debian = bookworm
 IMPORT github.com/earthly/lib/rust:a49d2a0f4028cd15666d19904f8fc5fbd0b9ba87 AS lib-rust
 
 install-build-dependencies:
-    FROM rust:1.80.1-$debian
+    FROM rust:1.80.0-$debian
     WORKDIR /lightway
     RUN dpkg --add-architecture arm64
     RUN apt-get update -qq


### PR DESCRIPTION
This reverts commit 9d643e98494f5d3ae7ea8e6f7f9a1ec2c5b15e10.

We have seen strange issue in CI since this update, e.g. https://github.com/expressvpn/lightway/actions/runs/10400777425/job/28801984468?pr=63 which failed because it looks like `lightway-server` build was using a different version of `lightway-core` (which didn't have the new generic type on `ServerAuth`).
