### PR TITLE
Update cargo deny github action to v2

### DIFF
--- a/.github/workflows/nightly-cargo-deny.yaml
+++ b/.github/workflows/nightly-cargo-deny.yaml
@@ -9,4 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: EmbarkStudios/cargo-deny-action@v1
+    - uses: EmbarkStudios/cargo-deny-action@v2


### PR DESCRIPTION
## Description

Update cargo deny github action to v2 
Similar to https://github.com/expressvpn/wolfssl-rs/pull/205

Current CI is not failing since our lock files are still in version 3. 
Update github action to future proof when we update the lock file next time

## Motivation and Context

Found wolfssl Ci errors with older version

## How Has This Been Tested?
Ran manually CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
