### PR TITLE
Support building lightway client on macOs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   ci:
-    needs: [earthly, e2e, coverage]
+    needs: [earthly, e2e, coverage, macos]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -149,3 +149,13 @@ jobs:
       - name: Coverage check fails
         if: steps.coverage-check.outputs.failed == 'true'
         run: exit 1
+
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          brew install autoconf automake libtool
+      - name: Build lightway client on mac
+        run: cargo build --release -p lightway-client

--- a/Earthfile
+++ b/Earthfile
@@ -49,10 +49,10 @@ build:
     LET target = "x86_64-unknown-linux-gnu"
 
     IF [ "$ARCH" = "arm64" ]
-        SET target = "aarch64-unknown-linux-gnu" 
+        SET target = "aarch64-unknown-linux-gnu"
     END
 
-    DO lib-rust+CARGO --args="build --release --target=$target" --output="$target/release/lightway-(client|server)$"
+    DO lib-rust+CARGO --args="build --release --features io-uring --target=$target" --output="$target/release/lightway-(client|server)$"
 
     SAVE ARTIFACT ./target/$target/release/lightway-client AS LOCAL ./target/$target/release/
     SAVE ARTIFACT ./target/$target/release/lightway-server AS LOCAL ./target/$target/release/

--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ or `-5` to pick a different algorithm.
 [`pwhash`]: https://crates.io/crates/pwhash
 
 > [!CAUTION]
-> The widely used but basic `htpasswd(1)` username / password database format 
-> was chosen here to provide an easy-to-setup reference implementation of 
-> Lightway. Users are encouraged to modify this implementation with more advanced 
-> username / password authentication mechanisms and their own choice of password 
-> hashing algorithms to suit their security needs. 
+> The widely used but basic `htpasswd(1)` username / password database format
+> was chosen here to provide an easy-to-setup reference implementation of
+> Lightway. Users are encouraged to modify this implementation with more advanced
+> username / password authentication mechanisms and their own choice of password
+> hashing algorithms to suit their security needs.
 
 Please note that when providing env variables it should be in upper case and using "_" as a word separator,
 while using as cli config, it should be in lower case with "-" as the word separator.
@@ -192,6 +192,10 @@ the `--inside-mtu` option but note that this requires additional privileges, spe
 > password via the configuration file or via `LW_CLIENT_PASSWORD`
 > environment variable.
 
+> [!Note]
+> macOs has restrictions on tunnel name. It will only allow the format `utun[0-9]+`.
+> To avoid guessing the available number, do not provide `tun_name` config and let the
+> system decide the tunnel name.
 ## E2E Testing
 
 To run all e2e tests:

--- a/lightway-app-utils/src/sockopt/ip_pktinfo.rs
+++ b/lightway-app-utils/src/sockopt/ip_pktinfo.rs
@@ -6,12 +6,27 @@ use std::os::fd::AsRawFd;
 #[cfg(not(target_vendor = "apple"))]
 /// Enable IP_PKTINFO sockopt.
 pub fn socket_enable_pktinfo(sock: &impl AsRawFd) -> std::io::Result<()> {
+    let level: i32;
+    let optname: i32;
+
+    #[cfg(target_vendor = "apple")]
+    {
+        level = libc::IPPROTO_IP;
+        optname = libc::IP_PKTINFO;
+    }
+
+    #[cfg(not(target_vendor = "apple"))]
+    {
+        level = libc::SOL_IP;
+        optname = libc::IP_PKTINFO;
+    }
+
     // SAFETY: `setsockopt` requires a valid fd and a valid buffer of `c_int` size
     let res = unsafe {
         libc::setsockopt(
             sock.as_raw_fd(),
-            libc::SOL_IP,
-            libc::IP_PKTINFO,
+            level,
+            optname,
             &1 as *const libc::c_int as *const libc::c_void,
             std::mem::size_of::<libc::c_int>() as libc::socklen_t,
         )

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -94,6 +94,12 @@ pub struct TunDirect {
 impl TunDirect {
     /// Create a new `Tun` struct
     pub fn new(config: TunConfig) -> Result<Self> {
+        #[cfg(target_os = "macos")]
+        let mut config = config;
+        #[cfg(target_os = "macos")]
+        config.platform_config(|config| {
+            config.enable_routing(false);
+        });
         let tun = tun::create_as_async(&config)?;
         let fd = tun.as_raw_fd();
         let mtu = tun.mtu()?;

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["postquantum", "io-uring"]
+default = ["postquantum"]
 debug = ["lightway-core/debug"]
 io-uring = ["lightway-app-utils/io-uring"]
 postquantum = ["lightway-core/postquantum"]

--- a/lightway-client/src/args.rs
+++ b/lightway-client/src/args.rs
@@ -45,8 +45,8 @@ pub struct Config {
     pub inside_mtu: Option<u16>,
 
     /// Tun device name to use
-    #[clap(short, long, default_value = "lightway")]
-    pub tun_name: String,
+    #[clap(short, long, default_value = None)]
+    pub tun_name: Option<String>,
 
     /// Local IP to use in Tun device
     #[clap(long, default_value = "100.64.0.6")]

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -55,7 +55,10 @@ async fn main() -> Result<()> {
     let root_ca_cert = RootCertificate::PemFileOrDirectory(&config.ca_cert);
 
     let mut tun_config = TunConfig::default();
-    tun_config.tun_name(config.tun_name);
+
+    if let Some(tun_name) = config.tun_name {
+        tun_config.tun_name(tun_name);
+    }
     if let Some(inside_mtu) = &config.inside_mtu {
         tun_config.mtu(*inside_mtu);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

One missing piece to enable compiling lightway client on macOS.
Lightway server needs some more cleanup, so not enable in this PR.

Client may still need lack some features since it is not tested fully. But this PR prevents the future compilation break on macOS.
After we test mac client thoroughly, we can add tests for macOS CI builds too.

## Motivation and Context

Added CI to build lightway-client on macos to prevent compilation break

## How Has This Been Tested?
Verified lightway-client is working in M1 macbook

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
