### PR TITLE
lightway-core: remove unnecessary trace prints

### DIFF
--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -178,7 +178,6 @@ pub struct ClientIpConfigCb;
 
 impl<T: Send + Sync> ClientIpConfig<ConnectionState<T>> for ClientIpConfigCb {
     fn ip_config(&self, state: &mut ConnectionState<T>, ip_config: InsideIpConfig) {
-        tracing::debug!("Got IP from server: {ip_config:?}");
         state.ip_config = Some(ip_config);
     }
 }

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -1269,8 +1269,6 @@ impl<AppState: Send> Connection<AppState> {
     }
 
     fn handle_auth_response(&mut self, cfg: AuthSuccessWithConfigV4) -> ConnectionResult<()> {
-        info!(config = ?cfg, "Authentication succeeded");
-
         // Ignore the message if client is already online
         if matches!(self.state, State::Online) {
             return Ok(());

--- a/lightway-core/src/wire/auth_success_with_config_ipv4.rs
+++ b/lightway-core/src/wire/auth_success_with_config_ipv4.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use crate::wire::SessionId;
 
 use super::{FromWireError, FromWireResult};
@@ -77,13 +79,19 @@ use more_asserts::*;
 /// NOTE: In the lightway-core C implementation this is
 /// `HE_MSGID_CONFIG_IPV4` with `he_msg_config_ipv4_t` as the payload,
 /// however it is sent as the response to an auth request.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq)]
 pub(crate) struct AuthSuccessWithConfigV4 {
     pub(crate) local_ip: String,
     pub(crate) peer_ip: String,
     pub(crate) dns_ip: String,
     pub(crate) mtu: String,
     pub(crate) session: SessionId,
+}
+
+impl Debug for AuthSuccessWithConfigV4 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthSuccessWithConfigV4").finish()
+    }
 }
 
 impl AuthSuccessWithConfigV4 {


### PR DESCRIPTION
Also disable printing ip config values using Debug trait

<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove unnecessary tracing. 
"Authentication succeeded" trace is not needed since immediately the connection state will move to Online.

Also restrict printing the `AuthSuccessWithConfigV4` using Debug trait accidently

## Motivation and Context

We do not want to print the server ip config in client logs.

## How Has This Been Tested?
Ran and verified manually that client does not print server ip config details

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
