### PR TITLE
Fix new lints in Rust 1.83

### DIFF
--- a/lightway-core/src/borrowed_bytesmut.rs
+++ b/lightway-core/src/borrowed_bytesmut.rs
@@ -80,7 +80,7 @@ impl<'a> BorrowedBytesMut<'a> {
 /// `bytes::Buf` trait for `BorrowedBytesMut`
 /// These are the only required methods. All get_* helpers are provided
 /// from the trait
-impl<'a> Buf for BorrowedBytesMut<'a> {
+impl Buf for BorrowedBytesMut<'_> {
     fn remaining(&self) -> usize {
         self.len()
     }
@@ -103,7 +103,7 @@ impl<'a> Buf for BorrowedBytesMut<'a> {
     }
 }
 
-impl<'a> Deref for BorrowedBytesMut<'a> {
+impl Deref for BorrowedBytesMut<'_> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {

--- a/lightway-core/src/connection/builders.rs
+++ b/lightway-core/src/connection/builders.rs
@@ -365,6 +365,6 @@ impl<'a, AppState: Send + 'static> ServerConnectionBuilder<'a, AppState> {
     }
 }
 
-impl<'a, AppState> BuilderPredicates for ServerConnectionBuilder<'a, AppState> {
+impl<AppState> BuilderPredicates for ServerConnectionBuilder<'_, AppState> {
     type Error = ConnectionBuilderError;
 }

--- a/lightway-core/src/connection/dplpmtud.rs
+++ b/lightway-core/src/connection/dplpmtud.rs
@@ -54,7 +54,6 @@ const PMTU_RAISE_TIMER_TIMEOUT: Duration = Duration::from_secs(600);
 ///
 /// Here the "Packetization Layer" is "Lightway" itself (not
 /// including DTLS or lower layers)
-
 fn probe_payload_size_for_plpmtu(plpmtu: u16) -> u16 {
     let overhead = std::mem::size_of::<wire::FrameKind>() + wire::Ping::WIRE_OVERHEAD;
     debug_assert_ge!(plpmtu, overhead as u16);

--- a/lightway-core/src/wire.rs
+++ b/lightway-core/src/wire.rs
@@ -299,7 +299,7 @@ pub(crate) enum Frame<'data> {
     DataFrag(data_frag::DataFrag),
 }
 
-impl<'data> Frame<'data> {
+impl Frame<'_> {
     pub(crate) fn kind(&self) -> FrameKind {
         match self {
             Self::NoOp => FrameKind::NoOp,
@@ -567,7 +567,7 @@ mod test_frame {
     #[test_case(&[0x0c] => Frame::Goodbye; "goodbye")]
     #[test_case(b"\x0e\x00\x0dserver config" => Frame::ServerConfig(ServerConfig{ data: Bytes::from_static(b"server config")}); "server config")]
     #[test_case(b"\x0f\x00\x0b\x12\x34\x2a\xcffragmentary"=> Frame::DataFrag(DataFrag{ id: 0x1234, offset: 0x5678, more_fragments: true, data: Bytes::from_static(b"fragmentary") }) ; "data frag")]
-    fn try_from_wire(buf: &'static [u8]) -> Frame {
+    fn try_from_wire(buf: &'static [u8]) -> Frame<'static> {
         let mut buf = BytesMut::from(buf);
         let r = Frame::try_from_wire(&mut buf).unwrap();
         assert!(buf.is_empty(), "Should consume entire frame");

--- a/lightway-core/src/wire/data.rs
+++ b/lightway-core/src/wire/data.rs
@@ -28,7 +28,7 @@ pub(crate) struct Data<'data> {
     pub(crate) data: Cow<'data, BytesMut>,
 }
 
-impl<'data> Data<'data> {
+impl Data<'_> {
     /// Wire overhead in bytes
     const WIRE_OVERHEAD: usize = 2;
 

--- a/lightway-server/src/connection_manager/connection_map.rs
+++ b/lightway-server/src/connection_manager/connection_map.rs
@@ -33,7 +33,7 @@ pub(crate) struct VacantEntry<'a, T> {
     session_id_map: &'a mut HashMap<SessionId, Arc<T>>,
 }
 
-impl<'a, T: Value> VacantEntry<'a, T> {
+impl<T: Value> VacantEntry<'_, T> {
     pub(crate) fn insert(self, value: &Arc<T>) -> Result<(), InsertError> {
         if self.socket_addr_entry.key() != &value.socket_addr() {
             return Err(InsertError::InconsistentSocketAddr);

--- a/lightway-server/src/io/outside/udp/cmsg.rs
+++ b/lightway-server/src/io/outside/udp/cmsg.rs
@@ -46,7 +46,7 @@ pub enum Message<'a> {
     Unknown(#[allow(dead_code)] &'a libc::cmsghdr),
 }
 
-impl<'a> Message<'a> {
+impl Message<'_> {
     pub(crate) const fn space<T>() -> usize {
         // SAFETY: CMSG_SPACE is always safe
         unsafe { libc::CMSG_SPACE(std::mem::size_of::<T>() as libc::c_uint) as usize }
@@ -154,7 +154,7 @@ pub(crate) struct BufferBuilder<'a, const N: usize> {
     _phantom: std::marker::PhantomData<&'a mut Buffer<N>>,
 }
 
-impl<'a, const N: usize> BufferBuilder<'a, N> {
+impl<const N: usize> BufferBuilder<'_, N> {
     pub(crate) fn fill_next<T>(
         &mut self,
         cmsg_level: libc::c_int,


### PR DESCRIPTION
Several of the form:
```
error: the following explicit lifetimes could be elided: 'a
  --> lightway-core/src/borrowed_bytesmut.rs:83:6
   |
83 | impl<'a> Buf for BorrowedBytesMut<'a> {
   |      ^^                           ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_lifetimes)]`
help: elide the lifetimes
   |
83 - impl<'a> Buf for BorrowedBytesMut<'a> {
83 + impl Buf for BorrowedBytesMut<'_> {
```

As well as:
```
error: empty line after doc comment
  --> lightway-core/src/connection/dplpmtud.rs:56:1
   |
56 | / /// including DTLS or lower layers)
57 | |
   | |_
58 |   fn probe_payload_size_for_plpmtu(plpmtu: u16) -> u16 {
   |   ---------------------------------------------------- the comment documents this function
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments
   = note: `-D clippy::empty-line-after-doc-comments` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::empty_line_after_doc_comments)]`
   = help: if the empty line is unintentional remove it
```

and

```
error: elided lifetime has a name
   --> lightway-core/src/wire.rs:570:45
    |
570 |     fn try_from_wire(buf: &'static [u8]) -> Frame {
    |                                             ^^^^^ this elided lifetime gets resolved as `'static`
    |
    = note: `-D elided-named-lifetimes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(elided_named_lifetimes)]`
help: consider specifying it explicitly
    |
570 |     fn try_from_wire(buf: &'static [u8]) -> Frame<'static> {
    |                                                  +++++++++
```

---
#133 is waiting for https://github.com/docker-library/official-images/pull/17990 so CI will pass. In the meantime address the new lints discovered by running locally.
