### PR TITLE
CVPN-1356 Check Session ID after connection is validated

### DIFF
--- a/docs/logs_and_metrics.md
+++ b/docs/logs_and_metrics.md
@@ -31,6 +31,7 @@ Lightway server also supports metrics to monitor. The following are the metrics 
 | conn_create_failed | server | Counter | A new connection could not be created |
 | conn_alloc_frag_map | core | Counter | A connection has used a fragmented data packet.<br>Therefore the 2M FragmentMap has been allocated |
 | wolfssl_appdata | core | Counter | An AppData result occurred during a WolfSSL operation.<br><br>Given current configuration we do not expect this to be non-zero |
+| session_id_mismatch | core | Counter | Server has received a mismatched session_id in the header after the packet content has been validated <br><br>Should generally be expected to happen rarely|
 | conn_created | server | Counter | The number of new connections created |
 | conn_link_up | server | Counter | Counts connection which have reached the “link up” state (~(D)TLS connection established) |
 | conn_rejected_no_free_ip | server | Counter | Counts connections which were rejected at auth time due to a lack of free IPs in the server pool<br><br>Should generally be expected to be 0 |

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -1017,7 +1017,7 @@ impl<AppState: Send> Connection<AppState> {
                         self.event(Event::SessionIdRotationAcknowledged { old, new });
                     }
                     // Session id in server is only used to look up the session if it was not found by client IP/Port, so a mismatch here won't affect anything.
-                    _ => {}
+                    _ => metrics::session_id_mismatch(),
                 }
             }
         }

--- a/lightway-core/src/metrics.rs
+++ b/lightway-core/src/metrics.rs
@@ -8,6 +8,8 @@ static METRIC_CONNECTION_ALLOC_FRAG_MAP: LazyLock<Counter> =
 const METRIC_WOLFSSL_APPDATA: &str = "wolfssl_appdata";
 static METRIC_INSIDE_IO_SEND_FAILED: LazyLock<Counter> =
     LazyLock::new(|| counter!("inside_io_send_failed"));
+static METRIC_SESSION_ID_MISMATCH: LazyLock<Counter> =
+    LazyLock::new(|| counter!("session_id_mismatch"));
 
 static TLS_PROTOCOL_VERSION_LABEL: &str = "tls_protocol_version";
 
@@ -27,4 +29,9 @@ pub(crate) fn wolfssl_appdata(tls_version: &ProtocolVersion) {
 pub(crate) fn inside_io_send_failed(err: std::io::Error) {
     debug!(%err, "Failed to send to inside IO");
     METRIC_INSIDE_IO_SEND_FAILED.increment(1);
+}
+
+/// Server has received a mismatched session_id in the header after the packet content has been validated
+pub(crate) fn session_id_mismatch() {
+    METRIC_SESSION_ID_MISMATCH.increment(1);
 }


### PR DESCRIPTION
## Description
The new approach would first validate the outside packet (both content validation and replay attack verification) and would only read or update the session_id once the packet is validated.
1. Prevents client from accepting session_id from unknown sources
2. Allows server to process valid packets even with session_id mismatch, since it's only a backup lookup method after IP/Port search fails. A mismatch here won't affect anything and the packet has been validated already anyway.

(+ Minor refactoring)

## Motivation and Context
Previously, we did not validate packet content before processing session_id, causing:
- clients to accept session_id from unknown sources
- servers to reject packets on session_id mismatch

These are not ideal and would easily affect the VPN performance or security

## How Has This Been Tested?
- cargo test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`