### PR TITLE
Fix UDP lightway connections failure in single threaded runtime

### DIFF
--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -20,6 +20,9 @@ impl Udp {
             None => tokio::net::UdpSocket::bind("0.0.0.0:0").await?,
         };
         let default_ip_pmtudisc = sockopt::get_ip_mtu_discover(&sock)?;
+        // Check for the socket's writable ready status, so that it can be used
+        // successfuly in WolfSsl's `OutsideIOSendCallback` callback
+        sock.writable().await?;
 
         let peer_addr = tokio::net::lookup_host(remote_addr)
             .await?

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -168,6 +168,10 @@ pub struct ClientConfig<'cert, A: 'static + Send + EventCallback> {
     #[educe(Debug(ignore))]
     pub event_handler: Option<A>,
 
+    /// Enable WolfSsl debugging
+    #[cfg(feature = "debug")]
+    pub tls_debug: bool,
+
     /// File path to save wireshark keylog
     #[cfg(feature = "debug")]
     pub keylog: Option<PathBuf>,
@@ -420,6 +424,11 @@ pub async fn client<A: 'static + Send + EventCallback>(
         extended: (),
     };
     let (pmtud_timer, pmtud_timer_task) = DplpmtudTimer::new();
+
+    #[cfg(feature = "debug")]
+    if config.tls_debug {
+        enable_tls_debug();
+    }
 
     let conn_builder = ClientContextBuilder::new(
         connection_type,

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -41,11 +41,6 @@ async fn main() -> Result<()> {
         Layer::Clap(matches),
     ])?;
 
-    #[cfg(feature = "debug")]
-    if config.tls_debug {
-        enable_tls_debug();
-    }
-
     tracing_subscriber::fmt()
         .with_max_level(config.log_level)
         .init();
@@ -105,6 +100,8 @@ async fn main() -> Result<()> {
         stop_signal: ctrlc_rx,
         network_change_signal: None,
         event_handler: Some(EventHandler),
+        #[cfg(feature = "debug")]
+        tls_debug: config.tls_debug,
         #[cfg(feature = "debug")]
         keylog: config.keylog,
     };

--- a/lightway-server/src/io/outside/udp.rs
+++ b/lightway-server/src/io/outside/udp.rs
@@ -137,6 +137,9 @@ impl UdpServer {
                 }
             }
         };
+        // Check for the socket's writable ready status, so that it can be used
+        // successfuly in WolfSsl's `OutsideIOSendCallback` callback
+        sock.writable().await?;
         let sock = Arc::new(sock);
 
         let bind_mode = if bind_address.ip().is_unspecified() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

With single threaded tokio runtime, the udp sockets return WouldBlock,
until we explicitly request the socket to be writable (UdpSocket::writable()).
The behavior seems different in multi threaded runtime, where it gets enabled
after the first few calls.

Since the outside io send is called from WolfSsl's callback which is not async,
we do not have a way to enable UdpSocket to be writable()

This causes the UDP lightway connection to fail, in case of single threaded environment.
i.e WolfSsl is not able to handle send failures, during initial negotiation

This commit makes the socket to be writable as soon as it is created, so that
WolfSsl can use sync send directly successfully.

## Motivation and Context


We saw inconsistent crashes in our CI with WolfSsl error 

https://github.com/expressvpn/lightway/actions/runs/11265863343/job/31328407767#step:4:30
https://cloud.earthly.dev/expressvpn/builds/b00380f8-e4fe-4e56-99fe-a03c050a8906/targets/6f52103d-e8dc-479f-81b9-6b1b0e4a354d?back=graph&new-build=enable

```
    635  ./tests+run-udp-aes256-test *failed* | lightway-e2e-client-1  | 2024-10-10T01:41:37.905384Z ERROR lightway_client: Failed to process outside data: WolfSSL Error: Fatal: code: -425, what: The security parameter is invalid
    636  ./tests+run-udp-aes256-test *failed* | lightway-e2e-client-1  | thread 'tokio-runtime-worker' panicked at /tmp/earthly/.cargo/git/checkouts/wolfssl-rs-4904f81b74b29d10/56d7b28/wolfssl/src/ssl.rs:406:18:
    637  ./tests+run-udp-aes256-test *failed* | lightway-e2e-client-1  | internal error: entered unreachable code: -326
    638  ./tests+run-udp-aes256-test *failed* | lightway-e2e-client-1  | note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
    639  ./tests+run-udp-aes256-test *failed* | lightway-e2e-client-1  | Error: Outside IO loop exited: Err(JoinError::Panic(Id(14), "internal error: entered unreachable code: -326", ...))
```

While trying to use single threaded runtime for client, we observed this same bug consistently.

## How Has This Been Tested?
Verified UDP connection is successful with single threaded runtime.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
