### PR TITLE
server: add support for bind retry attempts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.19.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd4884b1dd24f7d6628274a2f5ae22465c337c5ba065ec9b6edccddf8acc673"
+checksum = "15b482df36c13dd1869d73d14d28cd4855fbd6cfc32294bee109908a9f4a4ed7"
 dependencies = [
  "aho-corasick",
  "crossbeam-epoch",
@@ -1399,8 +1399,6 @@ dependencies = [
  "ordered-float",
  "quanta",
  "radix_trie",
- "rand",
- "rand_xoshiro",
  "sketches-ddsketch",
 ]
 
@@ -1858,15 +1856,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]

--- a/lightway-server/src/args.rs
+++ b/lightway-server/src/args.rs
@@ -1,5 +1,6 @@
 use std::{
     net::{Ipv4Addr, SocketAddr},
+    num::NonZeroUsize,
     path::PathBuf,
 };
 
@@ -102,6 +103,11 @@ pub struct Config {
     /// Address to listen to
     #[clap(long, default_value = "0.0.0.0:27690")]
     pub bind_address: SocketAddr,
+
+    /// Number of bind attempts, in case of AddrInUse failure
+    /// Will wait 1 second after failed attempt, before retrying
+    #[clap(long, default_value_t = NonZeroUsize::MIN)]
+    pub bind_attempts: NonZeroUsize,
 
     /// Enable PROXY protocol support (TCP only)
     #[clap(long)]

--- a/lightway-server/src/io/outside/tcp.rs
+++ b/lightway-server/src/io/outside/tcp.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, num::NonZeroUsize, sync::Arc, time::Duration};
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -171,9 +171,28 @@ impl TcpServer {
     pub(crate) async fn new(
         conn_manager: Arc<ConnectionManager>,
         bind_address: SocketAddr,
+        bind_attempts: NonZeroUsize,
         proxy_protocol: bool,
     ) -> Result<TcpServer> {
-        let sock = Arc::new(tokio::net::TcpListener::bind(bind_address).await?);
+        let bind_attempts = bind_attempts.get();
+        let mut attempts = 0;
+        let sock = loop {
+            match tokio::net::TcpListener::bind(bind_address).await {
+                Ok(sock) => break sock,
+                Err(e) if matches!(e.kind(), std::io::ErrorKind::AddrInUse) => {
+                    attempts += 1;
+                    warn!("Bind failed, attempt: {}", attempts);
+                    if attempts >= bind_attempts {
+                        return Err(e.into());
+                    }
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+                Err(e) => {
+                    return Err(e.into());
+                }
+            }
+        };
+        let sock = Arc::new(sock);
 
         Ok(Self {
             conn_manager,

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -25,6 +25,7 @@ use pnet::packet::ipv4::Ipv4Packet;
 use std::{
     collections::HashMap,
     net::{IpAddr, Ipv4Addr, SocketAddr},
+    num::NonZeroUsize,
     path::PathBuf,
     sync::Arc,
     time::Duration,
@@ -144,6 +145,9 @@ pub struct ServerConfig<SA: for<'a> ServerAuth<AuthState<'a>>> {
     /// Address to listen to
     pub bind_address: SocketAddr,
 
+    /// Number of bind attempts, in case of AddrInUse failure
+    pub bind_attempts: NonZeroUsize,
+
     /// Enable PROXY protocol support (TCP only)
     pub proxy_protocol: bool,
 
@@ -218,6 +222,7 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
             io::outside::UdpServer::new(
                 conn_manager.clone(),
                 config.bind_address,
+                config.bind_attempts,
                 config.udp_buffer_size,
             )
             .await?,
@@ -226,6 +231,7 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
             io::outside::TcpServer::new(
                 conn_manager.clone(),
                 config.bind_address,
+                config.bind_attempts,
                 config.proxy_protocol,
             )
             .await?,

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -138,6 +138,7 @@ async fn main() -> Result<()> {
         inside_plugins: Default::default(),
         outside_plugins: Default::default(),
         bind_address: config.bind_address,
+        bind_attempts: config.bind_attempts,
         proxy_protocol: config.proxy_protocol,
         udp_buffer_size: config.udp_buffer_size,
     };

--- a/tests/server/server_config.yaml
+++ b/tests/server/server_config.yaml
@@ -1,5 +1,6 @@
 ---
 bind_address: 0.0.0.0:27690
+bind_attempts: 3
 mode: tcp
 server_cert: "tests/certs/server.crt"
 server_key: "tests/certs/server.key"


### PR DESCRIPTION
## Description

Add retry support for bind attempts, if case bind fails with AddrInUse error.
The default attempt count is 1 and can be configurable using CLI config.

## Motivation and Context
When we replace running lightway instances, there are some situations, where the Bind address is not released in Kernel. This makes the new lightway server process to fail starting. 

Since this is intermittent, we can retry few times before bailing.

## How Has This Been Tested?
Ran manually server instances with already running instance.

```console
❯ cargo run --release --bin lightway-server -- --config-file ./ignore_server_conf.yaml --log-level debug --mode tcp --tun-name lw-sec --bind-attempts 3
   Compiling lightway-server v0.1.0 (/work/github/expressvpn/lightway/lightway-server)
    Finished `release` profile [optimized + debuginfo] target(s) in 30.15s
     Running `target/release/lightway-server --config-file ./ignore_server_conf.yaml --log-level debug --mode tcp --tun-name lw-sec --bind-attempts 3`
2025-02-05T02:32:19.467441Z  INFO lightway_server: Server starting with config:
ServerConfig {
    connection_type: Stream,
    server_cert: "/work/certs/selfsign/out/lightwayserver.crt",
    server_key: "/work/certs/selfsign/out/lightwayserver.key",
    ip_pool: 10.125.0.0/16,
    tun_ip: Some(
        10.125.0.1,
    ),
    ip_map: {},
    lightway_server_ip: 10.125.0.5,
    lightway_client_ip: 10.125.0.6,
    lightway_dns_ip: 10.125.0.1,
    enable_pqc: true,
    enable_tun_iouring: false,
    iouring_entry_count: 1024,
    iouring_sqpoll_idle_time: 100ms,
    key_update_interval: 900s,
    inside_plugins: 0 plugins,
    outside_plugins: 0 plugins,
    bind_address: 0.0.0.0:40890,
    bind_attempts: 3,
    proxy_protocol: false,
    udp_buffer_size: 15.7 MB,
}
2025-02-05T02:32:19.467491Z  INFO lightway_server: Server started with inside ip: 10.125.0.1
2025-02-05T02:32:19.470339Z  WARN lightway_server::io::outside::tcp: Bind failed, attempt: 1
2025-02-05T02:32:19.471491Z  INFO lightway_server::statistics: Session Statistics total=0 current=0 standby.five_minutes=0 standby.fifteen_minutes=0 standby.sixty_minutes=0 active.five_minutes=0 active.fifteen_minutes=0 active.sixty_minutes=0 pending_session_id_rotations=0
2025-02-05T02:32:19.471519Z  INFO lightway_server::statistics: IP Statistics current=0
2025-02-05T02:32:20.471074Z  WARN lightway_server::io::outside::tcp: Bind failed, attempt: 2
2025-02-05T02:32:21.471887Z  WARN lightway_server::io::outside::tcp: Bind failed, attempt: 3
Error: Address already in use (os error 98)
❯ cargo run --release --bin lightway-server -- --config-file ./ignore_server_conf.yaml --log-level debug --mode tcp --tun-name lw-sec --bind-attempts 0
    Finished `release` profile [optimized + debuginfo] target(s) in 0.10s
     Running `target/release/lightway-server --config-file ./ignore_server_conf.yaml --log-level debug --mode tcp --tun-name lw-sec --bind-attempts 0`
error: invalid value '0' for '--bind-attempts <BIND_ATTEMPTS>': number would be zero for non-zero type

For more information, try '--help'.

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
