### PR TITLE
KM-8884: Mock send success with non fatal UDP send error

### DIFF
--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -82,23 +82,16 @@ impl OutsideIOSendCallback for Udp {
                 // Swallow the error so the WolfSSL socket does not
                 // enter the error state.
                 //
-                // This way we can continue if/when the server shows up.
+                // This way we can continue if/when the server shows up. 
                 IOCallbackResult::Ok(0)
             }
-            Err(err) if matches!(err.raw_os_error(), Some(libc::ENETUNREACH)) => {
+            Err(err) if matches!(err.kind(), std::io::ErrorKind::NetworkUnreachable) => {
                 // This case indicates network unreachable error.
                 // Possibly there is a network change at the moment.
                 //
                 // Swallow the socket error so the error is not passed to the
                 // WolfSSL layer. Then the WolfSSL layer would not enter a
                 // fatal error state
-                //
-                // Note: this case should be matched by
-                // matches!(err.kind(), std::io::ErrorKind::NetworkUnreachable)
-                // However, at the time of implementing this match case,
-                // the version of rust we use does not support NetworkUnreachable.
-                // This match case can be rewritten to use NetworkUnreachable
-                // once rust is updated to support it.
                 IOCallbackResult::Ok(0)
             }
             Err(err) => IOCallbackResult::Err(err),

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -82,8 +82,14 @@ impl OutsideIOSendCallback for Udp {
                 // Swallow the error so the WolfSSL socket does not
                 // enter the error state.
                 //
-                // This way we can continue if/when the server shows up. 
-                IOCallbackResult::Ok(0)
+                // This way we can continue if/when the server shows up.
+                //
+                // Returning the number of bytes requested to be sent to mock
+                // that the send is successful.
+                // Otherwise, WolfSSL perceives that no data is sent and try
+                // to send the same data again, creating a live-lock until
+                // the network is reachable.
+                IOCallbackResult::Ok(buf.len())
             }
             Err(err) if matches!(err.kind(), std::io::ErrorKind::NetworkUnreachable) => {
                 // This case indicates network unreachable error.
@@ -92,7 +98,13 @@ impl OutsideIOSendCallback for Udp {
                 // Swallow the socket error so the error is not passed to the
                 // WolfSSL layer. Then the WolfSSL layer would not enter a
                 // fatal error state
-                IOCallbackResult::Ok(0)
+                //
+                // Returning the number of bytes requested to be sent to mock
+                // that the send is successful.
+                // Otherwise, WolfSSL perceives that no data is sent and try
+                // to send the same data again, creating a live-lock until the
+                // network is reachable.
+                IOCallbackResult::Ok(buf.len())
             }
             Err(err) => IOCallbackResult::Err(err),
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With non-fatal UDP send errors, return the number of bytes requested to be sent to mock that the send is successful.
Switched to use `NetworkUnreachable` variant in `std::io::ErrorKind` as it is no longer a part of the nightly features.

## Motivation and Context
Currently, WolfSSL perceives that no data is sent and try to send the same data again, creating a live-lock until the connection is available.
This is not good as the thread/async task that calls this will be stuck looping whereas holding the `core::Connection` lock at the same time.

## How Has This Been Tested?
Tested with CI.

Android:
- Verified that the app does not hang when it loses connection from the WAN (emulator, physical device)
- UDP floating still works (Android emulator)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
