### PR TITLE
crate: downgrade metrics-util to 0.18.0

### DIFF
--- a/lightway-server/Cargo.toml
+++ b/lightway-server/Cargo.toml
@@ -32,7 +32,7 @@ libc.workspace = true
 lightway-app-utils.workspace = true
 lightway-core = { workspace = true, features = ["postquantum"] }
 metrics.workspace = true
-metrics-util = "0.19.0"
+metrics-util = "0.18.0"
 pnet.workspace = true
 ppp = "2.2.0"
 pwhash = "1.0.0"


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Downgrade metrics-util to 0.18.0 until metrics-exporter-dogstatsd integration is done in server

## Motivation and Context

To keep metrics crate in sync

## How Has This Been Tested?
Verified locally the metrics worked

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
