### PR TITLE
CVPN-1935: Add `set_outside_io` to update outside IO callback

### DIFF
--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -20,7 +20,6 @@ use thiserror::Error;
 use tracing::{debug, error, info, trace, warn};
 use wolfssl::{ErrorKind, IOCallbackResult, ProtocolVersion};
 
-use crate::max_dtls_mtu;
 use crate::{
     ConnectionType, IPV4_HEADER_SIZE, InsideIOSendCallbackArg, PluginResult, SessionId,
     TCP_HEADER_SIZE, Version,
@@ -34,6 +33,7 @@ use crate::{
     utils::tcp_clamp_mss,
     wire::{self, AuthMethod},
 };
+use crate::{OutsideIOSendCallbackArg, max_dtls_mtu};
 
 use crate::context::ip_pool::{ClientIpConfigArg, ServerIpPoolArg};
 use crate::packet::{OutsidePacket, OutsidePacketError};
@@ -736,6 +736,11 @@ impl<AppState: Send> Connection<AppState> {
         };
 
         Ok(auth_handle.expired())
+    }
+
+    /// Update WolfSSL Session to use the new outside IO Callback
+    pub fn set_outside_io(&mut self, new_io: OutsideIOSendCallbackArg) {
+        self.session.io_cb_mut().io = new_io;
     }
 
     /// Accept some data from outside and run an iteration of the I/O


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Introduce `set_new_outside_io` to update outside IO callback in WolfSSL session.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This can be used when the client apps need to destroy/recreate the outside socket to make sure the same WolfSSL session can still be used for this connection.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested this on a test iPhone, verified that the WolfSSL session is using the new callback arguments properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
