### PR TITLE
CVPN-1893 Support building on tvOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,9 +2515,9 @@ dependencies = [
 
 [[package]]
 name = "tun"
-version = "0.7.13"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9298ac5c7f0076908d7a168c634bf4867b4a7d5725eb6356863f8640c6c35ef1"
+checksum = "528d712da3fafc9bf7ab8795244cb0197e4bfaa506e26280810f9ae327e20d6a"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,8 +807,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 [[package]]
 name = "fs-mistrust"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24bebe6ec0d7bd8eab0ea285dcf5dd9bcb7c334e47259a6a7c486bfdf0e0f1dd"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0f13b7a0e19b3fae163e76c8ade6499244abf834#0f13b7a0e19b3fae163e76c8ade6499244abf834"
 dependencies = [
  "derive_builder_fork_arti",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2830,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "wolfssl"
 version = "3.0.0"
-source = "git+https://github.com/expressvpn/wolfssl-rs#77cd052a8dec0f9b9adecb91045cdce84aed3a53"
+source = "git+https://github.com/expressvpn/wolfssl-rs#c7dad3f0df4b46de1477bc4863e5ce33406d6f96"
 dependencies = [
  "bytes",
  "log",
@@ -2841,7 +2841,7 @@ dependencies = [
 [[package]]
 name = "wolfssl-sys"
 version = "2.0.0"
-source = "git+https://github.com/expressvpn/wolfssl-rs#77cd052a8dec0f9b9adecb91045cdce84aed3a53"
+source = "git+https://github.com/expressvpn/wolfssl-rs#c7dad3f0df4b46de1477bc4863e5ce33406d6f96"
 dependencies = [
  "autotools",
  "bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,8 +509,7 @@ dependencies = [
 [[package]]
 name = "ctrlc"
 version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
+source = "git+https://github.com/Detegr/rust-ctrlc.git?rev=refs%2Fpull%2F128%2Fhead#45d21ff2778075dfef46fd37821d1a8fdc239638"
 dependencies = [
  "nix",
  "windows-sys 0.59.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,8 @@ async-trait = "0.1.77"
 bytes = "1.5.0"
 bytesize = { version = "1.3.0", features = ["serde"] }
 clap = { version = "4.4.7", features = ["derive"] }
-ctrlc = { version = "3.4.2", features = ["termination"] }
+# ctrlc = { version = "3.4.2", features = ["termination"] }
+ctrlc = { git = "https://github.com/Detegr/rust-ctrlc.git", rev = "refs/pull/128/head"}
 delegate = "0.12.0"
 educe = { version = "0.6.0", default-features = false, features = ["Debug"] }
 ipnet = { version = "2.8.0", features = ["serde"]}

--- a/deny.toml
+++ b/deny.toml
@@ -65,7 +65,8 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     "https://github.com/expressvpn/wolfssl-rs",
-    "https://gitlab.torproject.org/tpo/core/arti"
+    "https://gitlab.torproject.org/tpo/core/arti",
+    "https://github.com/Detegr/rust-ctrlc"
 ]
 
 # See https://github.com/briansmith/ring/blob/main/LICENSE Ring

--- a/deny.toml
+++ b/deny.toml
@@ -65,6 +65,7 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     "https://github.com/expressvpn/wolfssl-rs",
+    "https://gitlab.torproject.org/tpo/core/arti"
 ]
 
 # See https://github.com/briansmith/ring/blob/main/LICENSE Ring

--- a/lightway-app-utils/Cargo.toml
+++ b/lightway-app-utils/Cargo.toml
@@ -21,7 +21,9 @@ workspace = true
 anyhow.workspace = true
 bytes.workspace = true
 clap.workspace = true
-fs-mistrust = { version = "0.9.0", default-features = false }
+# Gitlab can only make reference to commits on the main branch only, so we are using the commit hash for the merge request on main
+# https://gitlab.torproject.org/tpo/core/arti/-/commit/0f13b7a0e19b3fae163e76c8ade6499244abf834
+fs-mistrust = { git = "https://gitlab.torproject.org/tpo/core/arti.git", rev = "0f13b7a0e19b3fae163e76c8ade6499244abf834", default-features = false }
 humantime = "2.1.0"
 io-uring = {  version = "0.7.0", optional = true }
 ipnet.workspace = true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes building/compilation issue when we are building it in tvOS.

We are manually setting these crates to use a specific commits/PRs as we are waiting for a new official release from them:
1. fs-mistrust:
Gitlab can only make reference to commits on the main branch only, so we are using the commit hash for the merge request on main
https://gitlab.torproject.org/tpo/core/arti/-/commit/0f13b7a0e19b3fae163e76c8ade6499244abf834
2. ctrlc
https://github.com/Detegr/rust-ctrlc/pull/128 to support building or compiling on tvOS.

Bumped `wolfssl` and `tun` to a new version that supports building on tvOS as well.

## Motivation and Context
Support tvOS

## How Has This Been Tested?
By building the internal client on all 3 tvOS platforms

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
