### PR TITLE
CVPN-1860: Skip unknown frames

### DIFF
--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -193,9 +193,11 @@ impl ConnectionError {
                     InvalidInsideIpConfig(_) => true,
                     AccessDenied => true,
                     Goodbye => true,
-                    WireError(_) => true,
                     WolfSSL(wolfssl::Error::Fatal(ErrorKind::DomainNameMismatch)) => true,
                     WolfSSL(wolfssl::Error::Fatal(ErrorKind::DuplicateMessage)) => true,
+
+                    WireError(wire::FromWireError::UnknownFrameType) => false,
+                    WireError(_) => true,
 
                     InvalidState => false, // Can be due to out of order or repeated messages
                     UnknownSessionID => false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Lightway UDP on receiving the unknown frame types, disconnects the session. But this is not needed since we can work ignoring the frame. This makes the server/client backward compatible and ignore frames which are not needed instead of disconnecting.

This is similar to C implementation:
https://github.com/expressvpn/lightway-core/blob/aeeb6acb7eb2189e08ce52685c985d5be71eb69c/src/he/flow.c#L209

## Motivation and Context

To make servers backward compatible with newer clients

## How Has This Been Tested?

Unit tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
