### PR TITLE
readme: Add a note on choosing other username / password mechanisms

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Protocol and design documentation can be found in the
 
 ## Supported platforms
 
-Lightway rust implementation currently supports Linux OS. Both x86_64 and arm64 platforms are
+Lightway Rust implementation currently supports Linux OS. Both x86_64 and arm64 platforms are
 supported and built as part of CI.
 
 Support for other platforms will be added soon.
@@ -103,6 +103,13 @@ or `-5` to pick a different algorithm.
 
 [`htpasswd(1)`]: https://httpd.apache.org/docs/2.4/programs/htpasswd.html
 [`pwhash`]: https://crates.io/crates/pwhash
+
+> [!CAUTION]
+> The widely used but basic `htpasswd(1)` username / password database format 
+> was chosen here to provide an easy-to-setup reference implementation of 
+> Lightway. Users of the open surce community are encouraged to modify this
+> implementation with more advanced username / password authentication mechanisms
+> and their own choice of password hashing algorithms to suit their security > needs. 
 
 Please note that when providing env variables it should be in upper case and using "_" as a word separator,
 while using as cli config, it should be in lower case with "-" as the word separator.


### PR DESCRIPTION
## Description
Adding a quick note to let the open-source community know that using the `htpasswd(1)` username/password format is a simple reference implementation and that users are free modify it to suit their security needs. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
