### PR TITLE
CVPN-1185: Ignore network unreachable socket error for linux-like OS when sending out packets from the udp socket of lightway-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,6 +1339,7 @@ dependencies = [
  "ctrlc",
  "educe",
  "futures",
+ "libc",
  "lightway-app-utils",
  "lightway-core",
  "more-asserts",

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -26,6 +26,7 @@ clap.workspace = true
 ctrlc.workspace = true
 educe.workspace = true
 futures = "0.3.30"
+libc.workspace = true
 lightway-app-utils.workspace = true
 lightway-core.workspace = true
 pnet.workspace = true

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -82,6 +82,22 @@ impl OutsideIOSendCallback for Udp {
                 // This way we can continue if/when the server shows up.
                 IOCallbackResult::Ok(0)
             }
+            Err(err) if matches!(err.raw_os_error(), Some(libc::ENETUNREACH)) => {
+                // This case indicates network unreachable error.
+                // Possibly there is a network change at the moment.
+                //
+                // Swallow the socket error so the error is not passed to the
+                // WolfSSL layer. Then the WolfSSL layer would not enter a
+                // fatal error state
+                //
+                // Note: this case should be matched by
+                // matches!(err.kind(), std::io::ErrorKind::NetworkUnreachable)
+                // However, at the time of implementing this match case,
+                // the version of rust we use does not support NetworkUnreachable.
+                // This match case can be rewritten to use NetworkUnreachable
+                // once rust is updated to support it.
+                IOCallbackResult::Ok(0)
+            }
             Err(err) => IOCallbackResult::Err(err),
         }
     }


### PR DESCRIPTION
## Description
Ignore network unreachable socket error for linux-like OS when sending out packets from the udp socket of lightway-client. This change only applies to linux-like OS. Other OS like WIndows may need a different implementation.

## Motivation and Context
if this error is not ignored and passed to the WolfSSL layer, the WolfSSL layer will enter a fatal socket error state and stop the inside IO loop during network change. Ignoring this error to prevent the inside IO loop from exiting.

## How Has This Been Tested?
The change has been dev tested in two environments: an android emulator (Pixel Fold API 35) and a physical android phone (Samsung A33).
Without the change, the error can be reproduced in both environments by switching off WiFi.
With the change, the error can no longer be reproduced in both environments.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
