### PR TITLE
server: fix deadlock of pending_session_id_rotations mutex

### DIFF
--- a/lightway-server/src/connection_manager.rs
+++ b/lightway-server/src/connection_manager.rs
@@ -371,10 +371,11 @@ impl ConnectionManager {
                 Ok((c, false))
             }
             connection_map::Entry::Vacant(_e) => {
+                let mut pending_session_id_rotations = self.pending_session_id_rotations.lock();
                 // Maybe this is a pending session rotation
-                if let Some(c) = self.pending_session_id_rotations.lock().get(&session_id) {
+                if let Some(c) = pending_session_id_rotations.get(&session_id) {
                     let Some(c) = c.upgrade() else {
-                        self.pending_session_id_rotations.lock().remove(&session_id);
+                        pending_session_id_rotations.remove(&session_id);
                         return Err(ConnectionManagerError::NoActiveSession);
                     };
                     let update_peer_address = addr != c.peer_addr();


### PR DESCRIPTION

## Description

Commit https://github.com/expressvpn/lightway/commit/bccfc81fbd2bc4ceaa57795b6bdc1a65ae581627 fixes the leaking UDP sessions. But it introduces a deadlock, by trying to lock the same Mutex twice consecutively on error condition.

Luckily our parking lot deadlock detection pin pointed it out.

Fixing it by locking once and using the same guard for removing stale entry.

## Motivation and Context
Server instances are restarted frequently

## How Has This Been Tested?

Verified in prod that instances are stable without deadlock

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
