### PR TITLE
server: cleanup pending_session_id_rotations for disconnected clients

### DIFF
--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -661,7 +661,7 @@ impl<AppState: Send> Connection<AppState> {
     /// [`Connection::tick_interval`] for usage.
     pub fn tick(&mut self) -> ConnectionResult<()> {
         self.is_tick_timer_running = false;
-        trace!(?self.session_id, "Processing connection tick");
+        trace!(session_id = ?self.session_id, "Processing connection tick");
 
         match self.state {
             State::Authenticating => {
@@ -677,6 +677,7 @@ impl<AppState: Send> Connection<AppState> {
             }
             _ if self.connection_type.is_datagram() => match self.session.dtls_has_timed_out() {
                 wolfssl::Poll::Ready(true) => {
+                    warn!(session_id = ?self.session_id, "DTLS timed out, disconnecting client");
                     let _ = self.disconnect();
                     return Err(ConnectionError::TimedOut);
                 }

--- a/lightway-server/src/connection.rs
+++ b/lightway-server/src/connection.rs
@@ -151,8 +151,7 @@ impl Connection {
     pub fn begin_session_id_rotation(self: &Arc<Self>) {
         let mut conn = self.lw_conn.lock().unwrap();
 
-        // A rotation is already in flight, nothing to be done this
-        // time.
+        // A rotation is already in flight, nothing to be done this time.
         if conn.pending_session_id().is_some() {
             return;
         }

--- a/lightway-server/src/connection_manager.rs
+++ b/lightway-server/src/connection_manager.rs
@@ -127,7 +127,7 @@ async fn handle_state_change(
         return;
     };
 
-    info!(session = ?conn.session_id(), ?state, "State changed for {:?}", conn.peer_addr(),);
+    info!(session = ?conn.session_id(), ?state, "State changed for {:?}", conn.peer_addr());
 
     match state {
         State::Connecting => {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When we initiate a session id rotation, we store the new session id along with
strong pointer of lightway_server::Connection inside the HashMap. We remove this
HashMap entry, when session rotation is completed.

In case the session rotation does not succeed, HashMap entry is not cleared
i.e. the strong pointer to Connection inside entry, is also not released and thus Connection gets leaked.

There are two issues in the current approach:
    1. Using strong pointer to Connection inside pending_session_id_rotations HashMap
    2. Not cleaning up the pending_session_id_rotations HashMap periodically

First problem is fixed by using Weak pointer to Connection inpending_session_id_rotations.

And the second issue by creating a task which periodically checks for connection and clean-up if connection is already invalid/disconnected.

## Motivation and Context

Some of the connections are not dropped even after the client has disconnected. 
On debugging, found these connections are stuck in pending session id rotation state.

## How Has This Been Tested?

Verified manually Connections structs are dropped while normal connection.
There is no clear way to repro client getting stucked at pending session id rotation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`