### PR TITLE
lightway-client/server: Hide `--password` option from CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ Cli arguments has the highest priority.
 Please note that when providing env variables it should be in upper case and using "_" as a word separator,
 while using as cli config, it should be in lower case with "-" as the word separator.
 
+> [!CAUTION]
+> Passing the `--password` option on the CLI will expose your password
+> to other users on the system. It is recommended to provide the
+> password via the configuration file or via `LW_SERVER_PASSWORD`
+> environment variable.
+
 #### Example:
 
 ```bash
@@ -104,6 +110,12 @@ Env variables should have the prefix `LW_CLIENT_`.
 By default the client will use the existing MTU on the tunnel device, this can be overridden with
 the `--inside-mtu` option but note that this requires additional privileges, specifically the
 `CAP_SYS_ADMIN` capability.
+
+> [!CAUTION]
+> Passing the `--password` option on the CLI will expose your password
+> to other users on the system. It is recommended to provide the
+> password via the configuration file or via `LW_CLIENT_PASSWORD`
+> environment variable.
 
 ## E2E Testing
 

--- a/lightway-client/src/args.rs
+++ b/lightway-client/src/args.rs
@@ -18,11 +18,11 @@ pub struct Config {
     pub mode: ConnectionType,
 
     /// Username for auth
-    #[clap(short, long, default_value_t)]
+    #[clap(short, long, default_value_t, hide = true)]
     pub user: String,
 
     /// Password for auth
-    #[clap(short, long, default_value_t)]
+    #[clap(short, long, default_value_t, hide = true)]
     pub password: String,
 
     /// CA certificate

--- a/lightway-server/src/args.rs
+++ b/lightway-server/src/args.rs
@@ -22,11 +22,11 @@ pub struct Config {
     pub mode: ConnectionType,
 
     /// Username for auth
-    #[clap(long, default_value_t)]
+    #[clap(long, default_value_t, hide = true)]
     pub user: String,
 
     /// Password for auth
-    #[clap(long, default_value_t)]
+    #[clap(long, default_value_t, hide = true)]
     pub password: String,
 
     /// Server certificate


### PR DESCRIPTION
## Description

Also add a cautionary note to the README.

## Motivation and Context

Using `--password` exposes the password to other users on the system via `/proc/$PID/cmdline` (which is world readable) and via tools such as `ps(1)`.

## How Has This Been Tested?

Before:

```console
$ ./target/debug/lightway-server --help
[...]
      --user <USER>
          Username for auth
          
          [default: ]

      --password <PASSWORD>
          Password for auth
          
          [default: ]
```

After:

```console
$ ./target/debug/lightway-server --help
[...nothing...]
```

Similarly for `lightway-client`.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
