### PR TITLE
CVPN-1514 Add Server UDP Buffer Size Config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1405,6 +1405,7 @@ dependencies = [
  "async-trait",
  "average",
  "bytes",
+ "bytesize",
  "clap",
  "ctrlc",
  "delegate",

--- a/lightway-server/Cargo.toml
+++ b/lightway-server/Cargo.toml
@@ -21,6 +21,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 average = "0.15.1"
 bytes.workspace = true
+bytesize = { version = "1.3.0", features = ["serde"] }
 clap.workspace = true
 ctrlc.workspace = true
 delegate.workspace = true

--- a/lightway-server/src/args.rs
+++ b/lightway-server/src/args.rs
@@ -3,6 +3,7 @@ use std::{
     path::PathBuf,
 };
 
+use bytesize::ByteSize;
 use clap::Parser;
 use ipnet::Ipv4Net;
 use twelf::config;
@@ -99,6 +100,10 @@ pub struct Config {
     /// Enable PROXY protocol support (TCP only)
     #[clap(long)]
     pub proxy_protocol: bool,
+
+    /// Set UDP buffer size. Default value is 15 MiB.
+    #[clap(long, default_value_t = ByteSize::mib(15))]
+    pub udp_buffer_size: ByteSize,
 
     /// Enable WolfSSL debug logging
     #[cfg(feature = "debug")]

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -137,6 +137,7 @@ async fn main() -> Result<()> {
         outside_plugins: Default::default(),
         bind_address: config.bind_address,
         proxy_protocol: config.proxy_protocol,
+        udp_buffer_size: config.udp_buffer_size,
     };
 
     server(config).await

--- a/tests/server/server_config.yaml
+++ b/tests/server/server_config.yaml
@@ -21,3 +21,4 @@ enable_tun_iouring: false
 iouring_entry_count: 1024
 key_update_interval: 15m
 user_db: "tests/server/lwpasswd"
+udp_buffer_size: 15 MiB


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Reads UDP Buffer Size in config and set buffer size in socket level

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Allow devs to tweak udp buffer size 
- Prevents hardcoding 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran cargo test locally + tried running lightway_server locally and print out the buffer size

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
