### PR TITLE
CVPN-1824 Encoding Request Retransmission

### DIFF
--- a/docs/inside_packet_codec.md
+++ b/docs/inside_packet_codec.md
@@ -137,5 +137,8 @@ request looks like this:
 The encoding request and encoding response packets could be lost since the inside packet codec is only used with Lightway UDP. Hence, a retransmission 
 mechanism is in place to ensure that the requests and responses can reach the peer.
 
-**TODO:** 
-- Update this section when this PR is reviewed and approved: [Pull Request #175]
+Each new and unique encoding request from the client is incrementally assigned a unique integer id. Lightway server only commits and gives responses 
+to encoding requests with its id higher or equal to the id of the most recently committed request.
+
+The number of re-transmission is limited by a constant to avoid wasting network resources in case the server does not have encoding enabled. If the client
+cannot receive a response after the maximum number of re-transmissions has been attempted, the request is considered as failed.

--- a/lightway-app-utils/src/codec_ticker.rs
+++ b/lightway-app-utils/src/codec_ticker.rs
@@ -1,0 +1,183 @@
+//! Handle `lightway_core::ScheduleCodecTickCb` callbacks using Tokio.
+
+use lightway_core::{Connection, ConnectionResult};
+use std::sync::{Mutex, Weak};
+use tokio::{sync::mpsc, task::JoinSet, time::Duration};
+
+/// App state compatible with [`codec_ticker_cb`]
+pub trait CodecTickerState {
+    /// Obtain the [`CodecTicker`] from the state.
+    fn ticker(&self) -> Option<&CodecTicker>;
+}
+
+/// Callback for use with
+/// [`lightway_core::ClientContextBuilder::with_schedule_codec_tick_cb`].
+pub fn codec_ticker_cb<AppState: CodecTickerState>(
+    d: std::time::Duration,
+    request_id: u64,
+    state: &mut AppState,
+) {
+    if let Some(ticker) = state.ticker() {
+        ticker.schedule(d, request_id);
+    }
+}
+
+/// Embed this into a [`Connection`]'s `AppState` and call
+/// [`CodecTicker::schedule`] from your
+/// `lightway_core::ScheduleCodecTickCb` implementation.
+pub struct CodecTicker(mpsc::UnboundedSender<u64>);
+
+impl CodecTicker {
+    /// Create a new [`CodecTicker`]. Once the connection is built
+    /// call [`CodecTickerTask::spawn_in`] with a `Weak` reference to
+    /// it.
+    pub fn new() -> (Self, CodecTickerTask) {
+        let (send, recv) = mpsc::unbounded_channel();
+
+        (Self(send), CodecTickerTask(recv))
+    }
+
+    /// Schedule a tick.
+    pub fn schedule(&self, d: Duration, request_id: u64) {
+        let sender = self.0.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(d).await;
+            let _ = sender.send(request_id);
+        });
+    }
+}
+
+/// Allow [`CodecTicker`] to be used as `AppState` directly.
+impl CodecTickerState for CodecTicker {
+    fn ticker(&self) -> Option<&CodecTicker> {
+        Some(self)
+    }
+}
+
+/// Get a suitable `lightway_core::Connection` on which to call
+/// `retransmit`.
+pub trait CodecTickable: Send + Sync {
+    /// Kick this tickable.
+    fn tick(&self, request_id: u64) -> ConnectionResult<()>;
+}
+
+impl<AppState: Send> CodecTickable for Mutex<Connection<AppState>> {
+    fn tick(&self, request_id: u64) -> ConnectionResult<()> {
+        self.lock().unwrap().codec_tick(request_id)
+    }
+}
+
+/// Task which receives tick requests from channel and calls tick.
+pub struct CodecTickerTask(mpsc::UnboundedReceiver<u64>);
+
+impl CodecTickerTask {
+    /// Spawn the handler task in a JoinSet
+    pub fn spawn_in<T: CodecTickable + 'static>(
+        self,
+        weak: Weak<T>,
+        join_set: &mut JoinSet<()>,
+    ) -> tokio::task::AbortHandle {
+        let mut recv = self.0;
+        join_set.spawn(async move {
+            while let Some(request_id) = recv.recv().await {
+                let Some(tickable) = weak.upgrade() else {
+                    return;
+                };
+
+                let _ = tickable.tick(request_id);
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn ticks() {
+        use std::sync::{Arc, Mutex};
+        use tokio::sync::oneshot;
+
+        let (ticker, ticker_task) = CodecTicker::new();
+
+        // We'll "tick" this channel
+        let (tx, rx) = oneshot::channel();
+
+        struct Dummy(Mutex<Option<oneshot::Sender<u64>>>);
+
+        impl CodecTickable for Dummy {
+            fn tick(&self, request_id: u64) -> ConnectionResult<()> {
+                self.0
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .unwrap()
+                    .send(request_id)
+                    .unwrap();
+                Ok(())
+            }
+        }
+
+        let conn = Arc::new(Dummy(Mutex::new(Some(tx))));
+        let mut join_set = JoinSet::new();
+
+        ticker_task.spawn_in(Arc::downgrade(&conn), &mut join_set);
+
+        ticker.schedule(Duration::ZERO, 102);
+
+        let received_request_id = rx.await.unwrap(); // Should get the tick
+        assert_eq!(received_request_id, 102);
+    }
+
+    #[tokio::test]
+    async fn task_exits_when_ticker_released() {
+        use std::sync::Arc;
+
+        let (ticker, ticker_task) = CodecTicker::new();
+
+        struct Dummy;
+
+        impl CodecTickable for Dummy {
+            fn tick(&self, _request_id: u64) -> ConnectionResult<()> {
+                panic!("Not expecting to retransmit");
+            }
+        }
+
+        let conn = Arc::new(Dummy);
+        let mut join_set = JoinSet::new();
+
+        ticker_task.spawn_in(Arc::downgrade(&conn), &mut join_set);
+
+        drop(ticker);
+
+        while (join_set.join_next().await).is_some() {}
+    }
+
+    #[tokio::test]
+    async fn task_exits_when_conn_released() {
+        use std::sync::Arc;
+
+        let (ticker, ticker_task) = CodecTicker::new();
+
+        struct Dummy;
+
+        impl CodecTickable for Dummy {
+            fn tick(&self, _request_id: u64) -> ConnectionResult<()> {
+                panic!("Not expecting to retransmit");
+            }
+        }
+
+        let conn = Arc::new(Dummy);
+        let mut join_set = JoinSet::new();
+
+        ticker_task.spawn_in(Arc::downgrade(&conn), &mut join_set);
+
+        drop(conn);
+
+        ticker.schedule(Duration::ZERO, 0);
+
+        // Task should exit cleanly
+        while (join_set.join_next().await).is_some() {}
+    }
+}

--- a/lightway-app-utils/src/lib.rs
+++ b/lightway-app-utils/src/lib.rs
@@ -2,6 +2,7 @@
 #![warn(missing_docs)]
 
 pub mod args;
+pub mod codec_ticker;
 pub mod sockopt;
 
 #[cfg(feature = "tokio")]
@@ -14,6 +15,8 @@ mod event_stream;
 mod iouring;
 mod tun;
 
+#[cfg(feature = "tokio")]
+pub use codec_ticker::{CodecTicker, CodecTickerState, CodecTickerTask, codec_ticker_cb};
 #[cfg(feature = "tokio")]
 pub use connection_ticker::{
     ConnectionTicker, ConnectionTickerState, ConnectionTickerTask, Tickable, connection_ticker_cb,

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -844,7 +844,7 @@ impl<AppState: Send> Connection<AppState> {
                 Ok(CodecStatus::PacketAccepted) => Ok(()),
                 Ok(CodecStatus::SkipPacket) => {
                     // The encoder does not accept the packet.
-                    // Packet should not be encoded. Sending to inside directly.
+                    // Packet should not be encoded. Sending to outside directly.
                     self.send_to_outside(pkt, false)
                 }
                 Err(e) => Err(ConnectionError::PacketCodecError(e)),
@@ -1426,7 +1426,7 @@ impl<AppState: Send> Connection<AppState> {
         let decoder = match &mut self.inside_pkt_decoder {
             Some(decoder) => decoder,
             None => {
-                // No Packet Accumulator exists to process the encoded packet
+                // No decoder exists to process the encoded packet
                 return Err(ConnectionError::PacketCodecDoesNotExist);
             }
         };
@@ -1436,7 +1436,7 @@ impl<AppState: Send> Connection<AppState> {
             Ok(CodecStatus::PacketAccepted) => Ok(()),
             Ok(CodecStatus::SkipPacket) => {
                 // The decoder does not accept the packet.
-                // Packet should be un-encoded. Sending to inside directly.
+                // Packet should not be decoded. Sending to inside directly.
                 self.send_to_inside(inside_bytes)
             }
             Err(e) => Err(ConnectionError::PacketCodecError(e)),

--- a/lightway-core/src/connection/builders.rs
+++ b/lightway-core/src/connection/builders.rs
@@ -256,6 +256,7 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
             mode: ConnectionMode::Client {
                 auth_method,
                 ip_config_cb: self.ctx.ip_config,
+                schedule_codec_tick_cb: self.ctx.schedule_codec_tick_cb,
             },
             inside_io: self.ctx.inside_io,
             schedule_tick_cb: self.ctx.schedule_tick_cb,

--- a/lightway-core/src/encoding_request_states.rs
+++ b/lightway-core/src/encoding_request_states.rs
@@ -1,0 +1,34 @@
+use crate::wire::EncodingRequest;
+
+use std::time::Duration;
+
+/// States of encoding requests
+#[derive(Default)]
+pub(crate) struct EncodingRequestStates {
+    /// Counter of the encoding requests from the client.
+    /// Note: the wrapping should rarely, if ever, happen.
+    /// The counter is a u64 and it takes 2^64 requests to wrap it.
+    /// If one request is made each nanosecond, it takes ~584 years to wrap.
+    pub id_counter: u64,
+
+    /// The latest encoding request packet that has yet to be acknowledged by the server
+    /// If Some(_), the latest encoding request is not acknowledged yet.
+    /// If None, the latest encoding request has been acknowledged, or
+    /// the number of retransmissions have reached the maximum limit.
+    /// Used by Client only.
+    pub pending_request_pkt: Option<EncodingRequest>,
+
+    /// Number of retransmissions done with the latest pending encoding request packet
+    /// Used by Client only.
+    pub retransmissions_counter: u8,
+}
+
+impl EncodingRequestStates {
+    pub(crate) fn retransmit_wait_time(&self) -> Duration {
+        const INITIAL_WAIT_TIME: Duration = Duration::from_millis(500);
+
+        // To begin with, wait for INITIAL_WAIT_TIME.
+        // Then, linearly increase the wait time with the number of retransmission attempted.
+        INITIAL_WAIT_TIME * ((1 + self.retransmissions_counter) as u32)
+    }
+}

--- a/lightway-core/src/lib.rs
+++ b/lightway-core/src/lib.rs
@@ -7,6 +7,7 @@ mod builder_predicates;
 mod cipher;
 mod connection;
 mod context;
+mod encoding_request_states;
 mod io;
 mod metrics;
 mod packet;
@@ -33,8 +34,9 @@ pub use connection::{
     ServerConnectionBuilder, State, dplpmtud::Timer as DplpmtudTimer,
 };
 pub use context::{
-    ClientContext, ClientContextBuilder, ConnectionType, ContextError, ScheduleTickCb, ServerAuth,
-    ServerAuthArg, ServerAuthHandle, ServerAuthResult, ServerContext, ServerContextBuilder,
+    ClientContext, ClientContextBuilder, ConnectionType, ContextError, ScheduleCodecTickCb,
+    ScheduleTickCb, ServerAuth, ServerAuthArg, ServerAuthHandle, ServerAuthResult, ServerContext,
+    ServerContextBuilder,
     ip_pool::{ClientIpConfig, ClientIpConfigArg, InsideIpConfig, ServerIpPool, ServerIpPoolArg},
 };
 pub use io::{

--- a/lightway-core/src/wire.rs
+++ b/lightway-core/src/wire.rs
@@ -582,8 +582,8 @@ mod test_frame {
     #[test_case(Frame::Goodbye => FrameKind::Goodbye)]
     #[test_case(Frame::ServerConfig(ServerConfig{ data: Default::default() }) => FrameKind::ServerConfig)]
     #[test_case(Frame::DataFrag(DataFrag{ id: 0, offset: 0, more_fragments: true, data: Default::default() }) => FrameKind::DataFrag)]
-    #[test_case(Frame::EncodingRequest(EncodingRequest{enable: true}) => FrameKind::EncodingRequest)]
-    #[test_case(Frame::EncodingResponse(EncodingResponse{enable: true}) => FrameKind::EncodingResponse)]
+    #[test_case(Frame::EncodingRequest(EncodingRequest{ id: 513, enable: true }) => FrameKind::EncodingRequest)]
+    #[test_case(Frame::EncodingResponse(EncodingResponse{ id: 513, enable: true }) => FrameKind::EncodingResponse)]
     fn frame_kind(f: Frame) -> FrameKind {
         f.kind()
     }
@@ -600,8 +600,8 @@ mod test_frame {
     #[test_case(Frame::Goodbye => vec![0x0c]; "goodbye")]
     #[test_case(Frame::ServerConfig(ServerConfig{ data: Bytes::from_static(b"server config")}) => b"\x0e\x00\x0dserver config".to_vec(); "server config")]
     #[test_case(Frame::DataFrag(DataFrag{ id: 0x1234, offset: 0x5678, more_fragments: true, data: Bytes::from_static(b"fragmentary") }) => b"\x0f\x00\x0b\x12\x34\x2a\xcffragmentary".to_vec() ; "data frag")]
-    #[test_case(Frame::EncodingRequest(EncodingRequest{enable: true}) => b"\x12\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00".to_vec(); "encoding request")]
-    #[test_case(Frame::EncodingResponse(EncodingResponse{enable: true}) => b"\x13\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00".to_vec(); "encoding response")]
+    #[test_case(Frame::EncodingRequest(EncodingRequest{ id: 513, enable: true}) => b"\x12\x00\x00\x00\x00\x00\x00\x02\x01\x01".to_vec(); "encoding request")]
+    #[test_case(Frame::EncodingResponse(EncodingResponse{ id: 513, enable: true}) => b"\x13\x00\x00\x00\x00\x00\x00\x02\x01\x01".to_vec(); "encoding response")]
     fn into_wire(f: Frame) -> Vec<u8> {
         let mut buf = BytesMut::new();
         f.append_to_wire(&mut buf);
@@ -622,8 +622,8 @@ mod test_frame {
     #[test_case(b"\x0f\x00\x0b\x12\x34\x2a\xcffragmentary"=> Frame::DataFrag(DataFrag{ id: 0x1234, offset: 0x5678, more_fragments: true, data: Bytes::from_static(b"fragmentary") }) ; "data frag")]
     #[test_case(&[0x10, 0, 3, 0xfe, 0xbe, 0xaa] => Frame::EncodedData(Data{ data: Cow::Owned(BytesMut::from(&[0xfe, 0xbe, 0xaa][..]))}); "encoded data")]
     #[test_case(b"\x11\x00\x0b\x12\x34\x2a\xcffragmentary"=> Frame::EncodedDataFrag(DataFrag{ id: 0x1234, offset: 0x5678, more_fragments: true, data: Bytes::from_static(b"fragmentary") }) ; "encoded data frag")]
-    #[test_case(b"\x12\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"=> Frame::EncodingRequest(EncodingRequest{enable: true}) ; "encoding request")]
-    #[test_case(b"\x13\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"=> Frame::EncodingResponse(EncodingResponse{enable: true}) ; "encoding response")]
+    #[test_case(b"\x12\x00\x00\x00\x00\x00\x00\x02\x01\x01"=> Frame::EncodingRequest(EncodingRequest{id: 513, enable: true}) ; "encoding request")]
+    #[test_case(b"\x13\x00\x00\x00\x00\x00\x00\x02\x02\x00"=> Frame::EncodingResponse(EncodingResponse{id: 514, enable: false}) ; "encoding response")]
     fn try_from_wire(buf: &'static [u8]) -> Frame<'static> {
         let mut buf = BytesMut::from(buf);
         let r = Frame::try_from_wire(&mut buf).unwrap();

--- a/lightway-core/src/wire/encoding_request.rs
+++ b/lightway-core/src/wire/encoding_request.rs
@@ -2,30 +2,44 @@ use bytes::{Buf, BufMut, BytesMut};
 
 use super::{FromWireError, FromWireResult};
 use crate::borrowed_bytesmut::BorrowedBytesMut;
-
 /// Encoding Request in lightway-core
 ///
-/// Frame size is fixed at 32 bytes, with 31 bytes reserved for future use.
-#[derive(PartialEq, Debug)]
+/// Wire format (fixed length):
+///
+/// ```text
+///  0                   1                   2                   3
+///  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                               id                              |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                               id                              |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |      enable   |
+/// +-+-+-+-+-+-+-+-+
+/// ```
+///
+/// Frame size is fixed at 9 bytes.
+#[derive(PartialEq, Debug, Clone)]
 pub(crate) struct EncodingRequest {
+    pub(crate) id: u64,
     pub(crate) enable: bool,
 }
 
 impl EncodingRequest {
     /// Wire Size in bytes
-    const WIRE_SIZE: usize = 32;
+    const WIRE_SIZE: usize = 9;
 
     pub(crate) fn try_from_wire(buf: &mut BorrowedBytesMut) -> FromWireResult<Self> {
         if buf.len() < Self::WIRE_SIZE {
             return Err(FromWireError::InsufficientData);
         };
 
+        let id = buf.get_u64();
         let enable = buf.get_u8();
-        buf.advance(Self::WIRE_SIZE - 1); // Skip reserved bytes
 
         match enable {
-            0 => Ok(Self { enable: false }),
-            1 => Ok(Self { enable: true }),
+            0 => Ok(Self { id, enable: false }),
+            1 => Ok(Self { id, enable: true }),
             _ => Err(FromWireError::InvalidBool),
         }
     }
@@ -35,8 +49,8 @@ impl EncodingRequest {
 
         let encoding_enabled = if self.enable { 1 } else { 0 };
 
+        buf.put_u64(self.id);
         buf.put_u8(encoding_enabled);
-        buf.put_bytes(0, Self::WIRE_SIZE - 1); // Add reserved bytes
     }
 }
 
@@ -44,24 +58,25 @@ impl EncodingRequest {
 mod test {
     use super::*;
     use crate::borrowed_bytesmut::ImmutableBytesMut;
-
     use test_case::test_case;
 
     #[test]
     fn from_wire_enabled() {
-        let mut buf = ImmutableBytesMut::from(&b"\x01uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu"[..]);
+        let mut buf = ImmutableBytesMut::from(&b"\x00\x00\x00\x00\x00\x00\x02\x01\x01"[..]);
         let mut buf = buf.as_borrowed_bytesmut();
 
         let wire = EncodingRequest::try_from_wire(&mut buf).expect("enabled");
+        assert_eq!(wire.id, 513_u64);
         assert!(wire.enable);
     }
 
     #[test]
     fn from_wire_disabled() {
-        let mut buf = ImmutableBytesMut::from(&b"\x00uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu"[..]);
+        let mut buf = ImmutableBytesMut::from(&b"\x00\x00\x00\x00\x00\x00\x02\x02\x00"[..]);
         let mut buf = buf.as_borrowed_bytesmut();
 
         let wire = EncodingRequest::try_from_wire(&mut buf).expect("disabled");
+        assert_eq!(wire.id, 514_u64);
         assert!(!wire.enable);
     }
 
@@ -75,8 +90,8 @@ mod test {
         ));
     }
 
-    #[test_case(EncodingRequest{enable: true} => b"\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00".to_vec(); "enable")]
-    #[test_case(EncodingRequest{enable: false} => b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00".to_vec(); "disable")]
+    #[test_case(EncodingRequest{id: 513, enable: true} => b"\x00\x00\x00\x00\x00\x00\x02\x01\x01".to_vec(); "enable")]
+    #[test_case(EncodingRequest{id: 514, enable: false} => b"\x00\x00\x00\x00\x00\x00\x02\x02\x00".to_vec(); "disable")]
     fn test_append_to_wire(te: EncodingRequest) -> Vec<u8> {
         let mut buf = BytesMut::new();
         te.append_to_wire(&mut buf);

--- a/lightway-core/src/wire/encoding_response.rs
+++ b/lightway-core/src/wire/encoding_response.rs
@@ -2,30 +2,44 @@ use bytes::{Buf, BufMut, BytesMut};
 
 use super::{FromWireError, FromWireResult};
 use crate::borrowed_bytesmut::BorrowedBytesMut;
-
 /// Encoding Response in lightway-core
 ///
-/// Frame size is fixed at 32 bytes, with 31 bytes reserved for future use.
+/// Wire format (fixed length):
+///
+/// ```text
+///  0                   1                   2                   3
+///  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                               id                              |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                               id                              |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |      enable   |
+/// +-+-+-+-+-+-+-+-+
+/// ```
+///
+/// Frame size is fixed at 9 bytes.
 #[derive(PartialEq, Debug)]
 pub(crate) struct EncodingResponse {
+    pub(crate) id: u64,
     pub(crate) enable: bool,
 }
 
 impl EncodingResponse {
     /// Wire Size in bytes
-    const WIRE_SIZE: usize = 32;
+    const WIRE_SIZE: usize = 9;
 
     pub(crate) fn try_from_wire(buf: &mut BorrowedBytesMut) -> FromWireResult<Self> {
         if buf.len() < Self::WIRE_SIZE {
             return Err(FromWireError::InsufficientData);
         };
 
+        let id = buf.get_u64();
         let enable = buf.get_u8();
-        buf.advance(Self::WIRE_SIZE - 1); // Skip reserved bytes
 
         match enable {
-            0 => Ok(Self { enable: false }),
-            1 => Ok(Self { enable: true }),
+            0 => Ok(Self { id, enable: false }),
+            1 => Ok(Self { id, enable: true }),
             _ => Err(FromWireError::InvalidBool),
         }
     }
@@ -35,8 +49,8 @@ impl EncodingResponse {
 
         let encoding_enabled = if self.enable { 1 } else { 0 };
 
+        buf.put_u64(self.id);
         buf.put_u8(encoding_enabled);
-        buf.put_bytes(0, Self::WIRE_SIZE - 1); // Add reserved bytes
     }
 }
 
@@ -44,24 +58,25 @@ impl EncodingResponse {
 mod test {
     use super::*;
     use crate::borrowed_bytesmut::ImmutableBytesMut;
-
     use test_case::test_case;
 
     #[test]
     fn from_wire_enabled() {
-        let mut buf = ImmutableBytesMut::from(&b"\x01uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu"[..]);
+        let mut buf = ImmutableBytesMut::from(&b"\x00\x00\x00\x00\x00\x00\x02\x01\x01"[..]);
         let mut buf = buf.as_borrowed_bytesmut();
 
         let wire = EncodingResponse::try_from_wire(&mut buf).expect("enabled");
+        assert_eq!(wire.id, 513_u64);
         assert!(wire.enable);
     }
 
     #[test]
     fn from_wire_disabled() {
-        let mut buf = ImmutableBytesMut::from(&b"\x00uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu"[..]);
+        let mut buf = ImmutableBytesMut::from(&b"\x00\x00\x00\x00\x00\x00\x02\x02\x00"[..]);
         let mut buf = buf.as_borrowed_bytesmut();
 
         let wire = EncodingResponse::try_from_wire(&mut buf).expect("disabled");
+        assert_eq!(wire.id, 514_u64);
         assert!(!wire.enable);
     }
 
@@ -75,8 +90,8 @@ mod test {
         ));
     }
 
-    #[test_case(EncodingResponse{enable: true} => b"\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00".to_vec(); "enable")]
-    #[test_case(EncodingResponse{enable: false} => b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00".to_vec(); "disable")]
+    #[test_case(EncodingResponse{id: 513, enable: true} => b"\x00\x00\x00\x00\x00\x00\x02\x01\x01".to_vec(); "enable")]
+    #[test_case(EncodingResponse{id: 514, enable: false} => b"\x00\x00\x00\x00\x00\x00\x02\x02\x00".to_vec(); "disable")]
     fn test_append_to_wire(te: EncodingResponse) -> Vec<u8> {
         let mut buf = BytesMut::new();
         te.append_to_wire(&mut buf);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Request id and response id in `EncodingRequest` and `EncodingResponse` wire frame types. 
    - Each unique request id corresponds to exactly 1 unique request
    - Use case: chronological order of each unique request
    - We may safely assume the id does not overflow, as it takes > 500 years to overflow it even one encoding request is made per nanosecond. 
- Re-transmission of `EncodingRequest` inside wire frame
    - A ticker is created in `lightway-client` to schedule for the next re-transmission (Similar to the pattern of `ConnectionTicker`.
    - Each schedule corresponds to a request by its id. Hence, stale request ticks are disabled accordingly.
    - The number of re-transmission is limited by a constant to avoid wasting network resources in case the server does not have encoding enabled.
- Handling of `EncodingRequest` in server:
    - The server only sends `EncodingResponse` back to the client and commits to the encoding request if the incoming request is not stale. 
    - An incoming request is not stale if and only if the request id is higher or equal to the id of the most recently acknowledged request.

## Motivation and Context
With Lightway UDP, `EncodingRequest` and `EncodingResponse` packets may be loss during transmission.

To make sure that the server receives the request from the client and the client receives the acknowledgement from the server, a retransmission mechanism is created for it.

## How Has This Been Tested?
**Request id in `EncodingRequest` and `EncodingResponse` wire frame types**: Unit tests
**`EncodingRequestRetransmitTicker`**: Unit tests

**Retransmission logic in `lightway-core::Connection`**: Manual tests with local network namespace scripts.
Used RaptorQ packet codec and created artifical packet loss after lightway's state changed to `Connect`.

**With no packet loss**:
- The client receives a response in the first attempt. 
- The next re-transmission tick aborts as the latest request has been acknowledged.
```
Client's log:
2025-03-24T09:10:03.073186Z DEBUG lightway_core::connection: Encoding Request 1 created
2025-03-24T09:10:03.073273Z  INFO lightway_core::connection: inside packet encoding state is now set to true
2025-03-24T09:10:03.574042Z DEBUG lightway_core::connection: retransmit for 1 cancelled as there is no pending pkt

Server's log:
2025-03-24T09:10:03.073240Z DEBUG lightway_core::connection: Client 3b4e6ad8bfff31fa: EncodingRequest 1 received. encoding state now: true.
``` 

**With moderate packet loss**:
- The request succeed in the second attempt
```
Client's log:
2025-03-24T09:11:30.312589Z  INFO xv_lightway_client: Enable encoding signal SIGUSR1 received.
2025-03-24T09:11:30.312625Z DEBUG lightway_core::connection: Encoding Request 2 created
2025-03-24T09:11:30.814061Z DEBUG lightway_core::connection: encoding request 2 attempting retransmission no. 1
2025-03-24T09:11:30.814451Z  INFO lightway_core::connection: inside packet encoding state is now set to true
2025-03-24T09:11:31.814686Z DEBUG lightway_core::connection: retransmit for 2 cancelled as there is no pending pkt

Server's log:
2025-03-24T09:11:30.814305Z DEBUG lightway_core::connection: Client 3b4e6ad8bfff31fa: EncodingRequest 2 received. encoding state now: true.
```

**With very high packet loss**:
- The client attempts to re-transmit until it reaches the maximum number of attempts:
- Re-transmission stops when max number of attempts is reached.
```
2025-03-24T08:40:44.772424Z DEBUG lightway_core::connection: Encoding Request 2 created
2025-03-24T08:40:45.274190Z DEBUG lightway_core::connection: encoding request 2 attempting retransmission no. 1
2025-03-24T08:40:46.275073Z DEBUG lightway_core::connection: encoding request 2 attempting retransmission no. 2
2025-03-24T08:40:47.775698Z DEBUG lightway_core::connection: encoding request 2 attempting retransmission no. 3
2025-03-24T08:40:49.776673Z DEBUG lightway_core::connection: encoding request 2 attempting retransmission no. 4
2025-03-24T08:40:52.277338Z DEBUG lightway_core::connection: encoding request 2 attempting retransmission no. 5
2025-03-24T08:40:55.278567Z  WARN lightway_core::connection: EncodingRequest retransmission max attempts reached
```

**Quickly make several requests under very high packet loss**:
- The re-transmit ticks of old requests are discarded accordingly.
```
2025-03-24T09:17:56.068170Z DEBUG lightway_core::connection: Encoding Request 11 created
2025-03-24T09:17:56.175127Z DEBUG lightway_core::connection: retransmit request for stale request 10 cancelled
2025-03-24T09:17:56.552632Z DEBUG lightway_core::connection: Encoding Request 12 created
2025-03-24T09:17:56.568717Z DEBUG lightway_core::connection: retransmit request for stale request 11 cancelled
2025-03-24T09:17:56.576261Z DEBUG lightway_core::connection: retransmit request for stale request 9 cancelled
2025-03-24T09:17:56.992817Z DEBUG lightway_core::connection: Encoding Request 13 created
2025-03-24T09:17:57.053803Z DEBUG lightway_core::connection: retransmit request for stale request 12 cancelled
2025-03-24T09:17:57.431707Z DEBUG lightway_core::connection: Encoding Request 14 created
2025-03-24T09:17:57.494056Z DEBUG lightway_core::connection: retransmit request for stale request 13 cancelled
2025-03-24T09:17:57.916635Z DEBUG lightway_core::connection: Encoding Request 15 created
2025-03-24T09:17:57.932864Z DEBUG lightway_core::connection: retransmit request for stale request 14 cancelled
2025-03-24T09:17:58.417502Z DEBUG lightway_core::connection: encoding request 15 attempting retransmission no. 1
2025-03-24T09:17:59.418513Z DEBUG lightway_core::connection: encoding request 15 attempting retransmission no. 2
2025-03-24T09:18:00.920475Z DEBUG lightway_core::connection: encoding request 15 attempting retransmission no. 3
2025-03-24T09:18:02.921497Z DEBUG lightway_core::connection: encoding request 15 attempting retransmission no. 4
2025-03-24T09:18:05.423439Z DEBUG lightway_core::connection: encoding request 15 attempting retransmission no. 5
```

**Update on May 6 2025**: manual tests are re-done after re-basing for the latest changes in https://github.com/expressvpn/lightway/pull/194. Everything works as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
