### PR TITLE
lightway-app-utils: iouring: Remove metrics

### DIFF
--- a/lightway-app-utils/src/metrics.rs
+++ b/lightway-app-utils/src/metrics.rs
@@ -1,63 +1,10 @@
-use metrics::{counter, gauge, histogram, Counter, Gauge, Histogram};
-use std::{sync::LazyLock, time::Duration};
+use metrics::{counter, Counter};
+use std::sync::LazyLock;
 
-static METRIC_TUN_IOURING_COMPLETION_BATCH_SIZE: LazyLock<Histogram> =
-    LazyLock::new(|| histogram!("tun_iouring_completion_batch_size"));
-static METRIC_TUN_IOURING_COMPLETIONS_BEFORE_BLOCKING: LazyLock<Histogram> =
-    LazyLock::new(|| histogram!("tun_iouring_completions_before_blocking"));
-
-static METRIC_TUN_IOURING_RX_EAGAIN: LazyLock<Counter> =
-    LazyLock::new(|| counter!("tun_iouring_rx_eagain"));
 static METRIC_TUN_IOURING_RX_ERR: LazyLock<Counter> =
     LazyLock::new(|| counter!("tun_iouring_rx_err"));
-
-static METRIC_TUN_IOURING_BLOCKED: LazyLock<Counter> =
-    LazyLock::new(|| counter!("tun_iouring_blocked"));
-static METRIC_TUN_IOURING_WAKE_EVENTFD: LazyLock<Counter> =
-    LazyLock::new(|| counter!("tun_iouring_wake_eventfd"));
-static METRIC_TUN_IOURING_WAKE_TX: LazyLock<Counter> =
-    LazyLock::new(|| counter!("tun_iouring_wake_tx"));
-
-static METRIC_TUN_IOURING_TOTAL_THREAD_TIME: LazyLock<Gauge> =
-    LazyLock::new(|| gauge!("tun_iouring_total_thread_time"));
-static METRIC_TUN_IOURING_IDLE_THREAD_TIME: LazyLock<Gauge> =
-    LazyLock::new(|| gauge!("tun_iouring_idle_thread_time"));
-
-/// Monitors size of uring completion queue on each iteration
-pub(crate) fn tun_iouring_completion_batch_size(sz: usize) {
-    METRIC_TUN_IOURING_COMPLETION_BATCH_SIZE.record(sz as f64);
-}
-
-pub(crate) fn tun_iouring_completions_before_blocking(sz: usize) {
-    METRIC_TUN_IOURING_COMPLETIONS_BEFORE_BLOCKING.record(sz as f64)
-}
-
-/// Count iouring RX entries which complete with EAGAIN
-pub(crate) fn tun_iouring_rx_eagain() {
-    METRIC_TUN_IOURING_RX_EAGAIN.increment(1)
-}
 
 /// Count iouring RX entries which complete with an error
 pub(crate) fn tun_iouring_rx_err() {
     METRIC_TUN_IOURING_RX_ERR.increment(1)
-}
-
-pub(crate) fn tun_iouring_blocked() {
-    METRIC_TUN_IOURING_BLOCKED.increment(1)
-}
-
-pub(crate) fn tun_iouring_wake_eventfd() {
-    METRIC_TUN_IOURING_WAKE_EVENTFD.increment(1)
-}
-
-pub(crate) fn tun_iouring_wake_tx() {
-    METRIC_TUN_IOURING_WAKE_TX.increment(1)
-}
-
-pub(crate) fn tun_iouring_total_thread_time(t: Duration) {
-    METRIC_TUN_IOURING_TOTAL_THREAD_TIME.set(t.as_millis() as f64);
-}
-
-pub(crate) fn tun_iouring_idle_thread_time(t: Duration) {
-    METRIC_TUN_IOURING_IDLE_THREAD_TIME.increment(t.as_millis() as f64);
 }


### PR DESCRIPTION
## Description

These are very spammy and not all that useful in practice.

Retain the `tun_iouring_rx_err` one since that should be exceptional

## Motivation and Context

These are really hammering the metrics subsystem when under load and we aren't learning much from them.

## How Has This Been Tested?

Observing the metrics stream.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
