### PR TITLE
Revert "server: add check for current state before disconnecting"

### DIFF
--- a/lightway-server/src/connection.rs
+++ b/lightway-server/src/connection.rs
@@ -178,9 +178,6 @@ impl Connection {
     }
 
     pub fn disconnect(&self) -> ConnectionResult<()> {
-        if matches!(self.state(), State::Disconnecting | State::Disconnected) {
-            return Ok(());
-        }
         metrics::connection_closed();
         self.manager.remove_connection(self);
         self.lw_conn.lock().unwrap().disconnect()


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

This reverts commit a8d6ed4091e2df0ce058a811d595c4bac1c68ca6.

This commit breaks the auth failure flow, where lightway state is set to disconnected by lightway core itself.
So server code cannot rely on lightway core state, to cleanup the connections and free memory.

This revert will openup the metrics double counting issue. I will do some more testing and do proper fix in further PR.

## Motivation and Context

Seeing connections are leaking with auth failure client connections.

## How Has This Been Tested?

Verified the connections is getting dropped on auth failure.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
