### PR TITLE
CVPN-1533 use tun instead of tun2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,7 +1331,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "tun2",
+ "tun",
 ]
 
 [[package]]
@@ -2628,10 +2628,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tun2"
-version = "3.1.8"
+name = "tun"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "294ac0e21fef392b8952f1dd538bc5752fd7c2ebfde1c204b0dd09aaa5489cd0"
+checksum = "224cb7686e768be38d03dc660f88947b8976c1d68b8ee731324fe4b761ab80a2"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/lightway-app-utils/Cargo.toml
+++ b/lightway-app-utils/Cargo.toml
@@ -38,7 +38,7 @@ tokio-stream = { workspace = true, optional = true }
 tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["json"] }
-tun2 = { version = "3", features = ["async"] }
+tun = { version = "0.7", features = ["async"] }
 
 [[example]]
 name = "udprelay"

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -6,9 +6,9 @@ use std::{
     ops::Deref,
     os::fd::{AsRawFd, RawFd},
 };
-use tun2::{AbstractDevice, AsyncDevice as TokioTun};
+use tun::{AbstractDevice, AsyncDevice as TokioTun};
 
-pub use tun2::Configuration as TunConfig;
+pub use tun::Configuration as TunConfig;
 
 #[cfg(feature = "io-uring")]
 use std::sync::Arc;
@@ -85,7 +85,7 @@ pub struct TunDirect {
 impl TunDirect {
     /// Create a new `Tun` struct
     pub fn new(config: TunConfig) -> Result<Self> {
-        let tun = tun2::create_as_async(&config)?;
+        let tun = tun::create_as_async(&config)?;
         let fd = tun.as_raw_fd();
         let mtu = tun.mtu()?;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Switching to using the [tun crate](https://github.com/meh/rust-tun) instead of the [tun2 crate](https://github.com/tun2proxy/rust-tun).

The upgrade should not lead to any bugs or side effects:
- Originally, we are using the version `3.1.8` of tun2. The author of the crate upgraded it to version `4.0.0`, and merged this `4.0.0` version to the new tun crate's version `0.7.0` ([Check out this branch comparison](https://github.com/tun2proxy/rust-tun/compare/v2...meh%3Arust-tun%3Amaster)). Hence, what we are doing is essentially upgrading from `3.1.8` to `4.0.0` and change the crate name.
- The [changelog](https://github.com/tun2proxy/rust-tun/compare/v3.1.8...v4.0.0) from `3.1.8` to `4.0.0` states that:
  - there is some reformatting, which does not affect the functionality at all
  - [some new functions are added](https://github.com/ssrlive/rust-tun/commit/428bc1ea0acfa958ea2d7e13fe9203598e509870) without removing old functions, which does not affect the existing functionalities.
  
Hence, the update should be safe. 

## Motivation and Context
The original tun2 crate has been archived and merged to the new tun crate. Changing Lightway to use tun crate as all the active development will be happening in the tun crate.

## How Has This Been Tested?
Existing automated tests are used.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
