### PR TITLE
CVPN-1483 Add SNI header setter in client connection builder

### DIFF
--- a/lightway-core/src/connection/builders.rs
+++ b/lightway-core/src/connection/builders.rs
@@ -180,6 +180,14 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
         }
     }
 
+    /// Sets SNI header of the session
+    pub fn with_sni_header(self, server_hostname: &str) -> Self {
+        Self {
+            session_config: self.session_config.with_sni(server_hostname),
+            ..self
+        }
+    }
+
     /// Sets the maximum number of in-progress fragmented packets to support.
     pub fn with_fragment_map_entries(self, max_fragment_map_entries: NonZeroU16) -> Self {
         Self {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
To allow the client to set the SNI header during the lightway connection, we would need to add a SNI header setter when we are building client connection and configuring the session config of woflssl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- To allow the android app to set SNI header while starting lightway connection
- C client already supports this feature but this isn't in Rust yet.

Issue: https://polymoon.atlassian.net/browse/CVPN-1483

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
