### PR TITLE
Align ARCH value to dpkg riscv64

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -53,7 +53,7 @@ build:
 
     IF [ "$ARCH" = "arm64" ]
         SET target = "aarch64-unknown-linux-gnu"
-    ELSE IF [ "$ARCH" = "riscv64gc" ]
+    ELSE IF [ "$ARCH" = "riscv64" ]
         SET target = "riscv64gc-unknown-linux-gnu"
     END
 
@@ -67,7 +67,7 @@ build-arm64:
     BUILD +build --ARCH="arm64"
 
 build-riscv64:
-    BUILD +build --ARCH="riscv64gc"
+    BUILD +build --ARCH="riscv64"
 
 build-kyber-client:
     FROM +source
@@ -76,7 +76,7 @@ build-kyber-client:
 
     IF [ "$ARCH" = "arm64" ]
         SET target = "aarch64-unknown-linux-gnu" 
-    ELSE IF [ "$ARCH" = "riscv64gc" ]
+    ELSE IF [ "$ARCH" = "riscv64" ]
         SET target = "riscv64gc-unknown-linux-gnu"
     END
 
@@ -91,7 +91,7 @@ test:
 
     IF [ "$ARCH" = "arm64" ]
         SET target = "aarch64-unknown-linux-gnu" 
-    ELSE IF [ "$ARCH" = "riscv64gc" ]
+    ELSE IF [ "$ARCH" = "riscv64" ]
         SET target = "riscv64gc-unknown-linux-gnu"
     END
 
@@ -111,9 +111,9 @@ test-miri:
 test-arm64:
     BUILD +test --ARCH="arm64"
 
-# test-riscv64 executes all unit and integration tests via Cargo for riscv64gc. Support running from an amd64 or arm64 host
+# test-riscv64 executes all unit and integration tests via Cargo for riscv64. Support running from an amd64 or arm64 host
 test-riscv64:
-    BUILD +test --ARCH="riscv64gc"
+    BUILD +test --ARCH="riscv64"
 
 # e2e runs all end-to-end tests, must be run with `--allow-privileged`
 e2e:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Align the ARCH detection in Earthfile to values emitted from `dpkg --print-architecture`.
Currently, The default value for ARCH is the output `dpkg --print-architecture`, however, the said command doesn't emit `"riscv64gc"`, it emits `"riscv64"`.
This commit aligns the value in the `if` arms to match the ones emitted from `dpkg`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
