### PR TITLE
server: disconnect lightway in case of TCP shutdown or other fatal failures

### DIFF
--- a/lightway-server/src/connection.rs
+++ b/lightway-server/src/connection.rs
@@ -192,6 +192,8 @@ impl Connection {
         self.lw_conn.lock().unwrap().disconnect()
     }
 
+    // This api should be idempotent since it can be called from multiple places
+    // when there is failures
     pub fn disconnect(&self) -> ConnectionResult<()> {
         self.manager.remove_connection(self);
         self.lw_conn.lock().unwrap().disconnect()

--- a/lightway-server/src/io/outside/tcp.rs
+++ b/lightway-server/src/io/outside/tcp.rs
@@ -171,6 +171,15 @@ async fn handle_connection(
         }
     };
 
+    // Disconnect the session in case of TCP shutdown or other fatal failures.
+    //
+    // Note that it is possible, disconnect has been called in `conn.handle_outside_data_error` already
+    // in case of fatal error case. It is still fine to call it again, since `disconnect`
+    // call is idempotent and no-op if it is already disconnected
+    //
+    // But we need this disconnect in case of TCP connection shutdown
+    let _ = conn.disconnect();
+
     info!("Connection closed: {:?}", err);
 }
 


### PR DESCRIPTION

## Description

Disconnect lightway in case of TCP shutdown or other fatal failures.

Note that it is possible, disconnect has been called in `conn.handle_outside_data_error` already in case of fatal error case. It is still fine to call it again, since `disconnect` call is idempotent and no-op if it is already disconnected

But we need this disconnect in case of TCP connection shutdown. Otherwise Server::Connection will be leaking.

## Motivation and Context

TCP connections are not getting closed in some servers

## How Has This Been Tested?
Verified in running prod server

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
