### PR TITLE
lightway-app-utils: iouring: Rework to push more processing into uring thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,20 +531,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "delegate"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,7 +1056,6 @@ dependencies = [
  "async-trait",
  "bytes",
  "clap",
- "dashmap",
  "humantime",
  "io-uring",
  "ipnet",
@@ -1081,12 +1066,14 @@ dependencies = [
  "serde",
  "serde_with",
  "serde_yaml 0.9.34+deprecated",
+ "test-case",
  "thiserror",
  "tokio",
  "tokio-eventfd",
  "tokio-stream",
  "tokio-tun",
  "tokio-util",
+ "tracing",
  "tracing-subscriber",
  "tun2",
 ]
@@ -1199,16 +1186,6 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
-
-[[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -1435,19 +1412,6 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
 
 [[package]]
 name = "peeking_take_while"
@@ -1698,15 +1662,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
-dependencies = [
- "bitflags 2.6.0",
-]
-
-[[package]]
 name = "regex"
 version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,12 +1726,6 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"

--- a/lightway-app-utils/Cargo.toml
+++ b/lightway-app-utils/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [features]
 default = [ "tokio" ]
-io-uring = [ "dep:io-uring", "dep:async-channel", "dep:tokio", "dep:tokio-eventfd" ]
+io-uring = [ "dep:io-uring", "dep:tokio", "dep:tokio-eventfd" ]
 tokio = [ "dep:tokio", "dep:tokio-stream" ]
 
 [lints]
@@ -19,10 +19,8 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-async-channel = { version = "2.1.1", optional = true }
 bytes.workspace = true
 clap.workspace = true
-dashmap = "6.0.1"
 humantime = "2.1.0"
 io-uring = {  version = "0.6.3", optional = true }
 ipnet.workspace = true
@@ -37,6 +35,7 @@ tokio = { workspace = true, optional = true }
 tokio-eventfd = { version = "0.2.1", optional = true }
 tokio-stream = { workspace = true, optional = true }
 tokio-util.workspace = true
+tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["json"] }
 tun2 = { version = "3", features = ["async"] }
 
@@ -46,5 +45,7 @@ path = "examples/udprelay.rs"
 
 [dev-dependencies]
 async-trait.workspace = true
+async-channel = { version = "2.1.1" }
 pnet.workspace = true
 tokio-tun = "0.11.2"
+test-case.workspace = true

--- a/lightway-app-utils/src/metrics.rs
+++ b/lightway-app-utils/src/metrics.rs
@@ -1,16 +1,70 @@
-use metrics::{counter, histogram, Counter, Histogram};
-use std::sync::LazyLock;
+use metrics::{counter, gauge, histogram, Counter, Gauge, Histogram};
+use std::{sync::LazyLock, time::Duration};
 
 static METRIC_TUN_IOURING_PACKET_DROPPED: LazyLock<Counter> =
     LazyLock::new(|| counter!("tun_iouring_packet_dropped"));
 static METRIC_TUN_IOURING_COMPLETION_BATCH_SIZE: LazyLock<Histogram> =
     LazyLock::new(|| histogram!("tun_iouring_completion_batch_size"));
+static METRIC_TUN_IOURING_COMPLETIONS_BEFORE_BLOCKING: LazyLock<Histogram> =
+    LazyLock::new(|| histogram!("tun_iouring_completions_before_blocking"));
 
-/// Counter for "sending into a full channel" type of error ([`async_channel::TrySendError::Full`])
+static METRIC_TUN_IOURING_RX_EAGAIN: LazyLock<Counter> =
+    LazyLock::new(|| counter!("tun_iouring_rx_eagain"));
+static METRIC_TUN_IOURING_RX_ERR: LazyLock<Counter> =
+    LazyLock::new(|| counter!("tun_iouring_rx_err"));
+
+static METRIC_TUN_IOURING_BLOCKED: LazyLock<Counter> =
+    LazyLock::new(|| counter!("tun_iouring_blocked"));
+static METRIC_TUN_IOURING_WAKE_EVENTFD: LazyLock<Counter> =
+    LazyLock::new(|| counter!("tun_iouring_wake_eventfd"));
+static METRIC_TUN_IOURING_WAKE_TX: LazyLock<Counter> =
+    LazyLock::new(|| counter!("tun_iouring_wake_tx"));
+
+static METRIC_TUN_IOURING_TOTAL_THREAD_TIME: LazyLock<Gauge> =
+    LazyLock::new(|| gauge!("tun_iouring_total_thread_time"));
+static METRIC_TUN_IOURING_IDLE_THREAD_TIME: LazyLock<Gauge> =
+    LazyLock::new(|| gauge!("tun_iouring_idle_thread_time"));
+
+/// Counter for "sending into a full channel" type of error ([`tokio::sync::mpsc::error::TrySendError::Full`])
 pub(crate) fn tun_iouring_packet_dropped() {
     METRIC_TUN_IOURING_PACKET_DROPPED.increment(1);
 }
 
+/// Monitors size of uring completion queue on each iteration
 pub(crate) fn tun_iouring_completion_batch_size(sz: usize) {
     METRIC_TUN_IOURING_COMPLETION_BATCH_SIZE.record(sz as f64);
+}
+
+pub(crate) fn tun_iouring_completions_before_blocking(sz: usize) {
+    METRIC_TUN_IOURING_COMPLETIONS_BEFORE_BLOCKING.record(sz as f64)
+}
+
+/// Count iouring RX entries which complete with EAGAIN
+pub(crate) fn tun_iouring_rx_eagain() {
+    METRIC_TUN_IOURING_RX_EAGAIN.increment(1)
+}
+
+/// Count iouring RX entries which complete with an error
+pub(crate) fn tun_iouring_rx_err() {
+    METRIC_TUN_IOURING_RX_ERR.increment(1)
+}
+
+pub(crate) fn tun_iouring_blocked() {
+    METRIC_TUN_IOURING_BLOCKED.increment(1)
+}
+
+pub(crate) fn tun_iouring_wake_eventfd() {
+    METRIC_TUN_IOURING_WAKE_EVENTFD.increment(1)
+}
+
+pub(crate) fn tun_iouring_wake_tx() {
+    METRIC_TUN_IOURING_WAKE_TX.increment(1)
+}
+
+pub(crate) fn tun_iouring_total_thread_time(t: Duration) {
+    METRIC_TUN_IOURING_TOTAL_THREAD_TIME.set(t.as_millis() as f64);
+}
+
+pub(crate) fn tun_iouring_idle_thread_time(t: Duration) {
+    METRIC_TUN_IOURING_IDLE_THREAD_TIME.increment(t.as_millis() as f64);
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This removes the need for the send and receive tasks posting sqe's to the thread for it to post by doing that as part of the loop. It also pulls the cqe processing into the same loop.

This now uses a model similar to that in most of the uring examples (in both C and Rust).

This change improves an iperf upload test from 2.03 Gbits/sec to 2.19 Gbigs/sec Gbits/sec and download from 2.34 Gbits/sec to 2.46 Gbits/sec.

The channel used for the tx and rx queues is changed from the async_channel to tokio::mpsc. The performance difference appears to be in the noise, however we no longer need the multi-consumer property (in fact we'd be happy with a spsc channel if there was one) and we use tokio::mpsc everywhere else.

## Motivation and Context

Trying to improve performance, following on from #78 (cumulatively upload perf has gone from 1.85->2.19 Gbits/sec and  download from 2.21 -> 2.46 Gbits/sec).

## How Has This Been Tested?

Using iperf in the containerized test setup on an otherwise idle c7i.8xlarge EC2 node.

Numbers quoted above are with both client and server using a 1024 entry io uring.

## Types of changes

Performance improvement.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
