### PR TITLE
Relax permissions checks on configuration files

### DIFF
--- a/lightway-app-utils/src/lib.rs
+++ b/lightway-app-utils/src/lib.rs
@@ -33,4 +33,4 @@ pub use tun::{Tun, TunConfig, TunDirect};
 #[cfg(feature = "io-uring")]
 mod metrics;
 mod utils;
-pub use utils::validate_configuration_file_path;
+pub use utils::{validate_configuration_file_path, Validate};

--- a/lightway-app-utils/src/utils.rs
+++ b/lightway-app-utils/src/utils.rs
@@ -3,15 +3,30 @@ use std::path::PathBuf;
 use anyhow::Result;
 use fs_mistrust::Mistrust;
 
+/// Specifies the limits which `validate_configuration_file_path`
+/// should enforce.
+pub enum Validate {
+    /// Ensure that only the file's owner can access (read or write)
+    OwnerOnly,
+    /// Ensure that only the file's owner can write but allow anyone
+    /// to read
+    AllowWorldRead,
+}
+
 /// Verifies whether input `path` points to a valid configuration file
 /// present in filesystem. Validates that the ownership permissions
 /// are acceptable.
-pub fn validate_configuration_file_path(path: &PathBuf) -> Result<()> {
-    Mistrust::builder()
+pub fn validate_configuration_file_path(path: &PathBuf, validate: Validate) -> Result<()> {
+    let mistrust = Mistrust::builder()
         .controlled_by_env_var("LW_DANGEROUSLY_DISABLE_PERMISSIONS_CHECKS")
-        .build()?
-        .verifier()
-        .require_file()
-        .check(path)?;
+        .build()?;
+
+    let verifier = mistrust.verifier().require_file();
+    let verifier = match validate {
+        Validate::OwnerOnly => verifier,
+        Validate::AllowWorldRead => verifier.permit_readable(),
+    };
+
+    verifier.check(path)?;
     Ok(())
 }

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -5,7 +5,9 @@ use clap::CommandFactory;
 use lightway_core::{Event, EventCallback};
 use twelf::Layer;
 
-use lightway_app_utils::{args::ConnectionType, validate_configuration_file_path, TunConfig};
+use lightway_app_utils::{
+    args::ConnectionType, validate_configuration_file_path, TunConfig, Validate,
+};
 use lightway_client::*;
 
 mod args;
@@ -30,7 +32,7 @@ async fn main() -> Result<()> {
         return Err(anyhow!("Config file not present"));
     };
 
-    validate_configuration_file_path(config_file)
+    validate_configuration_file_path(config_file, Validate::AllowWorldRead)
         .with_context(|| format!("Invalid configuration file {}", config_file.display()))?;
 
     let mut config = Config::with_layers(&[

--- a/tests/client/Earthfile
+++ b/tests/client/Earthfile
@@ -6,8 +6,7 @@ build-container:
     FROM ../base+container --debian=$debian
     COPY (../..+build/lightway-client --debian=$debian) .
     COPY --dir ../certs+client/* tests/certs/
-    COPY --dir --chmod 0660 client_config.yaml .
-    COPY --dir docker-entrypoint.sh run-test-inside.sh .
+    COPY --dir docker-entrypoint.sh client_config.yaml run-test-inside.sh .
     HEALTHCHECK --interval=1s --timeout=1s --start-period=0s --retries=30 CMD ping -c1 nginx
     IF [ -n "$TOKIO_WORKER_THREADS" ]
         ENV TOKIO_WORKER_THREADS=$TOKIO_WORKER_THREADS

--- a/tests/server/Earthfile
+++ b/tests/server/Earthfile
@@ -7,8 +7,7 @@ build-container:
     COPY (../..+build/lightway-server --debian=$debian) .
     COPY --dir --chmod 0660 ../certs+server/* tests/certs/
     COPY --dir --chmod 0660 lwpasswd tests/server/lwpasswd
-    COPY --dir docker-entrypoint.sh token.pub .
-    COPY --dir --chmod 0660 server_config.yaml  .
+    COPY --dir docker-entrypoint.sh server_config.yaml token.pub .
     HEALTHCHECK --interval=1s --timeout=1s --start-period=0s --retries=3 CMD [ -n "$(ss -HOlutn sport = :${SERVER_PORT:-443})" ]
     IF [ -n "$TOKIO_WORKER_THREADS" ]
         ENV TOKIO_WORKER_THREADS=$TOKIO_WORKER_THREADS


### PR DESCRIPTION
## Description

In 23c30e61c7e6 ("lightway-app-utils: Use `fs_mistrust` to validate config file safety.") restrictions were added to ensure that configuration files and secrets had permissions which would prevent another user from tampering with them. This also required that the files were not readable by other users.

As of b8e2fc51e0ef ("lightway-server: Support multiple users") the configuration file no longer contains any sensitive secrets so we can be more tolerant of the file being readable.

We continue to enforce non-readableness for the server key and the user database. We also add the missing checks for the server certificate, which we allow to be readable.

## Motivation and Context

#90 was rather restrictive in hindsight and since #91 there is no solid reason to be so restrictive for all files.

## How Has This Been Tested?

E2E has been adjusted

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
