### PR TITLE
Make pmtu base config

### DIFF
--- a/lightway-client/src/args.rs
+++ b/lightway-client/src/args.rs
@@ -92,6 +92,10 @@ pub struct Config {
     #[clap(long)]
     pub enable_pmtud: bool,
 
+    /// Base MTU to use for PMTU discovery
+    #[clap(long)]
+    pub pmtud_base_mtu: Option<u16>,
+
     /// Enable IO-uring interface for Tunnel
     #[clap(long, default_value_t)]
     pub enable_tun_iouring: bool,

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -127,6 +127,9 @@ pub struct ClientConfig<'cert, A: 'static + Send + EventCallback> {
     /// Enable PMTU discovery for Udp connections
     pub enable_pmtud: bool,
 
+    /// Base MTU for PMTU discovery
+    pub pmtud_base_mtu: Option<u16>,
+
     /// Enable IO-uring interface for Tunnel
     #[cfg(feature = "io-uring")]
     pub enable_tun_iouring: bool,
@@ -632,6 +635,7 @@ pub async fn client<A: 'static + Send + EventCallback>(
     .with_auth(config.auth)
     .with_event_cb(Box::new(event_cb))
     .with_inside_pkt_codec(inside_io_codec)
+    .when_some(config.pmtud_base_mtu, |b, mtu| b.with_pmtud_base_mtu(mtu))
     .when_some(config.server_dn, |b, sdn| {
         b.with_server_domain_name_validation(sdn)
     })

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -90,6 +90,7 @@ async fn main() -> Result<()> {
         sndbuf: config.sndbuf,
         rcvbuf: config.rcvbuf,
         enable_pmtud: config.enable_pmtud,
+        pmtud_base_mtu: config.pmtud_base_mtu,
         #[cfg(feature = "io-uring")]
         enable_tun_iouring: config.enable_tun_iouring,
         #[cfg(feature = "io-uring")]

--- a/lightway-core/src/connection/builders.rs
+++ b/lightway-core/src/connection/builders.rs
@@ -61,6 +61,7 @@ pub struct ClientConnectionBuilder<AppState> {
     connection_type: ConnectionType,
     ctx: ClientContext<AppState>,
     outside_mtu: usize,
+    pmtud_base_mtu: Option<u16>,
     auth_method: Option<AuthMethod>,
     session_config: wolfssl::SessionConfig<super::WolfSSLIOAdapter>,
     event_cb: Option<EventCallbackArg>,
@@ -111,6 +112,7 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
             event_cb: None,
             max_fragment_map_entries: FragmentMap::DEFAULT_MAX_ENTRIES,
             pmtud_timer: None,
+            pmtud_base_mtu: None,
             outside_plugins,
             inside_pkt_codec: None,
         })
@@ -225,6 +227,14 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
         }
     }
 
+    /// Sets the base mtu to use for PMTU discovery ([`ConnectionType::Datagram`] only)
+    pub fn with_pmtud_base_mtu(self, mtu: u16) -> Self {
+        Self {
+            pmtud_base_mtu: Some(mtu),
+            ..self
+        }
+    }
+
     /// Finalize the builder to create a [`Connection`] and begin the connection process.
     pub fn connect(self, app_state: AppState) -> ConnectionBuilderResult<Connection<AppState>> {
         let auth_method = self
@@ -265,6 +275,7 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
             outside_plugins: self.outside_plugins,
             max_fragment_map_entries: self.max_fragment_map_entries,
             pmtud_timer: self.pmtud_timer,
+            pmtud_base_mtu: self.pmtud_base_mtu,
             inside_pkt_codec: self.inside_pkt_codec,
         })?)
     }
@@ -399,6 +410,7 @@ impl<'a, AppState: Send + 'static> ServerConnectionBuilder<'a, AppState> {
             outside_plugins: self.outside_plugins,
             max_fragment_map_entries: self.max_fragment_map_entries,
             pmtud_timer: None,
+            pmtud_base_mtu: None,
             inside_pkt_codec: self.inside_pkt_codec,
         })?)
     }

--- a/lightway-server/src/connection_manager.rs
+++ b/lightway-server/src/connection_manager.rs
@@ -96,7 +96,7 @@ pub(crate) struct ConnectionManager {
 #[instrument(level = "trace", skip_all)]
 async fn handle_state_change(state: State, conn: &Weak<Connection>) {
     let Some(conn) = conn.upgrade() else {
-        info!("Connection has gone away, stopping");
+        info!(?state, "Connection has gone away");
         return;
     };
 
@@ -119,7 +119,7 @@ async fn handle_state_change(state: State, conn: &Weak<Connection>) {
 #[instrument(level = "trace", skip_all)]
 fn handle_finalize_session_rotation(conn: &Weak<Connection>, old: SessionId, new: SessionId) {
     let Some(conn) = conn.upgrade() else {
-        info!("Connection has gone away, stopping");
+        info!("Connection has gone away");
         return;
     };
 
@@ -132,7 +132,7 @@ fn handle_tls_keys_update_start(conn: &Weak<Connection>) {
 
     // For UDP connections begin a session ID rotation
     let Some(conn) = conn.upgrade() else {
-        info!("Connection has gone away, stopping");
+        info!("Connection has gone away");
         return;
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Make the base_mtu of PMTUD as config value

## Motivation and Context

At present, PMTUD uses default value of 1250 as base MTU.
By making the base_mtu as configurable, we can allow PMTU discovery  to be usable
even in networks which has lesser MTU than 1250

## How Has This Been Tested?
Verified PMTUD starts from the configurable value

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
