### PR TITLE
Bump earthly/dind image used for e2e tests

### DIFF
--- a/tests/e2e/Earthfile
+++ b/tests/e2e/Earthfile
@@ -1,6 +1,5 @@
 VERSION 0.8
 
 build-container:
-    FROM earthly/dind:ubuntu
+    FROM earthly/dind:ubuntu-24.04-docker-27.3.1-1
     COPY docker-compose.yml run-with-compose-stack.sh run-simple-test.sh run-udp-floating-test.sh .
-


### PR DESCRIPTION
## Description
This PR bumps the image tag for `earthly/dind` used in e2e tests to the latest available ubuntu-based buildkit image.

The previous `earthly/dind:ubuntu` is a legacy tag which is pinned to an outdated version.

## Motivation and Context
- Maintenance

## How Has This Been Tested?
- Pending CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
