### PR TITLE
test: fix the readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,12 +164,12 @@ The lightway-middle namespace facilitates a multi-hop network path: client <-> m
 
 Start server using this command,
 ```bash
-cargo build --bin lightway-server && sudo -E ip netns exec lightway-server ./target/debug/lightway-server --config-file './tests/server_config.yaml'
+cargo build --bin lightway-server && sudo -E ip netns exec lightway-server ./target/debug/lightway-server --config-file './tests/server/server_config.yaml'
 ```
 
 Start client using this command,
 ```bash
-cargo build --bin lightway-client && sudo -E ip netns exec lightway-client ./target/debug/lightway-client --config-file './tests/client_config.yaml' --server server:27690
+cargo build --bin lightway-client && sudo -E ip netns exec lightway-client ./target/debug/lightway-client --config-file './tests/client/client_config.yaml' --server server:27690
 ```
 
 Then enter into `lightway-client` namespace and trying pinging google.com

--- a/tests/client/Earthfile
+++ b/tests/client/Earthfile
@@ -5,7 +5,7 @@ build-container:
     ARG TOKIO_WORKER_THREADS
     FROM ../base+container --debian=$debian
     COPY (../..+build/lightway-client --debian=$debian) .
-    COPY --dir ../certs+client/* certs/
+    COPY --dir ../certs+client/* tests/certs/
     COPY --dir client_config.yaml docker-entrypoint.sh run-test-inside.sh .
     HEALTHCHECK --interval=1s --timeout=1s --start-period=0s --retries=30 CMD ping -c1 nginx
     IF [ -n "$TOKIO_WORKER_THREADS" ]

--- a/tests/client/client_config.yaml
+++ b/tests/client/client_config.yaml
@@ -1,7 +1,7 @@
 ---
 server: server:27690
 mode: tcp
-ca_cert: "./certs/ca.crt"
+ca_cert: "tests/certs/ca.crt"
 tun_name: lightway
 tun_local_ip: 100.64.0.6
 tun_peer_ip: 100.64.0.5

--- a/tests/server/Earthfile
+++ b/tests/server/Earthfile
@@ -5,7 +5,7 @@ build-container:
     ARG TOKIO_WORKER_THREADS
     FROM ../base+container --debian=$debian
     COPY (../..+build/lightway-server --debian=$debian) .
-    COPY --dir ../certs+server/* certs/
+    COPY --dir ../certs+server/* tests/certs/
     COPY --dir server_config.yaml docker-entrypoint.sh .
     HEALTHCHECK --interval=1s --timeout=1s --start-period=0s --retries=3 CMD [ -n "$(ss -HOlutn sport = :${SERVER_PORT:-443})" ]
     IF [ -n "$TOKIO_WORKER_THREADS" ]

--- a/tests/server/server_config.yaml
+++ b/tests/server/server_config.yaml
@@ -1,8 +1,8 @@
 ---
 bind_address: 0.0.0.0:27690
 mode: tcp
-server_cert: "certs/server.crt"
-server_key: "certs/server.key"
+server_cert: "tests/certs/server.crt"
+server_key: "tests/certs/server.key"
 tun_name: lightway
 ip_pool: 10.125.0.0/16
 tun_ip: 10.125.0.1


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
We recently refactored the test scripts as a result the README examples no longer work

## Motivation and Context
The examples should work for users to be able to test the repo

## How Has This Been Tested?
Manually run on an ubuntu machine 22.04

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
