### PR TITLE
client: Fix user unable to state server hostname

### DIFF
--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -1,4 +1,8 @@
-use std::{net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{
+    net::{SocketAddr, ToSocketAddrs},
+    path::PathBuf,
+    sync::Arc,
+};
 
 use anyhow::{Context, Result, anyhow};
 use clap::CommandFactory;
@@ -78,8 +82,9 @@ async fn main() -> Result<()> {
 
     let server_addr: SocketAddr = config
         .server
-        .parse()
-        .with_context(|| format!("Invalid server address: {}", config.server))?;
+        .to_socket_addrs()?
+        .next()
+        .ok_or_else(|| anyhow!("No addresses resolved for server: {}", config.server))?;
 
     let config = ClientConfig {
         mode,

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -24,7 +24,7 @@ TEST:
     ARG KYBER_CLIENT
 
     ARG SERVER_ARGS="--config-file server_config.yaml --log-level trace --mode ${MODE} ${SERVER_EXTRA_ARGS} --bind-address 0.0.0.0:${SERVER_PORT}"
-    ARG CLIENT_ARGS="--config-file client_config.yaml --log-level trace --mode ${MODE} ${CLIENT_EXTRA_ARGS}"
+    ARG CLIENT_ARGS="--config-file client_config.yaml --log-level trace --mode ${MODE} ${CLIENT_EXTRA_ARGS} --server server:${SERVER_PORT}"
 
     LET CLIENT_IMAGE_CMD="./client+build-container --TOKIO_WORKER_THREADS=$CLIENT_TOKIO_WORKER_THREADS --debian=$debian"
     IF [ "$KYBER_CLIENT" = "true" ]
@@ -40,7 +40,7 @@ TEST:
         --load lightway-test-server:latest=$SERVER_IMAGE \
         --load lightway-test-nginx:latest=$NGINX_IMAGE \
         --load lightway-test-iperf:latest=$IPERF_IMAGE
-        RUN --no-cache SERVER_PORT=$SERVER_PORT ./run-with-compose-stack.sh $TEST_SCRIPT
+        RUN --no-cache ./run-with-compose-stack.sh $TEST_SCRIPT
     END
 
 # run-tcp-aes256-test runs e2e test using TCP and AES256 cipher

--- a/tests/client/client_config.yaml
+++ b/tests/client/client_config.yaml
@@ -1,5 +1,5 @@
 ---
-server: 172.16.0.1:27690
+server: server:27690
 mode: tcp
 ca_cert: "tests/certs/ca.crt"
 tun_name: lightway

--- a/tests/client/docker-entrypoint.sh
+++ b/tests/client/docker-entrypoint.sh
@@ -10,20 +10,9 @@ echo "Ping server"
 echo "====================================================================="
 ping -W 1 -c 3 server
 
-server=$(dig +short server)
-
-# Add server argument using resolved IP and SERVER_PORT env var
-if [ -n "${SERVER_PORT:-}" ]; then
-    server_arg="--server=$server:$SERVER_PORT"
-    echo "Using server address: $server:$SERVER_PORT"
-else
-    server_arg=""
-    echo "No SERVER_PORT set, using arguments from command line"
-fi
-
 echo ""
 echo "====================================================================="
-echo "Start lightway-client: $* $server_arg"
+echo "Start lightway-client: $*"
 echo "====================================================================="
 
-exec ./lightway-client "$@" "$server_arg"
+exec ./lightway-client "$@"

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -47,8 +47,6 @@ services:
     command: ${CLIENT_ARGS}
     stop_signal: SIGTERM
     stop_grace_period: 10s
-    environment:
-      - SERVER_PORT=${SERVER_PORT}
     sysctls:
       # Ensure that `$new_ip` becomes the primary when `$current_ip`
       # is removed. Otherwise all addresses are removed which breaks


### PR DESCRIPTION
Previously parsing a hostname to the config would throw an error
This fixes it so that the hostname is resolved in the binary

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`config.server` is now resolved in `to_socket_addrs()`
scripts that use dig to resolve have been modified to rely on the binary

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
