### PR TITLE
CVPN-1958 Allow inside codec to actively flush the encoded/decoded pkts

### DIFF
--- a/docs/logs_and_metrics.md
+++ b/docs/logs_and_metrics.md
@@ -32,7 +32,6 @@ Lightway server also supports metrics to monitor. The following are the metrics 
 | conn_alloc_frag_map | core | Counter | A connection has used a fragmented data packet.<br>Therefore the 2M FragmentMap has been allocated |
 | wolfssl_appdata | core | Counter | An AppData result occurred during a WolfSSL operation.<br><br>Given current configuration we do not expect this to be non-zero |
 | session_id_mismatch | core | Counter | Server has received a mismatched session_id in the header after the packet content has been validated <br><br>Should generally be expected to happen rarely|
-| inside_pkt_dropped_due_to_fatal_err | core | Counter | The number of inside packets dropped due to a fatal error when trying to send packets to outside
 | received_encoding_req_non_online | core | Counter | Server received an encoding request when the Connection state is not Online |
 | received_encoding_req_with_tcp | core | Counter | Server received an encoding request when the Connection type is TCP |
 | received_encoding_res_as_server | core | Counter | Server received an encoding response |

--- a/lightway-app-utils/src/lib.rs
+++ b/lightway-app-utils/src/lib.rs
@@ -36,4 +36,4 @@ mod utils;
 pub use utils::{Validate, validate_configuration_file_path};
 
 mod packet_codec;
-pub use packet_codec::{PacketCodecFactory, PacketCodecFactoryType};
+pub use packet_codec::{PacketCodec, PacketCodecFactory, PacketCodecFactoryType};

--- a/lightway-app-utils/src/lib.rs
+++ b/lightway-app-utils/src/lib.rs
@@ -34,3 +34,6 @@ pub use tun::{Tun, TunConfig, TunDirect};
 mod metrics;
 mod utils;
 pub use utils::{Validate, validate_configuration_file_path};
+
+mod packet_codec;
+pub use packet_codec::{PacketCodecFactory, PacketCodecFactoryType};

--- a/lightway-app-utils/src/packet_codec.rs
+++ b/lightway-app-utils/src/packet_codec.rs
@@ -1,0 +1,17 @@
+use lightway_core::{PacketDecoderType, PacketEncoderType};
+
+/// Factory to build [`PacketEncoderType`] and [`PacketDecoderType`]
+/// This will be used to build a new instance of [`PacketEncoderType`] and [`PacketDecoderType`] for every connection.
+pub trait PacketCodecFactory {
+    /// Build a new instance of [`PacketEncoderType`]
+    fn build_encoder(&self) -> PacketEncoderType;
+
+    /// Build a new instance of [`PacketDecoderType`]
+    fn build_decoder(&self) -> PacketDecoderType;
+
+    /// Returns the codec name for debugging purpose
+    fn get_codec_name(&self) -> String;
+}
+
+/// Type for [`PacketCodecFactory`]
+pub type PacketCodecFactoryType = Box<dyn PacketCodecFactory + Send + Sync>;

--- a/lightway-app-utils/src/packet_codec.rs
+++ b/lightway-app-utils/src/packet_codec.rs
@@ -1,13 +1,13 @@
 use lightway_core::{PacketDecoderType, PacketEncoderType};
 
-/// Factory to build [`PacketEncoderType`] and [`PacketDecoderType`]
+use bytes::BytesMut;
+use tokio::sync::mpsc::UnboundedReceiver;
+
+/// Factory to build [`PacketEncoderType`] and [`PacketDecoderType`] and its utilities
 /// This will be used to build a new instance of [`PacketEncoderType`] and [`PacketDecoderType`] for every connection.
 pub trait PacketCodecFactory {
-    /// Build a new instance of [`PacketEncoderType`]
-    fn build_encoder(&self) -> PacketEncoderType;
-
-    /// Build a new instance of [`PacketDecoderType`]
-    fn build_decoder(&self) -> PacketDecoderType;
+    /// Build new instances of [`PacketEncoderType`] and [`PacketDecoderType`] and its utilities
+    fn build(&self) -> PacketCodec;
 
     /// Returns the codec name for debugging purpose
     fn get_codec_name(&self) -> String;
@@ -15,3 +15,19 @@ pub trait PacketCodecFactory {
 
 /// Type for [`PacketCodecFactory`]
 pub type PacketCodecFactoryType = Box<dyn PacketCodecFactory + Send + Sync>;
+
+/// PacketCodec and its utilities used by a Connection.
+/// Returned by [`PacketCodecFactory::build`]
+pub struct PacketCodec {
+    /// Inside Packet Encoder
+    pub encoder: PacketEncoderType,
+
+    /// Inside Packet Decoder
+    pub decoder: PacketDecoderType,
+
+    /// Emits the encoded packets from the encoder
+    pub encoded_pkt_receiver: UnboundedReceiver<BytesMut>,
+
+    /// Emits the decoded packets from the receiver
+    pub decoded_pkt_receiver: UnboundedReceiver<BytesMut>,
+}

--- a/lightway-client/src/args.rs
+++ b/lightway-client/src/args.rs
@@ -116,11 +116,6 @@ pub struct Config {
     #[clap(short, long, default_value_t)]
     pub server: String,
 
-    /// How often the pkt encoder is flushed
-    /// Only used if a codec is set
-    #[clap(long, default_value = "100us")]
-    pub pkt_encoder_flush_interval: Duration,
-
     /// Enable inside packet encoding once lightway connects
     /// Only used if a codec is set
     #[clap(short, long, default_value_t)]

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -188,12 +188,6 @@ pub struct ClientConfig<'cert, A: 'static + Send + EventCallback> {
 #[derive(educe::Educe)]
 #[educe(Debug)]
 pub struct ClientInsidePacketCodecConfig {
-    /// How often the packet encoder is flushed
-    pub flush_interval: Duration,
-
-    /// How often the packet decoder's states are cleaned up
-    pub clean_up_interval: Duration,
-
     /// Enables inside packet encoding when connection is established.
     pub enable_encoding_at_connect: bool,
 

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -464,7 +464,7 @@ pub async fn handle_decoded_pkt_send<T: Send + Sync>(
     Ok(())
 }
 
-async fn encoding_request_task<T: Send + Sync>(
+pub async fn encoding_request_task<T: Send + Sync>(
     weak: Weak<Mutex<Connection<ConnectionState<T>>>>,
     mut signal: tokio::sync::mpsc::Receiver<bool>,
 ) {

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -9,12 +9,12 @@ use futures::future::OptionFuture;
 use keepalive::Keepalive;
 use lightway_app_utils::{
     ConnectionTicker, ConnectionTickerState, DplpmtudTimer, EventStream, EventStreamCallback,
-    TunConfig, args::Cipher, connection_ticker_cb,
+    PacketCodecFactoryType, TunConfig, args::Cipher, connection_ticker_cb,
 };
 use lightway_core::{
     BuilderPredicates, ClientContextBuilder, ClientIpConfig, Connection, ConnectionError,
-    ConnectionType, Event, EventCallback, IOCallbackResult, InsideIpConfig, OutsidePacket,
-    PacketCodecFactoryType, State, ipv4_update_destination, ipv4_update_source,
+    ConnectionType, Event, EventCallback, IOCallbackResult, InsideIpConfig, OutsidePacket, State,
+    ipv4_update_destination, ipv4_update_source,
 };
 
 // re-export so client app does not need to depend on lightway-core

--- a/lightway-core/src/context.rs
+++ b/lightway-core/src/context.rs
@@ -12,7 +12,6 @@ use crate::{
     Version,
     context::ip_pool::ClientIpConfigArg,
     packet::OutsidePacketError,
-    packet_codec::PacketCodecFactoryType,
     plugin::{PluginFactoryError, PluginFactoryList, PluginList},
     version::VersionRangeInclusive,
     wire,
@@ -105,7 +104,6 @@ pub struct ClientContext<AppState> {
     pub(crate) ip_config: ClientIpConfigArg<AppState>,
     pub(crate) inside_plugins: Arc<PluginFactoryList>,
     pub(crate) outside_plugins: Arc<PluginFactoryList>,
-    pub(crate) inside_pkt_codec: Option<PacketCodecFactoryType>,
 }
 
 impl<AppState: Send + 'static> ClientContext<AppState> {
@@ -129,7 +127,6 @@ pub struct ClientContextBuilder<AppState> {
     ip_config: ClientIpConfigArg<AppState>,
     inside_plugins: Arc<PluginFactoryList>,
     outside_plugins: Arc<PluginFactoryList>,
-    inside_pkt_codec: Option<PacketCodecFactoryType>,
 }
 
 impl<AppState> ClientContextBuilder<AppState> {
@@ -162,7 +159,6 @@ impl<AppState> ClientContextBuilder<AppState> {
             ip_config,
             inside_plugins: Arc::new(PluginFactoryList::default()),
             outside_plugins: Arc::new(PluginFactoryList::default()),
-            inside_pkt_codec: None,
         })
     }
 
@@ -202,15 +198,6 @@ impl<AppState> ClientContextBuilder<AppState> {
         Ok(Self { wolfssl, ..self })
     }
 
-    /// Sets the Inside Packet Codec which should be used for Lightway connection.
-    /// See [`PacketCodecFactoryType`].
-    pub fn with_inside_pkt_codec(self, inside_pkt_codec: Option<PacketCodecFactoryType>) -> Self {
-        Self {
-            inside_pkt_codec,
-            ..self
-        }
-    }
-
     /// Finalize the builder, creating a [`ClientContext`].
     pub fn build(self) -> ClientContext<AppState> {
         let wolfssl = self.wolfssl.build();
@@ -222,7 +209,6 @@ impl<AppState> ClientContextBuilder<AppState> {
             ip_config: self.ip_config,
             inside_plugins: self.inside_plugins,
             outside_plugins: self.outside_plugins,
-            inside_pkt_codec: self.inside_pkt_codec,
         }
     }
 }
@@ -269,7 +255,6 @@ pub struct ServerContext<AppState = ()> {
     pub(crate) inside_plugins: PluginFactoryList,
     pub(crate) outside_plugins: PluginFactoryList,
     pub(crate) outside_plugins_instance: PluginList,
-    pub(crate) inside_pkt_codec: Option<PacketCodecFactoryType>,
 }
 
 impl<AppState: Send + 'static> ServerContext<AppState> {
@@ -324,7 +309,6 @@ pub struct ServerContextBuilder<AppState> {
     key_update_interval: std::time::Duration,
     inside_plugins: PluginFactoryList,
     outside_plugins: PluginFactoryList,
-    inside_pkt_codec: Option<PacketCodecFactoryType>,
 }
 
 /// server curves when PQC is not enabled, in decreasing order of preference.
@@ -386,7 +370,6 @@ impl<AppState> ServerContextBuilder<AppState> {
             key_update_interval: std::time::Duration::ZERO,
             inside_plugins: PluginFactoryList::default(),
             outside_plugins: PluginFactoryList::default(),
-            inside_pkt_codec: None,
         })
     }
 
@@ -458,15 +441,6 @@ impl<AppState> ServerContextBuilder<AppState> {
         })
     }
 
-    /// Sets the Inside Packet Codec which should be used for Lightway connection.
-    /// See [`PacketCodecFactoryType`].
-    pub fn with_inside_pkt_codec(self, inside_pkt_codec: Option<PacketCodecFactoryType>) -> Self {
-        Self {
-            inside_pkt_codec,
-            ..self
-        }
-    }
-
     /// Finalize the builder, creating a [`ServerContext`].
     pub fn build(self) -> ContextBuilderResult<ServerContext<AppState>> {
         debug_assert!(self.supported_protocol_versions.valid());
@@ -486,7 +460,6 @@ impl<AppState> ServerContextBuilder<AppState> {
             inside_plugins: self.inside_plugins,
             outside_plugins: self.outside_plugins,
             outside_plugins_instance,
-            inside_pkt_codec: self.inside_pkt_codec,
         })
     }
 }

--- a/lightway-core/src/lib.rs
+++ b/lightway-core/src/lib.rs
@@ -44,7 +44,7 @@ pub use io::{
 pub use packet::OutsidePacket;
 pub use packet_codec::{
     CodecStatus, PacketCodecResult, PacketDecoder, PacketDecoderType, PacketEncoder,
-    PacketEncoderType, WeakPacketDecoderType, WeakPacketEncoderType,
+    PacketEncoderType,
 };
 pub use plugin::{
     Plugin, PluginFactory, PluginFactoryError, PluginFactoryList, PluginFactoryType, PluginResult,

--- a/lightway-core/src/lib.rs
+++ b/lightway-core/src/lib.rs
@@ -43,9 +43,8 @@ pub use io::{
 };
 pub use packet::OutsidePacket;
 pub use packet_codec::{
-    CodecStatus, PacketCodecFactory, PacketCodecFactoryType, PacketCodecResult, PacketDecoder,
-    PacketDecoderType, PacketEncoder, PacketEncoderType, WeakPacketDecoderType,
-    WeakPacketEncoderType,
+    CodecStatus, PacketCodecResult, PacketDecoder, PacketDecoderType, PacketEncoder,
+    PacketEncoderType, WeakPacketDecoderType, WeakPacketEncoderType,
 };
 pub use plugin::{
     Plugin, PluginFactory, PluginFactoryError, PluginFactoryList, PluginFactoryType, PluginResult,

--- a/lightway-core/src/metrics.rs
+++ b/lightway-core/src/metrics.rs
@@ -10,8 +10,6 @@ static METRIC_INSIDE_IO_SEND_FAILED: LazyLock<Counter> =
     LazyLock::new(|| counter!("inside_io_send_failed"));
 static METRIC_SESSION_ID_MISMATCH: LazyLock<Counter> =
     LazyLock::new(|| counter!("session_id_mismatch"));
-static METRIC_INSIDE_PKT_DROPPED_DUE_TO_FATAL_ERR: LazyLock<Counter> =
-    LazyLock::new(|| counter!("inside packets dropped due to fatal error"));
 static METRIC_RECEIVED_ENCODING_REQ_NON_ONLINE: LazyLock<Counter> =
     LazyLock::new(|| counter!("received_encoding_req_non_online"));
 static METRIC_RECEIVED_ENCODING_REQ_WITH_TCP: LazyLock<Counter> =
@@ -42,10 +40,6 @@ pub(crate) fn inside_io_send_failed(err: std::io::Error) {
 /// Server has received a mismatched session_id in the header after the packet content has been validated
 pub(crate) fn session_id_mismatch() {
     METRIC_SESSION_ID_MISMATCH.increment(1);
-}
-
-pub(crate) fn inside_pkt_dropped_due_to_fatal_err(number: u64) {
-    METRIC_INSIDE_PKT_DROPPED_DUE_TO_FATAL_ERR.increment(number);
 }
 
 /// Server received an encoding request when the Connection state is not Online

--- a/lightway-core/src/packet_codec.rs
+++ b/lightway-core/src/packet_codec.rs
@@ -70,19 +70,3 @@ pub type WeakPacketEncoderType = Weak<dyn PacketEncoder + Send + Sync>;
 pub type PacketDecoderType = Arc<dyn PacketDecoder + Send + Sync>;
 /// Weak reference for [`PacketDecoder`]
 pub type WeakPacketDecoderType = Weak<dyn PacketDecoder + Send + Sync>;
-
-/// Factory to build [`PacketEncoderType`] and [`PacketDecoderType`]
-/// This will be used to build a new instance of [`PacketEncoderType`] and [`PacketDecoderType`] for every connection.
-pub trait PacketCodecFactory {
-    /// Build a new instance of [`PacketEncoderType`]
-    fn build_encoder(&self) -> PacketEncoderType;
-
-    /// Build a new instance of [`PacketDecoderType`]
-    fn build_decoder(&self) -> PacketDecoderType;
-
-    /// Returns the codec name for debugging purpose
-    fn get_codec_name(&self) -> String;
-}
-
-/// Type for [`PacketCodecFactory`]
-pub type PacketCodecFactoryType = Box<dyn PacketCodecFactory + Send + Sync>;

--- a/lightway-server/src/args.rs
+++ b/lightway-server/src/args.rs
@@ -117,10 +117,6 @@ pub struct Config {
     #[clap(long, default_value_t = ByteSize::mib(15))]
     pub udp_buffer_size: ByteSize,
 
-    /// How often the pkt encoder is flushed
-    #[clap(long, default_value = "100us")]
-    pub pkt_encoder_flush_interval: Duration,
-
     /// Enable WolfSSL debug logging
     #[cfg(feature = "debug")]
     #[clap(long)]

--- a/lightway-server/src/codec_list.rs
+++ b/lightway-server/src/codec_list.rs
@@ -1,5 +1,0 @@
-use lightway_core::WeakPacketEncoderType;
-use std::{collections::HashMap, net::Ipv4Addr};
-
-// Maps client's internal IP (assigned by IPManager) to its connection's packet encoder
-pub type InternalIPToEncoderMap = HashMap<Ipv4Addr, WeakPacketEncoderType>;

--- a/lightway-server/src/connection.rs
+++ b/lightway-server/src/connection.rs
@@ -113,8 +113,6 @@ impl Connection {
 
             pub fn outside_data_received(&self, buf: OutsidePacket) -> ConnectionResult<usize>;
             pub fn inside_data_received(&self, pkt: &mut BytesMut) -> ConnectionResult<()>;
-
-            pub fn get_inside_packet_encoder(&self) -> Option<PacketEncoderType>;
         }
     }
 
@@ -190,10 +188,6 @@ impl Connection {
         let mut conn = self.lw_conn.lock().unwrap();
 
         conn.send_to_inside(packet)
-    }
-
-    pub fn get_internal_ip(self: &Arc<Self>) -> Option<Ipv4Addr> {
-        self.lw_conn.lock().unwrap().app_state().internal_ip
     }
 
     // Use this only during shutdown, after clearing all connections from

--- a/lightway-server/src/connection_manager.rs
+++ b/lightway-server/src/connection_manager.rs
@@ -29,7 +29,6 @@ use lightway_core::{
     OutsideIOSendCallbackArg, OutsidePacket, ServerContext, SessionId, State, Version,
 };
 
-use crate::codec_list::InternalIPToEncoderMap;
 use crate::handle_inside_io_error;
 
 /// How often to check for connections to expire aged connections
@@ -89,18 +88,13 @@ pub(crate) struct ConnectionManager {
     ctx: ServerContext<ConnectionState>,
     connections: Mutex<ConnectionMap<Connection>>,
     pending_session_id_rotations: Mutex<HashMap<SessionId, Weak<Connection>>>,
-    encoders: Arc<Mutex<InternalIPToEncoderMap>>,
     /// Total number of sessions there have ever been
     total_sessions: AtomicUsize,
     inside_io_codec_factory: Option<PacketCodecFactoryType>,
 }
 
 #[instrument(level = "trace", skip_all)]
-async fn handle_state_change(
-    state: State,
-    conn: &Weak<Connection>,
-    encoders: Arc<Mutex<InternalIPToEncoderMap>>,
-) {
+async fn handle_state_change(state: State, conn: &Weak<Connection>) {
     let Some(conn) = conn.upgrade() else {
         info!("Connection has gone away, stopping");
         return;
@@ -116,23 +110,6 @@ async fn handle_state_change(
         State::Authenticating => {}
         State::Online => {
             metrics::connection_online(&conn);
-
-            // If codec is initialized, add the encoder and decoder to the lists so that
-            // the server can flush the encoder and clean up stale states in the decoder.
-            if let Some(encoder) = conn.get_inside_packet_encoder() {
-                let encoder = Arc::downgrade(&encoder);
-                match conn.get_internal_ip() {
-                    Some(internal_ip) => {
-                        encoders.lock().insert(internal_ip, encoder);
-                        tracing::debug!("{}'s encoder has been added to the list.", internal_ip);
-                    }
-                    None => {
-                        tracing::error!(
-                            "Internal IP not found when trying to add encoder to the list. "
-                        );
-                    }
-                }
-            }
         }
         State::Disconnecting => {}
         State::Disconnected => {}
@@ -170,14 +147,10 @@ fn handle_tls_keys_update_complete() {
 }
 
 #[instrument(level = "trace", skip_all)]
-async fn handle_events(
-    mut stream: EventStream,
-    conn: Weak<Connection>,
-    encoders: Arc<Mutex<InternalIPToEncoderMap>>,
-) {
+async fn handle_events(mut stream: EventStream, conn: Weak<Connection>) {
     while let Some(event) = stream.next().await {
         match event {
-            Event::StateChanged(state) => handle_state_change(state, &conn, encoders.clone()).await,
+            Event::StateChanged(state) => handle_state_change(state, &conn).await,
             Event::KeepaliveReply => {}
             Event::SessionIdRotationAcknowledged { old, new } => {
                 handle_finalize_session_rotation(&conn, old, new);
@@ -244,7 +217,6 @@ fn new_connection(
     protocol_version: Version,
     local_addr: SocketAddr,
     outside_io: OutsideIOSendCallbackArg,
-    encoders: Arc<Mutex<InternalIPToEncoderMap>>,
 ) -> Result<Arc<Connection>, ConnectionManagerError> {
     let (event_cb, event_stream) = EventStreamCallback::new();
 
@@ -275,11 +247,7 @@ fn new_connection(
         warn!(?err, "Failed to create new connection");
     })?;
 
-    tokio::spawn(handle_events(
-        event_stream,
-        Arc::downgrade(&conn),
-        encoders.clone(),
-    ));
+    tokio::spawn(handle_events(event_stream, Arc::downgrade(&conn)));
     tokio::spawn(handle_stale(Arc::downgrade(&conn)));
 
     if let Some((encoded_pkt_receiver, decoded_pkt_receiver)) = pkt_receivers {
@@ -299,7 +267,6 @@ fn new_connection(
 impl ConnectionManager {
     pub(crate) fn new(
         ctx: ServerContext<ConnectionState>,
-        encoders: Arc<Mutex<InternalIPToEncoderMap>>,
         inside_io_codec_factory: Option<PacketCodecFactoryType>,
     ) -> Arc<Self> {
         let conn_manager = Arc::new(Self {
@@ -307,7 +274,6 @@ impl ConnectionManager {
             connections: Mutex::new(Default::default()),
             pending_session_id_rotations: Mutex::new(Default::default()),
             total_sessions: Default::default(),
-            encoders,
             inside_io_codec_factory,
         });
 
@@ -375,7 +341,6 @@ impl ConnectionManager {
             protocol_version,
             socket_addr,
             outside_io,
-            self.encoders.clone(),
         )?;
         // TODO: what if addr was already present?
         self.connections.lock().insert(&conn)?;
@@ -431,7 +396,6 @@ impl ConnectionManager {
                     protocol_version,
                     local_addr,
                     outside_io,
-                    self.encoders.clone(),
                 )?;
                 e.insert(&c)?;
                 Ok((c, false))

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -18,10 +18,10 @@ pub use lightway_core::{
 
 use anyhow::{Context, Result, anyhow};
 use ipnet::Ipv4Net;
-use lightway_app_utils::{TunConfig, connection_ticker_cb};
+use lightway_app_utils::{PacketCodecFactoryType, TunConfig, connection_ticker_cb};
 use lightway_core::{
     AuthMethod, BuilderPredicates, ConnectionError, ConnectionResult, IOCallbackResult,
-    InsideIpConfig, PacketCodecFactoryType, Secret, ServerContextBuilder, ipv4_update_destination,
+    InsideIpConfig, Secret, ServerContextBuilder, ipv4_update_destination,
 };
 use parking_lot::Mutex;
 use pnet::packet::ipv4::Ipv4Packet;

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -160,7 +160,6 @@ async fn main() -> Result<()> {
         inside_plugins: Default::default(),
         outside_plugins: Default::default(),
         inside_pkt_codec: None,
-        pkt_encoder_flush_interval: config.pkt_encoder_flush_interval.into(),
         bind_address: config.bind_address,
         bind_attempts: config.bind_attempts,
         proxy_protocol: config.proxy_protocol,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added an encoded/decoded packet mpsc channel interface to PacketCodec.
    - Whenever a packet is ready to be emitted by the encoder/decoder, it is sent to the mpsc channel, and the client/server is responsible for sending the packets to the core.
    - packets are no longer sent as a batch, and is sent one by one when received from the mpsc channel.
- Removed the periodic flush logic of the encoder

## Motivation and Context
For now:
- Flushing of encoded packets can only be triggered by the periodic flush task and the receive of inside data 
- Flushing of decoded packets can only be triggered by the receive of outside data

which is not ideal because the codec cannot actively trigger a send to the core when the packets are ready, and can only passively wait for a flush.
If the packets sit in the codec for too long, the delay could be huge.

Hence, logic is needed to allow the codec to actively trigger a send to core.

## How Has This Been Tested?
Integrated Raptor Codec with the new changes
Do manual end-to-end test with the network namespace scripts.
Added debugging log lines and ran `ping` and `iperf3` and expected results are shown.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
