### PR TITLE
Increase tests timeout for riscv CI

### DIFF
--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -616,6 +616,12 @@ impl PQCrypto {
     }
 }
 
+fn get_test_timeout() -> u64 {
+    #[cfg(target_arch = "riscv64")]
+    return 5000;
+    2000
+}
+
 async fn run_test_tcp<S: TestSock>(
     cipher: Option<Cipher>,
     pqc: PQCrypto,
@@ -640,7 +646,7 @@ async fn run_test<S: TestSock>(
         )
     };
 
-    tokio::time::timeout(std::time::Duration::from_millis(2000), test)
+    tokio::time::timeout(std::time::Duration::from_millis(get_test_timeout()), test)
         .await
         .expect("Timed out");
 }
@@ -708,7 +714,7 @@ async fn test_server_dn(server_dn: Option<&str>) {
         )
     };
 
-    tokio::time::timeout(std::time::Duration::from_millis(2000), test)
+    tokio::time::timeout(std::time::Duration::from_millis(get_test_timeout()), test)
         .await
         .expect("Timed out");
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Increase test timeout from 2000ms to 5000ms.
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is needed to solve flaky tests, especially the RISC-V tests, where emulation incurs a significant performance overhead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
