### PR TITLE
Disconnect connection when session rekey failed

### DIFF
--- a/lightway-app-utils/src/connection_ticker.rs
+++ b/lightway-app-utils/src/connection_ticker.rs
@@ -77,7 +77,21 @@ pub struct ConnectionTickerTask(mpsc::UnboundedReceiver<()>);
 
 impl ConnectionTickerTask {
     /// Spawn the handler task
-    pub fn spawn<T: Tickable + 'static>(
+    pub fn spawn<T: Tickable + 'static>(self, weak: Weak<T>) -> tokio::task::JoinHandle<()> {
+        let mut recv = self.0;
+        tokio::task::spawn(async move {
+            while let Some(()) = recv.recv().await {
+                let Some(tickable) = weak.upgrade() else {
+                    break;
+                };
+
+                let _ = tickable.tick();
+            }
+        })
+    }
+
+    /// Spawn the handler task in a JoinSet
+    pub fn spawn_in<T: Tickable + 'static>(
         self,
         weak: Weak<T>,
         join_set: &mut JoinSet<()>,
@@ -119,9 +133,8 @@ mod tests {
         }
 
         let conn = Arc::new(Dummy(Mutex::new(Some(tx))));
-        let mut join_set = JoinSet::new();
 
-        ticker_task.spawn(Arc::downgrade(&conn), &mut join_set);
+        ticker_task.spawn(Arc::downgrade(&conn));
 
         ticker.schedule(Duration::ZERO);
 
@@ -143,13 +156,12 @@ mod tests {
         }
 
         let conn = Arc::new(Dummy);
-        let mut join_set = JoinSet::new();
 
-        ticker_task.spawn(Arc::downgrade(&conn), &mut join_set);
+        let task = ticker_task.spawn(Arc::downgrade(&conn));
 
         drop(ticker);
 
-        while (join_set.join_next().await).is_some() {}
+        task.await.unwrap(); // Task should exit cleanly
     }
 
     #[tokio::test]
@@ -167,9 +179,87 @@ mod tests {
         }
 
         let conn = Arc::new(Dummy);
+
+        let task = ticker_task.spawn(Arc::downgrade(&conn));
+
+        drop(conn);
+
+        ticker.schedule(Duration::ZERO);
+
+        task.await.unwrap(); // Task should exit cleanly
+    }
+
+    #[tokio::test]
+    async fn joinset_ticks() {
+        use std::sync::{Arc, Mutex};
+        use tokio::sync::oneshot;
+
+        let (ticker, ticker_task) = ConnectionTicker::new();
+
+        // We'll "tick" this channel
+        let (tx, rx) = oneshot::channel();
+
+        struct Dummy(Mutex<Option<oneshot::Sender<()>>>);
+
+        impl Tickable for Dummy {
+            fn tick(&self) -> ConnectionResult<()> {
+                self.0.lock().unwrap().take().unwrap().send(()).unwrap();
+                Ok(())
+            }
+        }
+
+        let conn = Arc::new(Dummy(Mutex::new(Some(tx))));
         let mut join_set = JoinSet::new();
 
-        ticker_task.spawn(Arc::downgrade(&conn), &mut join_set);
+        ticker_task.spawn_in(Arc::downgrade(&conn), &mut join_set);
+
+        ticker.schedule(Duration::ZERO);
+
+        rx.await.unwrap(); // Should get the tick
+    }
+
+    #[tokio::test]
+    async fn joinset_task_exits_when_ticker_released() {
+        use std::sync::Arc;
+
+        let (ticker, ticker_task) = ConnectionTicker::new();
+
+        struct Dummy;
+
+        impl Tickable for Dummy {
+            fn tick(&self) -> ConnectionResult<()> {
+                panic!("Not expecting to tick");
+            }
+        }
+
+        let conn = Arc::new(Dummy);
+        let mut join_set = JoinSet::new();
+
+        ticker_task.spawn_in(Arc::downgrade(&conn), &mut join_set);
+
+        drop(ticker);
+
+        while (join_set.join_next().await).is_some() {}
+    }
+
+    #[tokio::test]
+    async fn joinset_task_exits_when_conn_released() {
+        use std::sync::Arc;
+
+        let (ticker, ticker_task) = ConnectionTicker::new();
+
+        struct Dummy;
+
+        impl Tickable for Dummy {
+            fn tick(&self) -> ConnectionResult<()> {
+                panic!("Not expecting to tick");
+            }
+        }
+
+        let conn = Arc::new(Dummy);
+        let mut join_set = JoinSet::new();
+
+        ticker_task.spawn_in(Arc::downgrade(&conn), &mut join_set);
 
         drop(conn);
 

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -667,7 +667,7 @@ pub async fn client<A: 'static + Send + EventCallback>(
         event_handler,
     ));
 
-    ticker_task.spawn(Arc::downgrade(&conn), &mut join_set);
+    ticker_task.spawn_in(Arc::downgrade(&conn), &mut join_set);
     pmtud_timer_task.spawn(Arc::downgrade(&conn), &mut join_set);
 
     let outside_io_loop: JoinHandle<anyhow::Result<()>> = tokio::spawn(outside_io_task(

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -16,7 +16,7 @@ use std::{
     time::{Duration, Instant},
 };
 use thiserror::Error;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 use wolfssl::{ErrorKind, IOCallbackResult, ProtocolVersion};
 
 use crate::max_dtls_mtu;
@@ -624,6 +624,7 @@ impl<AppState: Send> Connection<AppState> {
 
         // Trigger a callback if timer is not already running
         if !self.is_tick_timer_running {
+            trace!("Scheduling tick for {:?}", interval);
             if let Some(schedule_tick_cb) = self.schedule_tick_cb {
                 schedule_tick_cb(interval, &mut self.app_state);
 
@@ -659,6 +660,7 @@ impl<AppState: Send> Connection<AppState> {
     /// [`Connection::tick_interval`] for usage.
     pub fn tick(&mut self) -> ConnectionResult<()> {
         self.is_tick_timer_running = false;
+        trace!(?self.session_id, "Processing connection tick");
 
         match self.state {
             State::Authenticating => {

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -676,6 +676,9 @@ impl<AppState: Send> Connection<AppState> {
                     return Err(ConnectionError::InvalidMode);
                 }
             }
+            State::Disconnecting | State::Disconnected => {
+                return Err(ConnectionError::Disconnected);
+            }
             _ if self.connection_type.is_datagram() => match self.session.dtls_has_timed_out() {
                 wolfssl::Poll::Ready(true) => {
                     self.set_state(State::Disconnected)?;

--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -210,7 +210,7 @@ async fn server<S: TestSock>(sock: Arc<S>, pqc: PQCrypto) {
 
     let mut join_set = JoinSet::new();
 
-    ticker_task.spawn(Arc::downgrade(&conn), &mut join_set);
+    ticker_task.spawn_in(Arc::downgrade(&conn), &mut join_set);
     loop {
         tokio::select! {
             // Inside data received
@@ -323,7 +323,7 @@ async fn client<S: TestSock>(
         .unwrap();
     let client = Arc::new(Mutex::new(client));
 
-    ticker_task.spawn(Arc::downgrade(&client), &mut join_set);
+    ticker_task.spawn_in(Arc::downgrade(&client), &mut join_set);
 
     let event_client = client.clone();
 

--- a/lightway-server/src/connection.rs
+++ b/lightway-server/src/connection.rs
@@ -89,8 +89,7 @@ impl Connection {
             .set(Arc::downgrade(&conn))
             .unwrap();
 
-        let mut join_set = tokio::task::JoinSet::new();
-        ticker_task.spawn(Arc::downgrade(&conn), &mut join_set);
+        ticker_task.spawn(Arc::downgrade(&conn));
 
         Ok(conn)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Spawn the ticker task in JoinSet only if it is going to be stored. Else create as normal tokio task
which will be killed when Channel sender is dropped

## Motivation and Context
Found ticker is not working in server while testing.

## How Has This Been Tested?
Manually verified the tick is properly called after timer expiry

```
2025-03-21T03:02:26.241855Z  INFO lightway_core::connection: Update TLS keys session=c8fece5b7d4d8de7
2025-03-21T03:02:26.242026Z DEBUG lightway_core::connection: event event=TlsKeysUpdateStart
2025-03-21T03:02:26.242076Z TRACE lightway_core::connection: Scheduling tick for 100ms
2025-03-21T03:02:26.242151Z TRACE handle_events:handle_tls_keys_update_start: lightway_server::metrics: Begin session rot
ation
2025-03-21T03:02:26.243634Z DEBUG lightway_core::connection: event event=TlsKeysUpdateCompleted
2025-03-21T03:02:26.248196Z DEBUG lightway_core::connection: event event=SessionIdRotationAcknowledged { old: c8fece5b7d4
d8de7, new: 2f16b0c4b5013a6e }
2025-03-21T03:02:26.248319Z TRACE handle_events:handle_finalize_session_rotation: lightway_server::metrics: Finalize sess
ion rotation
2025-03-21T03:02:26.343356Z TRACE lightway_core::connection: Processing connection tick self.session_id=2f16b0c4b5013a6e
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
