### PR TITLE
app-utils: conditionally build libc constants for Apple instead

### DIFF
--- a/lightway-app-utils/src/sockopt.rs
+++ b/lightway-app-utils/src/sockopt.rs
@@ -5,4 +5,5 @@ mod ip_mtu_discover;
 mod ip_pktinfo;
 
 pub use ip_mtu_discover::*;
+#[cfg(not(target_vendor = "apple"))]
 pub use ip_pktinfo::*;

--- a/lightway-app-utils/src/sockopt/ip_mtu_discover.rs
+++ b/lightway-app-utils/src/sockopt/ip_mtu_discover.rs
@@ -60,13 +60,13 @@ pub fn get_ip_mtu_discover(sock: &impl AsRawFd) -> std::io::Result<IpPmtudisc> {
     let level: i32;
     let optname: i32;
 
-    #[cfg(target_os = "macos")]
+    #[cfg(target_vendor = "apple")]
     {
         level = libc::IPPROTO_IP;
         optname = libc::IP_DONTFRAG;
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(target_vendor = "apple"))]
     {
         level = libc::SOL_IP;
         optname = libc::IP_MTU_DISCOVER;
@@ -106,13 +106,13 @@ pub fn set_ip_mtu_discover(sock: &impl AsRawFd, pmtudisc: IpPmtudisc) -> std::io
     let level: i32;
     let optname: i32;
 
-    #[cfg(target_os = "macos")]
+    #[cfg(target_vendor = "apple")]
     {
         level = libc::IPPROTO_IP;
         optname = libc::IP_DONTFRAG;
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(target_vendor = "apple"))]
     {
         level = libc::SOL_IP;
         optname = libc::IP_MTU_DISCOVER;

--- a/lightway-app-utils/src/sockopt/ip_pktinfo.rs
+++ b/lightway-app-utils/src/sockopt/ip_pktinfo.rs
@@ -1,7 +1,9 @@
 #![allow(unsafe_code)]
 
+#[cfg(not(target_vendor = "apple"))]
 use std::os::fd::AsRawFd;
 
+#[cfg(not(target_vendor = "apple"))]
 /// Enable IP_PKTINFO sockopt.
 pub fn socket_enable_pktinfo(sock: &impl AsRawFd) -> std::io::Result<()> {
     // SAFETY: `setsockopt` requires a valid fd and a valid buffer of `c_int` size


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since iOS also doesn't support SOL_IP, we are now updating the some of the libc constant to be built conditionally based on `target_vendor = "apple"` instead of just MacOS.

We have also updated `socket_enable_pktinfo` to be built/included only when we are not using an apple platform.

## Motivation and Context
Originally, `socket_enable_pktinfo` can't be built on Mac/iOS platform because mac/ios platform doesn't have `SOL_IP` in libc. So this PR fixes this, and allows us to build libraries on apple platforms.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested our internal clients can be built on iOS platform (`aarch64-apple-ios`, `aarch64-apple-ios-sim`) when it's referencing this new branch and includes `lightway-core`, `lightway-client`, `lightway-app-utils` in their dependency

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
