### PR TITLE
Call set_logging_callback for debugging WolfSSL

### DIFF
--- a/lightway-app-utils/Cargo.toml
+++ b/lightway-app-utils/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 default = [ "tokio" ]
 io-uring = [ "dep:io-uring", "dep:tokio", "dep:tokio-eventfd" ]
 tokio = [ "dep:tokio", "dep:tokio-stream" ]
+debug = [ ]
 
 [lints]
 workspace = true

--- a/lightway-app-utils/src/lib.rs
+++ b/lightway-app-utils/src/lib.rs
@@ -36,4 +36,9 @@ mod utils;
 pub use utils::{Validate, validate_configuration_file_path};
 
 mod packet_codec;
+#[cfg(feature = "debug")]
+mod wolfssl_tracing;
+#[cfg(feature = "debug")]
+pub use wolfssl_tracing::wolfssl_tracing_callback;
+
 pub use packet_codec::{PacketCodec, PacketCodecFactory, PacketCodecFactoryType};

--- a/lightway-app-utils/src/wolfssl_tracing.rs
+++ b/lightway-app-utils/src/wolfssl_tracing.rs
@@ -1,0 +1,28 @@
+#![allow(unsafe_code)]
+
+use std::ffi::CStr;
+use tracing::debug;
+
+/// Callback function to WolfSSL's [`set_logging_callback`] (which conforms to [`WolfsslLoggingCallback`])
+/// It will pass the log message to [`tracing`] via `debug` macro.
+/// This is marked `unsafe` to match the `bindgen`-generated function type for FFI compatibility.
+/// # SAFETY
+/// The caller must originate from the WolfSSL library's logging callback,
+/// as it is not designed to be used or called from Rust.
+#[allow(non_snake_case)]
+pub unsafe extern "C" fn wolfssl_tracing_callback(
+    _logLevel: std::os::raw::c_int,
+    logMessage: *const std::os::raw::c_char,
+) {
+    if logMessage.is_null() {
+        return;
+    }
+    // SAFETY: Based on the safety requirements for CStr
+    // https://doc.rust-lang.org/std/ffi/struct.CStr.html#safety
+    // We check the pointer is not null, and the string pointed will be
+    // null terminated since it is generated as snprintf from wolfssl
+    // Ref: https://github.com/wolfSSL/wolfssl/blob/master/wolfcrypt/src/logging.c
+    let c_str = unsafe { CStr::from_ptr(logMessage) };
+    let msg = c_str.to_str().unwrap_or("Unable to decode C string");
+    debug!(msg);
+}

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 
 [features]
 default = ["postquantum"]
-debug = ["lightway-core/debug"]
+debug = ["lightway-core/debug","lightway-app-utils/debug"]
 io-uring = ["lightway-app-utils/io-uring"]
 postquantum = ["lightway-core/postquantum"]
 kyber_only = ["postquantum", "lightway-core/kyber_only"]

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -28,6 +28,10 @@ pub use lightway_core::{enable_tls_debug, set_logging_callback};
 use pnet::packet::ipv4::Ipv4Packet;
 
 #[cfg(feature = "debug")]
+use crate::debug::WiresharkKeyLogger;
+#[cfg(feature = "debug")]
+use lightway_app_utils::wolfssl_tracing_callback;
+#[cfg(feature = "debug")]
 use std::path::PathBuf;
 use std::{
     net::Ipv4Addr,
@@ -41,9 +45,6 @@ use tokio::{
 };
 use tokio_stream::StreamExt;
 use tracing::info;
-
-#[cfg(feature = "debug")]
-use crate::debug::WiresharkKeyLogger;
 
 /// Connection type
 /// Applications can also attach socket for library to use directly,
@@ -577,7 +578,7 @@ pub async fn client<A: 'static + Send + EventCallback>(
 
     #[cfg(feature = "debug")]
     if config.tls_debug {
-        enable_tls_debug();
+        set_logging_callback(Some(wolfssl_tracing_callback));
     }
 
     let (inside_io_codec, encoded_pkt_receiver, decoded_pkt_receiver) =

--- a/lightway-server/Cargo.toml
+++ b/lightway-server/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 
 [features]
 default = ["io-uring"]
-debug = ["lightway-core/debug"]
+debug = ["lightway-core/debug","lightway-app-utils/debug"]
 io-uring = ["lightway-app-utils/io-uring"]
 
 [lints]

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -12,7 +12,11 @@ use tracing::{error, trace};
 use twelf::Layer;
 
 use args::Config;
+#[cfg(feature = "debug")]
+use lightway_app_utils::wolfssl_tracing_callback;
 use lightway_app_utils::{TunConfig, Validate, validate_configuration_file_path};
+#[cfg(feature = "debug")]
+use lightway_core::set_logging_callback;
 use lightway_server::*;
 
 async fn metrics_debug() {
@@ -100,7 +104,7 @@ async fn main() -> Result<()> {
 
     #[cfg(feature = "debug")]
     if config.tls_debug {
-        enable_tls_debug();
+        set_logging_callback(Some(wolfssl_tracing_callback));
     }
 
     let fmt = tracing_subscriber::fmt().with_max_level(config.log_level);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Call `set_logging_callback` for debugging WolfSSL when `debug` feature is on. This makes debugging WolfSSL easier as we don't have build WolfSSL from scratch everytime we want debug logs from it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Easier to read and get debug logs from WolfSSL without jumping a bunch of hoops

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Able to obtain WolfSSL logs on Android using the same callback function

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
- [ ] Any update to `xenon/libxenon-src` is accompanied by a reference to the specific commit in the git changelog
