### PR TITLE
lightway-core: Bump wolfssl dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,7 +2426,7 @@ dependencies = [
 [[package]]
 name = "wolfssl"
 version = "2.0.0"
-source = "git+https://github.com/expressvpn/wolfssl-rs#70d48027b7112705a4c051866d063489b9ae13bf"
+source = "git+https://github.com/expressvpn/wolfssl-rs#23596aa7e6b94b94dcd5d8ec362ff2f71884b461"
 dependencies = [
  "bytes",
  "log",
@@ -2437,7 +2437,7 @@ dependencies = [
 [[package]]
 name = "wolfssl-sys"
 version = "1.2.0"
-source = "git+https://github.com/expressvpn/wolfssl-rs#70d48027b7112705a4c051866d063489b9ae13bf"
+source = "git+https://github.com/expressvpn/wolfssl-rs#23596aa7e6b94b94dcd5d8ec362ff2f71884b461"
 dependencies = [
  "autotools",
  "bindgen 0.70.0",

--- a/lightway-core/src/connection/builders.rs
+++ b/lightway-core/src/connection/builders.rs
@@ -202,7 +202,7 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
             .auth_method
             .ok_or(ConnectionBuilderError::AuthRequired)?;
 
-        let session = wolfssl::Session::new_from_context(&self.ctx.wolfssl, self.session_config)?;
+        let session = self.ctx.wolfssl.new_session(self.session_config)?;
 
         let inside_mtu = self.ctx.inside_io.mtu();
         if self.connection_type.is_datagram()
@@ -326,7 +326,7 @@ impl<'a, AppState: Send + 'static> ServerConnectionBuilder<'a, AppState> {
             ));
         }
 
-        let session = wolfssl::Session::new_from_context(&self.ctx.wolfssl, self.session_config)?;
+        let session = self.ctx.wolfssl.new_session(self.session_config)?;
 
         Ok(Connection::new(NewConnectionArgs {
             app_state,


### PR DESCRIPTION
This picks up https://github.com/expressvpn/wolfssl-rs/pull/174 which includes a small API change, so switch to `wolfssl::Context::new_session()` over the now removed `wolfssl::Session::new_from_context()`.
