### PR TITLE
GHA/Earthfile: Add a job to run a subset of module unit tests under Miri

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [test, test-arm64, build, build-arm64, fmt, lint, check-dependencies]
+        target: [test, test-miri, test-arm64, build, build-arm64, fmt, lint, check-dependencies]
     runs-on: ubuntu-latest
     env:
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"


### PR DESCRIPTION
[Miri][] is a tool which helps detect undefined behaviour (in unsafe code).

Run the tests of any module which contains unsafe code under it to help flag up any errors.

We don't run all tests since Miri does not currently support various calls, for one example:
```
error: unsupported operation: returning ready events from epoll_wait is not yet implemented
  --> $CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/sys/unix/selector/epoll.rs:56:9
   |
56 | /         syscall!(epoll_wait(
57 | |             self.ep.as_raw_fd(),
58 | |             events.as_mut_ptr(),
59 | |             events.capacity() as i32,
60 | |             timeout,
61 | |         ))
   | |__________^ returning ready events from epoll_wait is not yet implemented
```
but there were several similar cases.

We could sprinkle `#[cfg_attr(miri, ignore)]` all over the place but there were _lots_ in some cases covering all the tests in a module. Since much of the benefit comes from testing our unsafe abstractions (rather than the users of those abstractions) keep things simple and restrict the set of tests run.

Right now it seems that the `libc` crate does not fully support strict provenance:
```
warning: integer-to-pointer cast
          +test-miri |     --> $CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.158/src/unix/linux_like/mod.rs:1545:13
          +test-miri |      |
          +test-miri | 1545 |             0 as *mut cmsghdr
          +test-miri |      |             ^^^^^^^^^^^^^^^^^ integer-to-pointer cast
          +test-miri |      |
          +test-miri |      = help: this program is using integer-to-pointer casts or (equivalently) `ptr::with_exposed_provenance`, which means that Miri might miss pointer bugs in this program
          +test-miri |      = help: see https://doc.rust-lang.org/nightly/std/ptr/fn.with_exposed_provenance.html for more details on that operation
          +test-miri |      = help: to ensure that Miri does not miss bugs in your program, use Strict Provenance APIs (https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance, https://crates.io/crates/sptr) instead
          +test-miri |      = help: you can then set `MIRIFLAGS=-Zmiri-strict-provenance` to ensure you are not relying on `with_exposed_provenance` semantics
          +test-miri |      = help: alternatively, `MIRIFLAGS=-Zmiri-permissive-provenance` disables this warning
          +test-miri |      = note: BACKTRACE on thread `io::outside::ud`:
          +test-miri |      = note: inside `libc::CMSG_FIRSTHDR` at /tmp/earthly/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.158/src/unix/linux_like/mod.rs:1545:13: 1545:30
```
For now disable with `-Zmiri-permissive-provenance`.

[Miri]: https://github.com/rust-lang/miri