### PR TITLE
lightway-app-utils: iouring: Make sqpoll idle time configurable

### DIFF
--- a/lightway-app-utils/examples/udprelay.rs
+++ b/lightway-app-utils/examples/udprelay.rs
@@ -11,6 +11,7 @@ use pnet::packet::ipv4::MutableIpv4Packet;
 
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::net::UdpSocket;
 use tokio_tun::Tun;
 
@@ -196,7 +197,14 @@ struct TunIOUring {
 
 impl TunIOUring {
     async fn new(tun: Tun, ring_size: usize, channel_size: usize) -> Result<Self> {
-        let tun_iouring = IOUring::new(Arc::new(tun), ring_size, channel_size, TUN_MTU).await?;
+        let tun_iouring = IOUring::new(
+            Arc::new(tun),
+            ring_size,
+            channel_size,
+            TUN_MTU,
+            Duration::from_millis(100),
+        )
+        .await?;
 
         Ok(Self { tun_iouring })
     }

--- a/lightway-client/src/args.rs
+++ b/lightway-client/src/args.rs
@@ -102,6 +102,12 @@ pub struct Config {
     #[clap(long, default_value_t = 1024)]
     pub iouring_entry_count: usize,
 
+    /// IO-uring sqpoll idle time. If non-zero use a kernel thread to
+    /// perform submission queue polling. After the given idle time
+    /// the thread will go to sleep.
+    #[clap(long, default_value = "100ms")]
+    pub iouring_sqpoll_idle_time: Duration,
+
     /// Server domain name
     #[clap(long, default_value = None)]
     pub server_dn: Option<String>,

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -134,6 +134,12 @@ pub struct ClientConfig<'cert, A: 'static + Send + EventCallback> {
     #[cfg(feature = "io-uring")]
     pub iouring_entry_count: usize,
 
+    /// IO-uring sqpoll idle time. If non-zero use a kernel thread to
+    /// perform submission queue polling. After the given idle time
+    /// the thread will go to sleep.
+    #[cfg(feature = "io-uring")]
+    pub iouring_sqpoll_idle_time: Duration,
+
     /// Server domain name to validate
     pub server_dn: Option<String>,
 
@@ -388,7 +394,7 @@ pub async fn client<A: 'static + Send + EventCallback>(
 
     #[cfg(feature = "io-uring")]
     let iouring = if config.enable_tun_iouring {
-        Some(config.iouring_entry_count)
+        Some((config.iouring_entry_count, config.iouring_sqpoll_idle_time))
     } else {
         None
     };

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -96,6 +96,8 @@ async fn main() -> Result<()> {
         enable_tun_iouring: config.enable_tun_iouring,
         #[cfg(feature = "io-uring")]
         iouring_entry_count: config.iouring_entry_count,
+        #[cfg(feature = "io-uring")]
+        iouring_sqpoll_idle_time: config.iouring_sqpoll_idle_time.into(),
         server_dn: config.server_dn,
         server: config.server,
         inside_plugins: Default::default(),

--- a/lightway-server/src/args.rs
+++ b/lightway-server/src/args.rs
@@ -81,6 +81,12 @@ pub struct Config {
     #[clap(long, default_value_t = 1024)]
     pub iouring_entry_count: usize,
 
+    /// IO-uring sqpoll idle time. If non-zero use a kernel thread to
+    /// perform submission queue polling. After the given idle time
+    /// the thread will go to sleep.
+    #[clap(long, default_value = "100ms")]
+    pub iouring_sqpoll_idle_time: Duration,
+
     /// Log format
     #[clap(long, value_enum, default_value_t = LogFormat::Full)]
     pub log_format: LogFormat,

--- a/lightway-server/src/io/inside/tun.rs
+++ b/lightway-server/src/io/inside/tun.rs
@@ -10,13 +10,16 @@ use lightway_core::{
 };
 use std::os::fd::{AsRawFd, RawFd};
 use std::sync::Arc;
+use std::time::Duration;
 
 pub(crate) struct Tun(AppUtilsTun);
 
 impl Tun {
-    pub async fn new(tun: TunConfig, iouring: Option<usize>) -> Result<Self> {
+    pub async fn new(tun: TunConfig, iouring: Option<(usize, Duration)>) -> Result<Self> {
         let tun = match iouring {
-            Some(ring_size) => AppUtilsTun::iouring(tun, ring_size).await?,
+            Some((ring_size, sqpoll_idle_time)) => {
+                AppUtilsTun::iouring(tun, ring_size, sqpoll_idle_time).await?
+            }
             None => AppUtilsTun::direct(tun).await?,
         };
         Ok(Tun(tun))

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -118,6 +118,9 @@ pub struct ServerConfig<SA: for<'a> ServerAuth<AuthState<'a>>> {
     /// IO-uring submission queue count
     pub iouring_entry_count: usize,
 
+    /// IO-uring sqpoll idle time.
+    pub iouring_sqpoll_idle_time: Duration,
+
     /// The key update interval for DTLS/TLS 1.3 connections
     pub key_update_interval: Duration,
 
@@ -173,7 +176,7 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
     let auth = Arc::new(AuthAdapter(config.auth));
 
     let iouring = if config.enable_tun_iouring {
-        Some(config.iouring_entry_count)
+        Some((config.iouring_entry_count, config.iouring_sqpoll_idle_time))
     } else {
         None
     };

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -132,6 +132,7 @@ async fn main() -> Result<()> {
         enable_pqc: config.enable_pqc,
         enable_tun_iouring: config.enable_tun_iouring,
         iouring_entry_count: config.iouring_entry_count,
+        iouring_sqpoll_idle_time: config.iouring_sqpoll_idle_time.into(),
         key_update_interval: config.key_update_interval.into(),
         inside_plugins: Default::default(),
         outside_plugins: Default::default(),

--- a/tests/client/client_config.yaml
+++ b/tests/client/client_config.yaml
@@ -15,6 +15,7 @@ outside_mtu: 1500
 cipher: aes256
 enable_pqc: false
 enable_tun_iouring: false
+# iouring_sqpoll_idle_time: 100ms
 iouring_entry_count: 1024
 keepalive_interval: 0s
 keepalive_timeout: 0s

--- a/tests/server/server_config.yaml
+++ b/tests/server/server_config.yaml
@@ -18,6 +18,7 @@ log_format: full
 log_level: info
 enable_pqc: false
 enable_tun_iouring: false
+# iouring_sqpoll_idle_time: 100ms
 iouring_entry_count: 1024
 key_update_interval: 15m
 user_db: "tests/server/lwpasswd"


### PR DESCRIPTION
## Description

Make it configurable and plumb it all the way through to the config file. The default remains 100ms.

## Motivation and Context

This is a useful tunable to play with when trading CPU use vs performance.

## How Has This Been Tested?

Observing the behaviour using htop and in particular observing that with it set to 0 no kernel thread is created.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
