### PR TITLE
ci: add tests for riscv64gc

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,7 @@
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
 runner = ["qemu-aarch64-static"] # use qemu user emulation for cargo run and test
+
+[target.riscv64gc-unknown-linux-gnu]
+runner = "qemu-riscv64-static -L /usr/riscv64-linux-gnu -cpu rv64"
+linker = "riscv64-linux-gnu-gcc"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [test, test-miri, test-arm64, build, build-arm64, fmt, lint, check-dependencies]
+        target: [test, test-miri, test-arm64, test-riscv64, build, build-arm64, build-riscv64, fmt, lint, check-dependencies]
     runs-on: ubuntu-latest
     env:
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Introduce tests via running qemu and CI jobs for compiling to the `riscv64gc` target.

## Motivation and Context
This is to ensure `riscv64gc` targets are covered under the tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
