### PR TITLE
server: drop connection mutex to avoid deadlock

### DIFF
--- a/lightway-server/src/connection.rs
+++ b/lightway-server/src/connection.rs
@@ -164,6 +164,9 @@ impl Connection {
             }
         };
 
+        // Drop Connection mutex, before adding it in pending_session_ids
+        drop(conn);
+
         self.manager.begin_session_id_rotation(self, new_session);
     }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

There is a potential deadlock with server::Connection mutex and pending_session_ids mutex.

Consider the following flow:
1. Client moves from Wifi to Celuular and the IP changes, and lightway is trying t float the UDP connection
2. Connection::begin_session_id_rotation will lock the connection mutex and update lightway_core to rotate session id and then add the server::Connection to pending_session_id_rotations after locking it.
3. At the same time, traffic from client started using new pending_id. This will be processed in server::outside_io::udp::run() -> data_received()
4. In data_received() api, we will try to find the connection belonging to that new pending_session_id using find_or_create_datagram_connection_with() call.
5. In this api, we lock the pending_session_id_rotations mutex and then calling c.peer_addr() which will try to lock the Connection mutex.
6. So we are locking two mutexes in different order which has possiblity of deadlock

Avoid it by dropping the mutex guard before adding it to connection.

## Motivation and Context

Some server instances are found hanging in production, with deadlock around these apis.

## How Has This Been Tested?

Verified mutex guard has been discarded by adding prints in local testing.
I could not repro the above exact case since this is a race condition.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
