### PR TITLE
app-utils: use official v0.9.1 fs-mistrust for tvOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,8 +805,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fs-mistrust"
-version = "0.9.0"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0f13b7a0e19b3fae163e76c8ade6499244abf834#0f13b7a0e19b3fae163e76c8ade6499244abf834"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4cb1d3bd5de41d56855c3aa0b35fa49d7cf2ff987f25d92df10f0b8c53c3b0"
 dependencies = [
  "derive_builder_fork_arti",
  "libc",

--- a/deny.toml
+++ b/deny.toml
@@ -65,7 +65,6 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     "https://github.com/expressvpn/wolfssl-rs",
-    "https://gitlab.torproject.org/tpo/core/arti",
     "https://github.com/Detegr/rust-ctrlc"
 ]
 

--- a/lightway-app-utils/Cargo.toml
+++ b/lightway-app-utils/Cargo.toml
@@ -21,9 +21,7 @@ workspace = true
 anyhow.workspace = true
 bytes.workspace = true
 clap.workspace = true
-# Gitlab can only make reference to commits on the main branch only, so we are using the commit hash for the merge request on main
-# https://gitlab.torproject.org/tpo/core/arti/-/commit/0f13b7a0e19b3fae163e76c8ade6499244abf834
-fs-mistrust = { git = "https://gitlab.torproject.org/tpo/core/arti.git", rev = "0f13b7a0e19b3fae163e76c8ade6499244abf834", default-features = false }
+fs-mistrust = { version = "0.9.1", default-features = false }
 humantime = "2.1.0"
 io-uring = {  version = "0.7.0", optional = true }
 ipnet.workspace = true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There's a new release of v0.9.1 for fs-mistrust that now support tvOS, so we revert to use the official release from crates-io 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Use official release instead of commit hash

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passed internal CI on tvOS

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
