### PR TITLE
Server: Close tcp connections on expiry/aged out

### DIFF
--- a/lightway-server/src/connection.rs
+++ b/lightway-server/src/connection.rs
@@ -178,6 +178,9 @@ impl Connection {
     }
 
     pub fn disconnect(&self) -> ConnectionResult<()> {
+        if matches!(self.state(), State::Disconnecting | State::Disconnected) {
+            return Ok(());
+        }
         metrics::connection_closed();
         self.manager.remove_connection(self);
         self.lw_conn.lock().unwrap().disconnect()

--- a/lightway-server/src/connection_manager.rs
+++ b/lightway-server/src/connection_manager.rs
@@ -27,7 +27,7 @@ use lightway_core::{
 };
 
 /// How often to check for connections to expire aged connections
-const CONNECTION_AGE_EXPIRATION_INTERVAL: Duration = Duration::minutes(1);
+pub(crate) const CONNECTION_AGE_EXPIRATION_INTERVAL: Duration = Duration::minutes(1);
 
 /// How often to check for connections to expire connections where authentication has expired
 const CONNECTION_AUTH_EXPIRATION_INTERVAL: Duration = Duration::hours(6);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In TCP server, we create a tokio task for each TCP connection (unlike UDP, where there
is only one tokio task) and it waits on TCP socket to recv packets.
During normal client disconnects, tcp socket read will return 0/Err and the task exits.
But in case of network failure, it is possible tcp socket stays alive, until TCP keepalive
times out.

Instead of waiting for TCP keepalive, close the socket proactively in case the connection
is not online

Inactive lightway connections are aged out and closed regularly and this proactive TCP close
will be useful in those evictions.


## Motivation and Context

Close TCP on disconnect and save resource

## How Has This Been Tested?

Verified the TCP state is cleared from kernel after the timeout.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
