### PR TITLE
feat: let ServerAuth determine if inside packet encoding can be used

### DIFF
--- a/lightway-core/src/context/server_auth.rs
+++ b/lightway-core/src/context/server_auth.rs
@@ -1,15 +1,17 @@
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use bytes::Bytes;
 use tracing::info;
 
-use crate::{Version, wire};
+use crate::{LightwayFeature, Version, wire};
 
 /// A handle onto a successful auth result.
 pub trait ServerAuthHandle: std::fmt::Debug {
     /// Validate if this authentication is still valid, returns
     /// true if it has expired.
     fn expired(&self) -> bool;
+    /// All features available to this connection.
+    fn features(&self) -> HashSet<LightwayFeature>;
 }
 
 /// Result of [`ServerAuth`] `authorize_*` methods.

--- a/lightway-core/src/features.rs
+++ b/lightway-core/src/features.rs
@@ -1,0 +1,6 @@
+/// Optional lightway features, which can be negotiated during the auth.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub enum LightwayFeature {
+    /// Whether the server will accept EncodingRequests.
+    InsidePktCodec,
+}

--- a/lightway-core/src/lib.rs
+++ b/lightway-core/src/lib.rs
@@ -8,6 +8,7 @@ mod cipher;
 mod connection;
 mod context;
 mod encoding_request_states;
+mod features;
 mod io;
 mod metrics;
 mod packet;
@@ -39,6 +40,7 @@ pub use context::{
     ServerContextBuilder,
     ip_pool::{ClientIpConfig, ClientIpConfigArg, InsideIpConfig, ServerIpPool, ServerIpPoolArg},
 };
+pub use features::LightwayFeature;
 pub use io::{
     InsideIOSendCallback, InsideIOSendCallbackArg, OutsideIOSendCallback, OutsideIOSendCallbackArg,
 };

--- a/lightway-core/src/metrics.rs
+++ b/lightway-core/src/metrics.rs
@@ -10,6 +10,8 @@ static METRIC_INSIDE_IO_SEND_FAILED: LazyLock<Counter> =
     LazyLock::new(|| counter!("inside_io_send_failed"));
 static METRIC_SESSION_ID_MISMATCH: LazyLock<Counter> =
     LazyLock::new(|| counter!("session_id_mismatch"));
+static METRIC_RECEIVED_ENCODING_REQ_NO_AUTHORIZATION: LazyLock<Counter> =
+    LazyLock::new(|| counter!("received_encoding_req_no_authorization"));
 static METRIC_RECEIVED_ENCODING_REQ_NON_ONLINE: LazyLock<Counter> =
     LazyLock::new(|| counter!("received_encoding_req_non_online"));
 static METRIC_RECEIVED_ENCODING_REQ_WITH_TCP: LazyLock<Counter> =
@@ -40,6 +42,11 @@ pub(crate) fn inside_io_send_failed(err: std::io::Error) {
 /// Server has received a mismatched session_id in the header after the packet content has been validated
 pub(crate) fn session_id_mismatch() {
     METRIC_SESSION_ID_MISMATCH.increment(1);
+}
+
+/// Server received an encoding request when the client does not have authorization to use inside packet encoding
+pub(crate) fn received_encoding_req_no_authorization() {
+    METRIC_RECEIVED_ENCODING_REQ_NO_AUTHORIZATION.increment(1);
 }
 
 /// Server received an encoding request when the Connection state is not Online

--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
@@ -32,9 +33,22 @@ struct TestAuth;
 impl ServerAuth<ConnectionTicker> for TestAuth {
     fn authorize_token(&self, _token: &str, _app_state: &mut ConnectionTicker) -> ServerAuthResult {
         ServerAuthResult::Granted {
-            handle: None,
+            handle: Some(Box::new(TestAuthHandle)),
             tunnel_protocol_version: None,
         }
+    }
+}
+
+#[derive(Debug)]
+struct TestAuthHandle;
+
+impl ServerAuthHandle for TestAuthHandle {
+    fn expired(&self) -> bool {
+        false
+    }
+
+    fn features(&self) -> HashSet<LightwayFeature> {
+        HashSet::from([LightwayFeature::InsidePktCodec])
     }
 }
 


### PR DESCRIPTION
By default, in `lightway-server`, inside packet encoding is enabled. The application can choose to override this behaviour in its `ServerAuth` implementation.

## Description
A new `features()` function is added to `ServerAuthHandle`. This allows the Server to specify which features are available to the connection during authorization. An application can choose to override this field in its `ServerAuth` implementation.

## Motivation and Context
This will allow applications to control which connections can use inside packet encoding.

## How Has This Been Tested?
Unit tests are added to check if `can_use_inside_pkt_encoding` defaults to true. This maintains existing behaviour, so is not breaking.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
