### PR TITLE
ci: temp ignore metrics-util crate for outdated check

### DIFF
--- a/.github/workflows/weekly-cargo-update.yaml
+++ b/.github/workflows/weekly-cargo-update.yaml
@@ -82,7 +82,9 @@ jobs:
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         echo "comment<<$EOF" >> "$GITHUB_OUTPUT"
 
-        if ! cargo outdated --root-deps-only --exit-code 1 | tee /tmp/workspace-outdated.log ; then
+        # Ignore metric-util for now, until this is fixed:
+        # https://github.com/metrics-rs/metrics/issues/560
+        if ! cargo outdated --ignore metrics-util --root-deps-only --exit-code 1 | tee /tmp/workspace-outdated.log ; then
             echo "Workspace dependencies are out of date"
             failed=true
 

--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,9 @@ yanked = "deny"
 ignore = [
     # yaml_rust is unmaintained, which is a dependency of twelf. Ignoring until its fixed
     "RUSTSEC-2024-0320",
+    # paste is unmaintained, which is a dependency of fs-mistrust->pwd-grp. Ignoring until its fixed
+    # https://gitlab.torproject.org/tpo/core/rust-pwd-grp/-/issues/5
+    "RUSTSEC-2024-0436",
 ]
 
 [licenses]


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Upstream dogstatsd exporter has been moved to metrics org recently and with the move, code has been refactored with some features dropped like consolidating metrics in single UDP packet etc.
Ref: 
https://github.com/metrics-rs/metrics/issues/554
https://github.com/metrics-rs/metrics/issues/560

Until it is fixed, ignore the outdated error for metrics-util crate.

## Motivation and Context

Weekly cargo update is continuously failing with cargo outdated check.
https://github.com/expressvpn/lightway/actions/workflows/weekly-cargo-update.yaml

This error will prevent us to check other outdated packages.
Temporarily ignore metrics-util until the above issue is fixed.

And another cargo deny error:
https://github.com/expressvpn/lightway/actions/runs/14987755691/job/42104785560

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

