### PR TITLE
server: use local addr for outgoing traffic

### DIFF
--- a/lightway-server/src/io/outside/udp/cmsg.rs
+++ b/lightway-server/src/io/outside/udp/cmsg.rs
@@ -93,3 +93,252 @@ impl<'a, const N: usize> Iterator for Iter<'a, N> {
         }
     }
 }
+
+#[repr(C, align(16))] // Must be suitably aligned for a `libc::cmsghdr`.
+pub(crate) struct BufferMut<const N: usize>([u8; N]);
+
+impl<const N: usize> BufferMut<N> {
+    pub(crate) fn zeroed() -> Self {
+        Self([0; N])
+    }
+
+    /// # Safety
+    ///
+    /// From <https://man7.org/linux/man-pages/man3/cmsg.3.html>:
+    /// The provided buffer should be zero-initialized to ensure the
+    /// correct operation of CMSG_NXTHDR().
+    ///
+    /// Since `BufferMut::zeroed()` is the only constructor this must
+    /// be the case.
+    ///
+    /// Note that this is not mentioned in
+    /// <https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/basedefs/sys_socket.h.html>.
+    pub(crate) fn builder(&mut self) -> BufferBuilder<N> {
+        // Build a `msghdr` so we can use the `CMSG_*` functionality in
+        // libc. We will only use the `CMSG_*` macros which only use
+        // the `msg_control*` fields.
+        let msghdr = libc::msghdr {
+            msg_name: std::ptr::null_mut(),
+            msg_namelen: 0,
+            msg_iov: std::ptr::null_mut(),
+            msg_iovlen: 0,
+            msg_control: self.0.as_mut_ptr() as *mut _,
+            msg_controllen: self.0.len(),
+            msg_flags: 0,
+        };
+        // SAFETY: We constructed a sufficiently valid `msghdr` above.
+        // `msg_control[..msg_controllen]` are valid initialized bytes
+        // per the safety requirements for calling this method.
+        let cmsghdr = unsafe { libc::CMSG_FIRSTHDR(&msghdr) };
+
+        BufferBuilder {
+            msghdr,
+            cmsghdr,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<const N: usize> AsRef<[u8]> for BufferMut<N> {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+pub(crate) struct BufferBuilder<'a, const N: usize> {
+    msghdr: libc::msghdr,
+    cmsghdr: *mut libc::cmsghdr,
+    // `msghdr` contains a raw pointer into the owning `Buffer` and
+    // `cursor` is within that buffer. Ensure it remains live longer
+    // than this iterator.
+    _phantom: std::marker::PhantomData<&'a mut Buffer<N>>,
+}
+
+impl<'a, const N: usize> BufferBuilder<'a, N> {
+    pub(crate) fn fill_next<T>(
+        &mut self,
+        cmsg_level: libc::c_int,
+        cmsg_type: libc::c_int,
+        data: T,
+    ) -> std::io::Result<()> {
+        // Our use of `CMSG_FIRSTHDR` to get a validly aligned pointer
+        // to a `cmsghdr` assumes that `cmsghdr` requires no more
+        // alignment than `BufferMut`.
+        const { assert!(std::mem::align_of::<libc::cmsghdr>() <= std::mem::align_of::<BufferMut<N>>()) };
+        // Our use of `CMSG_DATA` to get a validly aligned pointer to
+        // `T` requires that `T` requires no more alignment than
+        // `cmsghdr`.
+        const { assert!(std::mem::align_of::<T>() <= std::mem::align_of::<libc::cmsghdr>()) };
+
+        if self.cmsghdr.is_null() {
+            return Err(std::io::Error::other(
+                "cmsg buffer: insufficient space for next header",
+            ));
+        }
+
+        let data_size = std::mem::size_of::<T>();
+
+        // SAFETY: `CMSG_LEN` is always safe
+        let cmsg_len = unsafe { libc::CMSG_LEN(data_size as libc::c_uint) as libc::size_t };
+        // SAFETY:
+        //
+        // The pointer is valid. It was produced by a previous call to
+        // either `CMSG_FIRSTHDR` or `CMSG_NXTHDR`. Both of which
+        // check for bounds compared with the length in `msghdr` and
+        // return NULL if there is not enough space. We checked for
+        // NULL above.
+        //
+        // The pointer is correctly aligned for a `cmsghdr`:
+        // - For the initial iteration `CMSG_FIRSTHDR` maintains the
+        //   alignment of the underlying `BufferMut`, which we
+        //   asserted above is at least that of a `cmsghdr`.
+        // - For subsequent iterations `CMSG_NXTHDR` takes alignment
+        //   into consideration and returns a pointer correctly aligned
+        //   for a `cmsghdr`.
+        unsafe {
+            self.cmsghdr.write(libc::cmsghdr {
+                cmsg_len,
+                cmsg_level,
+                cmsg_type,
+            });
+        }
+
+        // SAFETY: `self.cmsghdr` is a valid `cmsghdr` from a prior
+        // call to `CMSG_FIRSTHDR` or `CMSG_NXTHDR`, see full argument
+        // above.
+        let cmsg_data = unsafe { libc::CMSG_DATA(self.cmsghdr) };
+
+        // Check that we have sufficient space remaining. `CMSG_DATA`
+        // does not do this.
+        let max = self.msghdr.msg_control as usize + self.msghdr.msg_controllen;
+        let end = cmsg_data as usize + data_size;
+
+        if end > max {
+            return Err(std::io::Error::other(
+                "cmsg buffer: insufficient space for data",
+            ));
+        }
+
+        let cmsg_data = cmsg_data as *mut T;
+        // SAFETY:
+        //
+        // `CMSG_DATA` always returns a valid pointer given a valid
+        // `cmsghdr`, which we gave it.
+        //
+        // We validated there was enough room for a `T` above.
+        //
+        // `CMSG_DATA` returns a pointer validly aligned for a
+        // `cmsghdr`. We asserted above that `T` does not have a
+        // stricter alignment requirement.
+        unsafe { cmsg_data.write(data) };
+
+        // SAFETY: `self.cmsghdr` is a valid `cmsghdr` from a prior
+        // call to `CMSG_FIRSTHDR` or `CMSG_NXTHDR`. If the result is
+        // NULL this will be checked on the next call to `fill_next`.
+        self.cmsghdr = unsafe { libc::CMSG_NXTHDR(&self.msghdr, self.cmsghdr) };
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+
+    use super::*;
+    use more_asserts::*;
+
+    #[test]
+    fn success_single_pktinfo() {
+        const SIZE: usize = Message::space::<libc::in_pktinfo>();
+        let mut cmsg = BufferMut::<SIZE>::zeroed();
+        let mut builder = cmsg.builder();
+        builder
+            .fill_next(
+                0,
+                0,
+                libc::in_pktinfo {
+                    ipi_ifindex: 0,
+                    ipi_spec_dst: libc::in_addr { s_addr: 0 },
+                    ipi_addr: libc::in_addr { s_addr: 0 },
+                },
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn fill_empty_buffer() {
+        let mut cmsg = BufferMut::<0>::zeroed();
+        let mut builder = cmsg.builder();
+        let err = builder.fill_next(0, 0, 0).unwrap_err();
+        assert!(matches!(err.kind(), std::io::ErrorKind::Other));
+        assert!(err
+            .to_string()
+            .contains("cmsg buffer: insufficient space for next header"));
+    }
+
+    #[test]
+    fn not_enough_room_for_first_header() {
+        let mut cmsg = BufferMut::<4>::zeroed();
+        assert_lt!(cmsg.0.len(), std::mem::size_of::<libc::cmsghdr>());
+
+        let mut builder = cmsg.builder();
+        let err = builder.fill_next(0, 0, 0).unwrap_err();
+        assert!(matches!(err.kind(), std::io::ErrorKind::Other));
+        assert!(err
+            .to_string()
+            .contains("cmsg buffer: insufficient space for next header"));
+    }
+
+    #[test]
+    fn not_enough_room_for_next_header() {
+        const SIZE: usize = Message::space::<libc::in_pktinfo>();
+        let mut cmsg = BufferMut::<SIZE>::zeroed();
+
+        let mut builder = cmsg.builder();
+
+        builder
+            .fill_next(
+                0,
+                0,
+                libc::in_pktinfo {
+                    ipi_ifindex: 0,
+                    ipi_spec_dst: libc::in_addr { s_addr: 0 },
+                    ipi_addr: libc::in_addr { s_addr: 0 },
+                },
+            )
+            .unwrap();
+        let err = builder.fill_next(0, 0, 0).unwrap_err();
+        assert!(matches!(err.kind(), std::io::ErrorKind::Other));
+        assert!(err
+            .to_string()
+            .contains("cmsg buffer: insufficient space for next header"));
+    }
+
+    #[test]
+    fn not_enough_room_for_data() {
+        // NOTE: Message::space adds padding, which can confound things here.
+        const SIZE: usize =
+            std::mem::size_of::<libc::cmsghdr>() + std::mem::size_of::<libc::in_pktinfo>() - 1;
+        let mut cmsg = BufferMut::<SIZE>::zeroed();
+        assert_gt!(cmsg.0.len(), std::mem::size_of::<libc::cmsghdr>());
+        assert_lt!(cmsg.0.len(), Message::space::<libc::in_pktinfo>());
+
+        let mut builder = cmsg.builder();
+        let err = builder
+            .fill_next(
+                0,
+                0,
+                libc::in_pktinfo {
+                    ipi_ifindex: 0,
+                    ipi_spec_dst: libc::in_addr { s_addr: 0 },
+                    ipi_addr: libc::in_addr { s_addr: 0 },
+                },
+            )
+            .unwrap_err();
+        assert!(matches!(err.kind(), std::io::ErrorKind::Other));
+        assert!(err
+            .to_string()
+            .contains("cmsg buffer: insufficient space for data"));
+    }
+}


### PR DESCRIPTION
## Description
As a followup to #62 as well as being prepared to receive from multiple interfaces we also need to arrange that replies to a given connection use the correct source address.


## Motivation and Context

On a server with multiple interfaces I would like to configure to listen on 0.0.0.0:PORT to support connections to any IP address.

## How Has This Been Tested?

Locally, plus I ran [miri](https://github.com/rust-lang/miri)  over the new cmsg helper.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
