### PR TITLE
lightway-core: Ignore `wire::Frame::Data{Frag}` until `State::Online`

### DIFF
--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -1334,6 +1334,10 @@ impl<AppState: Send> Connection<AppState> {
     }
 
     fn handle_outside_data_packet(&mut self, data: wire::Data) -> ConnectionResult<()> {
+        if !matches!(self.state, State::Online) {
+            return Err(ConnectionError::InvalidState);
+        }
+
         // into_owned should be a NOP here since
         // `wire::Data::try_from_wire` produced a `Cow::Owned`
         // variant.
@@ -1341,6 +1345,10 @@ impl<AppState: Send> Connection<AppState> {
     }
 
     fn handle_outside_data_fragment(&mut self, frag: wire::DataFrag) -> ConnectionResult<()> {
+        if !matches!(self.state, State::Online) {
+            return Err(ConnectionError::InvalidState);
+        }
+
         match self.fragment_map.add_fragment(frag) {
             FragmentMapResult::Complete(data) => {
                 self.handle_outside_data_bytes(data)?;


### PR DESCRIPTION

## Description

Data packets (whether fragmented or not) received from outside should not be forwarded out of the inside path until the connection is `Online` or after it has begun the disconnect process.

We already correctly do this for data received on the inside path, in `Connection::inside_data_received`.

## Motivation and Context

Traffic should only flow across an Online connection.

## How Has This Been Tested?

e2e tests continue to pass.
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
