### PR TITLE
ci: remove earthly satellite in github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,6 @@ jobs:
         target: [test, test-miri, test-arm64, test-riscv64, build, build-arm64, build-riscv64, fmt, lint, check-dependencies]
     runs-on: ubuntu-latest
     env:
-      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
       FORCE_COLOR: 1
     steps:
       - uses: earthly/actions-setup@v1
@@ -32,12 +31,11 @@ jobs:
           version: ~v0.8
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4
-      - name: Run +${{ matrix.target }} on Earthly satellite
-        run: earthly --ci --org expressvpn --satellite lightway +${{ matrix.target }}
+      - name: Run +${{ matrix.target }} on Earthly
+        run: earthly --ci +${{ matrix.target }}
   e2e:
     runs-on: ubuntu-latest
     env:
-      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
       FORCE_COLOR: 1
     strategy:
       fail-fast: false
@@ -49,12 +47,11 @@ jobs:
           version: ~v0.8
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4
-      - name: Run +e2e on Earthly satellite
-        run: earthly --ci --org expressvpn --satellite lightway --allow-privileged +e2e --debian ${{ matrix.distro }}
+      - name: Run +e2e on Earthly
+        run: earthly --ci --allow-privileged +e2e --debian ${{ matrix.distro }}
   coverage:
     runs-on: ubuntu-latest
     env:
-      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
       FORCE_COLOR: 1
     steps:
       - uses: earthly/actions-setup@v1
@@ -62,10 +59,10 @@ jobs:
           version: ~v0.8
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4
-      - name: Run +coverage on Earthly satellite
+      - name: Run +coverage on Earthly
         id: coverage
         run: |
-          earthly --ci --org expressvpn --satellite lightway --artifact +coverage/* output/
+          earthly --ci --artifact +coverage/* output/
 
           cat output/summary.txt
 

--- a/README.md
+++ b/README.md
@@ -361,14 +361,6 @@ TCPv4 as usual.
 
 [PROXY protocol]: https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
 
-## Speeding up development with Earthly Satellites
-
-Please refer to [official documentation for Earthly Satellites](https://docs.earthly.dev/earthly-cloud/satellites).
-
-If you are a member of ExpressVPN, you can get access to the same Earthly organization used in our CI. The organization is named `expressvpn`, inside which contains a satellite named `lightway`.
-
-If you are not a member of ExpressVPN, you may set up your own Earthly satellite according the official instructions above.
-
 ## Debugging
 
 ### Decrypting TLS1.3 data packets


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

 remove earthly satellite in github actions since satellites will be sundown by July 16, 2025.

Read more:
https://earthly.dev/blog/shutting-down-earthfiles-cloud/

## Motivation and Context

Earthly satellites are shutdown

## How Has This Been Tested?
CI passed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
