### PR TITLE
Workaround for Mermaid sequence diagrams not handling double <br/>

### DIFF
--- a/docs/udp_session_id.md
+++ b/docs/udp_session_id.md
@@ -24,13 +24,13 @@ sequenceDiagram
 
     Note over Client: Address: 192.168.100.43
     Client->>Server: Src: 192.168.100.43, Session: A
-    Note over Server: Lookup Connection by peer addr 192.168.100.43 ✅<br/><br/>Begin Rotation<br/>Pending Session ← B
+    Note over Server: Lookup Connection by peer addr 192.168.100.43 ✅<br/>---------<br/>Begin Rotation<br/>Pending Session ← B
     activate Server
     Server->>+Client: Dst: 192.168.100.43, Session: B
     deactivate Client
     Note over Client: Accept new Session:<br/>Session ← B
     Client->>Server: Src: 192.168.100.43, Session: B
-    Note over Server: Lookup Connection by peer addr 192.168.100.43 ✅<br/><br/>Since "B = Pending Session B" finalize rotation:<br/>Session ← B<br/>Pending Session ← None
+    Note over Server: Lookup Connection by peer addr 192.168.100.43 ✅<br/>---------<br/>Since "B = Pending Session B" finalize rotation:<br/>Session ← B<br/>Pending Session ← None
     deactivate Server
     Server->>Client: Dst: 192.168.100.43, Session: B
 ```
@@ -50,13 +50,13 @@ sequenceDiagram
     Note over Client: Network Change:<br/>Address ← 10.1.2.3
     Client->>Server: Src: 10.1.2.3, Session: A
     Note over Server: Lookup Connection by peer addr 10.1.2.3 ❌
-    Note over Server: Lookup Connection by Session A ✅<br/>Peer Addr ← 10.1.2.3<br/><br/>Begin Rotation<br/>Pending Session ← B
+    Note over Server: Lookup Connection by Session A ✅<br/>Peer Addr ← 10.1.2.3<br/>---------<br/>Begin Rotation<br/>Pending Session ← B
     activate Server
     Server->>+Client: Dst: 10.1.2.3, Session: B
     deactivate Client
     Note over Client: Accept new Session:<br/>Session ← B
     Client->>Server: Src: 10.1.2.3, Session: B
-    Note over Server: Lookup Connection by peer addr 10.1.2.3 ✅<br/><br/>Since "B = Pending Session B" finalize rotation:<br/>Session ← B<br/>Pending Session ← None
+    Note over Server: Lookup Connection by peer addr 10.1.2.3 ✅<br/>---------<br/>Since "B = Pending Session B" finalize rotation:<br/>Session ← B<br/>Pending Session ← None
     deactivate Server
     Server->>Client: Dst: 10.1.2.3, Session: B
 ```
@@ -73,7 +73,7 @@ sequenceDiagram
 
     Note over Client: Address: 192.168.100.43
     Client->>Server: Src: 192.168.100.43, Session: A
-    Note over Server: Lookup Connection by peer addr 192.168.100.43 ✅<br/><br/>Begin Rotation<br/>Pending Session ← B
+    Note over Server: Lookup Connection by peer addr 192.168.100.43 ✅<br/>---------<br/>Begin Rotation<br/>Pending Session ← B
     activate Server
     Server->>+Client: Dst: 192.168.100.43, Session: B
     deactivate Client
@@ -82,7 +82,7 @@ sequenceDiagram
     Client->>Server: Src: 10.1.2.3, Session: B
     Note over Server: Lookup Connection by peer addr 10.1.2.3 ❌
     Note over Server: Lookup Connection by Session B ❌
-    Note over Server: Lookup Connection by Pending Session B ✅<br/>Peer Addr ← 10.1.2.3<br/><br/>Since "B = Pending Session B" finalize rotation:<br/>Session ← B<br/>Pending Session ← None
+    Note over Server: Lookup Connection by Pending Session B ✅<br/>Peer Addr ← 10.1.2.3<br/>---------<br/>Since "B = Pending Session B" finalize rotation:<br/>Session ← B<br/>Pending Session ← None
     deactivate Server
     Server->>Client: Dst: 10.1.2.3, Session: B
 ```
@@ -103,11 +103,11 @@ sequenceDiagram
     note over Server: Begin Rotation<br/>Pending Session ← B
     Server->>+Client: Dst: 192.168.100.43, Session: B
     Client->>Server: Src: 192.168.100.43, Session: A
-    Note over Server: Lookup Connection by peer addr 192.168.100.43 ✅<br/><br/>Since "A ≠ Pending Session B" do not finalize rotation
+    Note over Server: Lookup Connection by peer addr 192.168.100.43 ✅<br/>---------<br/>Since "A ≠ Pending Session B" do not finalize rotation
     Note over Client: Accept new Session:<br/>Session ← B
     deactivate Client
     Client->>Server: Src: 192.168.100.43, Session: B
-    Note over Server: Lookup Connection by peer addr 192.168.100.43 ✅<br/><br/>Since "B = Pending Session B" finalize rotation:<br/>Session ← B<br/>Pending Session ← None
+    Note over Server: Lookup Connection by peer addr 192.168.100.43 ✅<br/>---------<br/>Since "B = Pending Session B" finalize rotation:<br/>Session ← B<br/>Pending Session ← None
     deactivate Server
     Server->>Client: Dst: 192.168.100.43, Session: B
 ```
@@ -131,13 +131,13 @@ sequenceDiagram
     Note over Client: Network Change:<br/>Address ← 10.1.2.3
     Client->>Server: Src: 10.1.2.3, Session: A
     Note over Server: Lookup Connection by peer addr 10.1.2.3 ❌
-    Note over Server: Lookup Connection by Session A ✅<br/><br/>Since "A ≠ Pending Session B" do not finalize rotation
+    Note over Server: Lookup Connection by Session A ✅<br/>---------<br/>Since "A ≠ Pending Session B" do not finalize rotation
     Note over Client: Accept new Session:<br/>Session ← B
     deactivate Client
     Client->>Server: Src: 10.1.2.3, Session: B
     Note over Server: Lookup Connection by peer addr 10.1.2.3 ❌
     Note over Server: Lookup Connection by Session B ❌
-    Note over Server: Lookup Connection by Pending Session B ✅<br/>Peer Addr ← 10.1.2.3<br/><br/>Since "B = Pending Session B" finalize rotation:<br/>Session ← B<br/>Pending Session ← None
+    Note over Server: Lookup Connection by Pending Session B ✅<br/>Peer Addr ← 10.1.2.3<br/>---------<br/>Since "B = Pending Session B" finalize rotation:<br/>Session ← B<br/>Pending Session ← None
     deactivate Server
     Server->>Client: Dst: 10.1.2.3, Session: B
 ```


### PR DESCRIPTION
## Description
Safari's current version of Javascript seems to cause Mermaid to
not handle <br/><br/> (double line breaks). When used, the Github
website preview will fail to render with error
"svg element not in render tree".

Workaround is to add some content between the line breaks.

## Motivation and Context
Here is what the failure looks like without the fix:
![Screenshot 2024-10-03 at 11 14 48](https://github.com/user-attachments/assets/a55a3af9-8fe0-4768-9803-4abf5370ff5c)


## How Has This Been Tested?
Tested by viewing the Github website preview at https://github.com/expressvpn/lightway/blob/try-mermaid-workaround/docs/udp_session_id.md 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
