### PR TITLE
lightway-app-utils: Bump tun2 dep to 2.0.6

### DIFF
--- a/lightway-app-utils/Cargo.toml
+++ b/lightway-app-utils/Cargo.toml
@@ -36,7 +36,7 @@ tokio-eventfd = { version = "0.2.1", optional = true }
 tokio-stream = { workspace = true, optional = true }
 tokio-util = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["json"] }
-tun2 = { version = "2.0.3", features = ["async"] }
+tun2 = { version = "2.0.6", features = ["async"] }
 
 [[example]]
 name = "udprelay"


### PR DESCRIPTION
After the changes in 89a7b4943502 ("lightway-app-utils: Update for tun2 API changes") we depend on the API changes in this release.
