### PR TITLE
workspace: use ctrlc 3.4.6 release for tvOS support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,8 +508,9 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.5"
-source = "git+https://github.com/Detegr/rust-ctrlc.git?rev=refs%2Fpull%2F128%2Fhead#45d21ff2778075dfef46fd37821d1a8fdc239638"
+version = "3.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697b5419f348fd5ae2478e8018cb016c00a5881c7f46c717de98ffd135a5651c"
 dependencies = [
  "nix",
  "windows-sys 0.59.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,7 @@ async-trait = "0.1.77"
 bytes = "1.5.0"
 bytesize = { version = "1.3.0", features = ["serde"] }
 clap = { version = "4.4.7", features = ["derive"] }
-# ctrlc = { version = "3.4.2", features = ["termination"] }
-ctrlc = { git = "https://github.com/Detegr/rust-ctrlc.git", rev = "refs/pull/128/head"}
+ctrlc = { version = "3.4.6", features = ["termination"] }
 delegate = "0.12.0"
 educe = { version = "0.6.0", default-features = false, features = ["Debug"] }
 ipnet = { version = "2.8.0", features = ["serde"]}

--- a/deny.toml
+++ b/deny.toml
@@ -70,7 +70,6 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     "https://github.com/expressvpn/wolfssl-rs",
-    "https://github.com/Detegr/rust-ctrlc"
 ]
 
 # See https://github.com/briansmith/ring/blob/main/LICENSE Ring


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use the official release from ctrlc that brings support to tvOS, so that we don't need to rely on the branched PR: https://github.com/Detegr/rust-ctrlc/releases/tag/3.4.6

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Use the new official release instead

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
