### PR TITLE
lightway-server: reexport `ConnectionType` to applications

### DIFF
--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -9,15 +9,16 @@ mod statistics;
 #[cfg(feature = "debug")]
 pub use lightway_core::enable_tls_debug;
 pub use lightway_core::{
-    PluginFactoryError, PluginFactoryList, ServerAuth, ServerAuthHandle, ServerAuthResult, Version,
+    ConnectionType, PluginFactoryError, PluginFactoryList, ServerAuth, ServerAuthHandle,
+    ServerAuthResult, Version,
 };
 
 use anyhow::{anyhow, Context, Result};
 use ipnet::Ipv4Net;
 use lightway_app_utils::{connection_ticker_cb, TunConfig};
 use lightway_core::{
-    ipv4_update_destination, AuthMethod, BuilderPredicates, ConnectionError, ConnectionType,
-    IOCallbackResult, InsideIpConfig, Secret, ServerContextBuilder,
+    ipv4_update_destination, AuthMethod, BuilderPredicates, ConnectionError, IOCallbackResult,
+    InsideIpConfig, Secret, ServerContextBuilder,
 };
 use pnet::packet::ipv4::Ipv4Packet;
 use std::{


### PR DESCRIPTION
## Description

Since it is present in the public `ServerConfig` struct and we want consumers to be able to set that without going via
`lightway_app_utils::args::ConnectionType` or taking a direct dependency on `lightway_core` if they don't need to.

This was the only type used in `ServerConfig` which was not available from either a reexport in the `lightway-server` crate or from `lightway-app-utils`.

## Motivation and Context

It was not possible to create a `ServerConfig` directly, without using `lightway_app_utils::args::ConnectionType` together with `into()`.

## How Has This Been Tested?

Build test is sufficient.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
