### PR TITLE
CVPN-2123 Enable System CA Certs feature in WolfSSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3204,7 +3204,7 @@ dependencies = [
 [[package]]
 name = "wolfssl"
 version = "3.0.0"
-source = "git+https://github.com/expressvpn/wolfssl-rs#8d443e97886193c230a0a74feeb6cbc906832289"
+source = "git+https://github.com/expressvpn/wolfssl-rs#b5712f6fef289f46a3bd772ee5680be909e6c888"
 dependencies = [
  "bytes",
  "log",
@@ -3215,7 +3215,7 @@ dependencies = [
 [[package]]
 name = "wolfssl-sys"
 version = "2.0.0"
-source = "git+https://github.com/expressvpn/wolfssl-rs#8d443e97886193c230a0a74feeb6cbc906832289"
+source = "git+https://github.com/expressvpn/wolfssl-rs#b5712f6fef289f46a3bd772ee5680be909e6c888"
 dependencies = [
  "autotools",
  "bindgen",

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,7 @@
                   "--skip=routing_table::tests"
                 ];
                 cargoLock.outputHashes = {
-                  "wolfssl-3.0.0" = "sha256-4nCoGOIhiGC7aTDvdXpVNTBzMl4dkNCJxtcuODumW2Q=";
+                  "wolfssl-3.0.0" = "sha256-+T60rvjI3TPzD5HSM+9GRfIUw1FM/wTe+s7XeNswDyQ=";
                 };
               };
 

--- a/lightway-core/Cargo.toml
+++ b/lightway-core/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
+default = ["wolfssl/system_ca_certs"]
 debug = ["wolfssl/debug"]
 # Enable additional APIs to support wire protocol fuzzing
 fuzzing_api = []


### PR DESCRIPTION
## Description

This change is introducing an option to use the system’s CA trust store for TLS certificate verification. This enhancement is designed to give downstream developers greater flexibility, such as making HTTPs API calls that use a Root CA-signed certificate. Please note, however, that this change does not mean that Lightway will begin accepting Root CA-signed certificates.

This change only adds the capability to WolfSSL. To use this feature, developers will need to call a specific function to load the system's certificates into the WolfSSL context. This process does not affect existing certificate validation unless explicitly enabled by the developer.

Mirroring the change from https://github.com/expressvpn/lightway-core/pull/200

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
