### PR TITLE
CVPN-1878: Disconnect properly when dtls rekey fails

### DIFF
--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -677,7 +677,7 @@ impl<AppState: Send> Connection<AppState> {
             }
             _ if self.connection_type.is_datagram() => match self.session.dtls_has_timed_out() {
                 wolfssl::Poll::Ready(true) => {
-                    self.set_state(State::Disconnected)?;
+                    let _ = self.disconnect();
                     return Err(ConnectionError::TimedOut);
                 }
                 wolfssl::Poll::PendingWrite

--- a/lightway-server/src/connection.rs
+++ b/lightway-server/src/connection.rs
@@ -132,6 +132,9 @@ impl Connection {
             ConnectionError::Goodbye => {
                 metrics::connection_client_closed();
             }
+            ConnectionError::Disconnected => {
+                metrics::connection_data_after_disconnect();
+            }
             ConnectionError::WolfSSL(_) => {
                 metrics::connection_tls_error(fatal);
             }

--- a/lightway-server/src/connection.rs
+++ b/lightway-server/src/connection.rs
@@ -115,10 +115,6 @@ impl Connection {
         }
     }
 
-    pub fn handle_end_of_stream(&self) {
-        let _ = self.disconnect();
-    }
-
     /// Handle an outside data error. On a fatal error will disconnect
     /// and return [`std::ops::ControlFlow::Break`], the caller should
     /// stop processing further traffic for this connection (closing

--- a/lightway-server/src/connection.rs
+++ b/lightway-server/src/connection.rs
@@ -90,6 +90,7 @@ impl Connection {
             .unwrap();
 
         ticker_task.spawn(Arc::downgrade(&conn));
+        metrics::connection_created(&protocol_version);
 
         Ok(conn)
     }
@@ -192,7 +193,6 @@ impl Connection {
     }
 
     pub fn disconnect(&self) -> ConnectionResult<()> {
-        metrics::connection_closed();
         self.manager.remove_connection(self);
         self.lw_conn.lock().unwrap().disconnect()
     }
@@ -201,5 +201,6 @@ impl Connection {
 impl Drop for Connection {
     fn drop(&mut self) {
         trace!("Dropping Connection!");
+        metrics::connection_closed();
     }
 }

--- a/lightway-server/src/connection_manager.rs
+++ b/lightway-server/src/connection_manager.rs
@@ -231,8 +231,6 @@ fn new_connection(
     outside_io: OutsideIOSendCallbackArg,
     encoders: Arc<Mutex<InternalIPToEncoderMap>>,
 ) -> Result<Arc<Connection>, ConnectionManagerError> {
-    metrics::connection_created(&protocol_version);
-
     let (event_cb, event_stream) = EventStreamCallback::new();
 
     manager.total_sessions.fetch_add(1, Ordering::Relaxed);

--- a/lightway-server/src/io/outside/tcp.rs
+++ b/lightway-server/src/io/outside/tcp.rs
@@ -171,8 +171,6 @@ async fn handle_connection(
         }
     };
 
-    conn.handle_end_of_stream();
-
     info!("Connection closed: {:?}", err);
 }
 

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -185,7 +185,7 @@ pub struct ServerConfig<SA: for<'a> ServerAuth<AuthState<'a>>> {
 fn handle_inside_io_error(conn: Arc<Connection>, result: ConnectionResult<()>) {
     match result {
         Ok(()) => {}
-        Err(ConnectionError::InvalidState) => {
+        Err(ConnectionError::InvalidState | ConnectionError::Disconnected) => {
             // Skip forwarding packet when offline
             metrics::tun_rejected_packet_invalid_state();
         }

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -197,7 +197,7 @@ fn handle_inside_io_error(conn: Arc<Connection>, result: ConnectionResult<()>) {
             let fatal = err.is_fatal(conn.connection_type());
             metrics::tun_rejected_packet_invalid_other(fatal);
             if fatal {
-                conn.handle_end_of_stream();
+                let _ = conn.disconnect();
             }
         }
     }

--- a/lightway-server/src/metrics.rs
+++ b/lightway-server/src/metrics.rs
@@ -19,6 +19,8 @@ static METRIC_CONNECTION_REJECTED_NO_FREE_IP: LazyLock<Counter> =
     LazyLock::new(|| counter!("conn_rejected_no_free_ip"));
 static METRIC_CONNECTION_REJECTED_ACCESS_DENIED: LazyLock<Counter> =
     LazyLock::new(|| counter!("conn_rejected_access_denied"));
+static METRIC_CONNECTION_DATA_AFT_DISCONNECT: LazyLock<Counter> =
+    LazyLock::new(|| counter!("conn_data_after_disconnect"));
 const METRIC_CONNECTION_TLS_ERROR: &str = "conn_tls_error";
 const METRIC_CONNECTION_UNKNOWN_ERROR: &str = "conn_unknown_error";
 static METRIC_CONNECTION_AGED_OUT: LazyLock<Counter> = LazyLock::new(|| counter!("conn_aged_out"));
@@ -295,6 +297,11 @@ pub(crate) fn connection_tls_error(fatal: bool) {
 /// Unknown error for [`lightway_core::Connection`].
 pub(crate) fn connection_unknown_error(fatal: bool) {
     counter!(METRIC_CONNECTION_UNKNOWN_ERROR, FATAL_LABEL => fatal.to_string()).increment(1);
+}
+
+/// [`lightway_core::Connection`] already in disconnected state
+pub(crate) fn connection_data_after_disconnect() {
+    METRIC_CONNECTION_DATA_AFT_DISCONNECT.increment(1)
 }
 
 /// Tunnel rejected packet, [`lightway_core::Connection`] not in


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Disconnect the lightway clients properly if session rekeying failed.
On previous commit, we fixed the timers which is needed to kickout the client
https://github.com/expressvpn/lightway/pull/174/commits/7f9f08d3142a50cdfdc74fcf4ab8ba843df0c2cb

But the disconnect was not proper and we just set the state to Disconnected. This causes the assigned IP address to leak.

Fix it properly by disconnecting client using Connection::disconnect()

### Additional changes:
Fixed metrics which were off since this commit https://github.com/expressvpn/lightway/pull/174/commits/d09b07d65e2a8feb6727675f7605831924027545

The above commit introduces a new fatal error `Disconnected` on Connection::inside_data_received and Connection::outside_data_received apis.
And since this is a fatal error, it also call lightway-server::Connection::disconnect(). This causes the following metrics to go off
- connection_closed - since it is called for each packet received after disconnecting
- conn_error_unknown(fatal) - Cause it is a new fatal error (previously these errors were counted against conn_error_unknown(non fatal))

## Motivation and Context

Assigned internal ips was leaking in production after the last update https://github.com/expressvpn/lightway/pull/174

## How Has This Been Tested?

Verified the IPs are not leaked after the connection is disconnected with rekey failures.

<details>

<summary>Unit test logs</summary>

```
2025-04-01T09:20:00.481954Z  INFO lightway_core::connection: Update TLS keys session=45987bae444d130a
2025-04-01T09:20:00.481976Z DEBUG lightway_core::connection: event event=TlsKeysUpdateStart
2025-04-01T09:20:00.481987Z TRACE lightway_core::connection: Scheduling tick for 100ms
2025-04-01T09:20:00.482013Z TRACE handle_events:handle_tls_keys_update_start: lightway_server::metrics: Begin session rotation
2025-04-01T09:20:00.583333Z TRACE lightway_core::connection: Processing connection tick self.session_id=45987bae444d130a
2025-04-01T09:20:00.583425Z TRACE lightway_core::connection: Scheduling tick for 200ms
2025-04-01T09:20:00.784676Z TRACE lightway_core::connection: Processing connection tick self.session_id=45987bae444d130a
2025-04-01T09:20:00.784699Z TRACE lightway_core::connection: Scheduling tick for 400ms
2025-04-01T09:20:01.186703Z TRACE lightway_core::connection: Processing connection tick self.session_id=45987bae444d130a
2025-04-01T09:20:01.186840Z TRACE lightway_core::connection: Scheduling tick for 800ms
2025-04-01T09:20:01.789325Z DEBUG lightway_core::connection: event event=SessionIdRotationAcknowledged { old: 45987bae444d130a, new: dedbbc27b8a8a851 }
2025-04-01T09:20:01.789529Z TRACE handle_events:handle_finalize_session_rotation: lightway_server::metrics: Finalize session rotation
2025-04-01T09:20:01.988200Z TRACE lightway_core::connection: Processing connection tick self.session_id=dedbbc27b8a8a851
2025-04-01T09:20:01.988262Z TRACE lightway_core::connection: Scheduling tick for 1.6s
2025-04-01T09:20:03.589565Z TRACE lightway_core::connection: Processing connection tick self.session_id=dedbbc27b8a8a851
2025-04-01T09:20:03.589681Z TRACE lightway_core::connection: Scheduling tick for 3.2s
2025-04-01T09:20:05.483004Z DEBUG lightway_core::connection: Received ping id=14 payload_length=1245
2025-04-01T09:20:05.483036Z DEBUG lightway_core::connection: Sending pong id=14
2025-04-01T09:20:06.791695Z TRACE lightway_core::connection: Processing connection tick self.session_id=dedbbc27b8a8a851
2025-04-01T09:20:06.791940Z TRACE lightway_core::connection: Scheduling tick for 6.4s
2025-04-01T09:20:10.484358Z DEBUG lightway_core::connection: Received ping id=15 payload_length=1245
2025-04-01T09:20:10.484387Z DEBUG lightway_core::connection: Sending pong id=15
2025-04-01T09:20:13.193697Z TRACE lightway_core::connection: Processing connection tick self.session_id=dedbbc27b8a8a851
2025-04-01T09:20:13.193739Z  WARN lightway_core::connection: DTLS timed out, disconnecting client
2025-04-01T09:20:13.193744Z  INFO lightway_core::connection: state=Disconnecting
2025-04-01T09:20:13.193749Z DEBUG lightway_core::connection: event event=StateChanged(Disconnecting)
2025-04-01T09:20:13.193757Z  INFO lightway_server::ip_manager: Free ip=10.125.63.241
2025-04-01T09:20:13.193888Z  INFO lightway_core::connection: state=Disconnected
2025-04-01T09:20:13.193893Z DEBUG lightway_core::connection: event event=StateChanged(Disconnected)
2025-04-01T09:20:13.193918Z  INFO handle_events:handle_state_change: lightway_server::connection_manager: State changed for 192.168.0.2:50850 session=dedbbc27b8a8a851 state=Disconnected
2025-04-01T09:20:13.193937Z  INFO handle_events:handle_state_change: lightway_server::connection_manager: State changed for 192.168.0.2:50850 session=dedbbc27b8a8a851 state=Disconnecting
2025-04-01T09:20:13.801830Z  WARN lightway_server::io::outside::udp: Failed to process outside data: Disconnected
2025-04-01T09:20:13.801889Z TRACE lightway_server::connection: Dropping Connection!
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
