### PR TITLE
client: Parallel connect

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -43,7 +43,7 @@ source:
     FROM +install-build-dependencies
     COPY --keep-ts Cargo.toml Cargo.lock ./
     COPY --keep-ts deny.toml ./
-    COPY --keep-ts --dir lightway-core lightway-app-utils lightway-client lightway-server .cargo ./
+    COPY --keep-ts --dir lightway-core lightway-app-utils lightway-client lightway-server tests .cargo ./
 
 # build builds with the Cargo release profile
 build:

--- a/lightway-app-utils/src/args/cipher.rs
+++ b/lightway-app-utils/src/args/cipher.rs
@@ -3,11 +3,12 @@ use serde::{Deserialize, Serialize};
 
 use lightway_core::Cipher as LWCipher;
 
-#[derive(Copy, Clone, Debug, ValueEnum, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, ValueEnum, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 /// [`LWCipher`] wrapper compatible with clap and twelf
 pub enum Cipher {
     /// AES256 Cipher
+    #[default]
     Aes256,
     /// Chacha20 Cipher
     Chacha20,

--- a/lightway-app-utils/src/args/connection_type.rs
+++ b/lightway-app-utils/src/args/connection_type.rs
@@ -3,13 +3,14 @@ use serde::{Deserialize, Serialize};
 
 use lightway_core::ConnectionType as LWConnectionType;
 
-#[derive(Copy, Clone, ValueEnum, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, ValueEnum, Debug, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 /// [`lightway_core::ConnectionType`] wrapper compatible with clap and twelf
 pub enum ConnectionType {
     /// UDP (Datagram)
     Udp,
     /// TCP (Stream)
+    #[default]
     Tcp,
 }
 

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -30,14 +30,14 @@ pub enum Tun {
 
 impl Tun {
     /// Create new `Tun` instance with direct read/write
-    pub async fn direct(config: TunConfig) -> Result<Self> {
+    pub async fn direct(config: &TunConfig) -> Result<Self> {
         Ok(Self::Direct(TunDirect::new(config)?))
     }
 
     /// Create new `Tun` instance with iouring read/write
     #[cfg(feature = "io-uring")]
     pub async fn iouring(
-        config: TunConfig,
+        config: &TunConfig,
         ring_size: usize,
         sqpoll_idle_time: Duration,
     ) -> Result<Self> {
@@ -102,14 +102,8 @@ pub struct TunDirect {
 
 impl TunDirect {
     /// Create a new `Tun` struct
-    pub fn new(config: TunConfig) -> Result<Self> {
-        #[cfg(target_os = "macos")]
-        let mut config = config;
-        #[cfg(target_os = "macos")]
-        config.platform_config(|config| {
-            config.enable_routing(false);
-        });
-        let tun = tun::create_as_async(&config)?;
+    pub fn new(config: &TunConfig) -> Result<Self> {
+        let tun = tun::create_as_async(config)?;
         let fd = tun.as_raw_fd();
         let mtu = tun.mtu()?;
 
@@ -173,7 +167,7 @@ pub struct TunIoUring {
 impl TunIoUring {
     /// Create `TunIoUring` struct
     pub async fn new(
-        config: TunConfig,
+        config: &TunConfig,
         ring_size: usize,
         sqpoll_idle_time: Duration,
     ) -> Result<Self> {

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -37,7 +37,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-stream = { workspace = true, features = ["time"] }
 tokio-util.workspace = true
-tracing.workspace = true
+tracing = { workspace = true, features = ["attributes"] }
 tracing-subscriber = { workspace = true}
 twelf.workspace = true
 

--- a/lightway-client/src/args.rs
+++ b/lightway-client/src/args.rs
@@ -93,6 +93,11 @@ pub struct Config {
     #[clap(long, default_value = "0s")]
     pub keepalive_timeout: Duration,
 
+    /// How long to wait before selecting the best connection. If the preferred
+    /// connection connects before the timeout, it will be used immediately.
+    #[clap(long, default_value = "0s")]
+    pub preferred_connection_wait_interval: Duration,
+
     /// Socket send buffer size
     #[clap(long)]
     pub sndbuf: Option<ByteSize>,

--- a/lightway-client/src/args.rs
+++ b/lightway-client/src/args.rs
@@ -4,6 +4,7 @@ use bytesize::ByteSize;
 use clap::Parser;
 use lightway_app_utils::args::{Cipher, ConnectionType, Duration, LogLevel};
 use lightway_core::{AuthMethod, MAX_OUTSIDE_MTU};
+use serde::Serialize;
 use std::{net::Ipv4Addr, path::PathBuf};
 use twelf::config;
 
@@ -15,9 +16,31 @@ pub struct Config {
     #[clap(short, long)]
     pub config_file: PathBuf,
 
+    /// Servers to attempt to connect to. Configuration is only supported in
+    /// config file, not command line or environment variable
+    #[clap(skip)]
+    #[serde(default)]
+    pub servers: Vec<ConnectionConfig>,
+
+    /// Server to connect to in <hostname>:<port> format
+    /// Only used if `servers` is empty
+    #[clap(short, long, default_value_t)]
+    pub server: String,
+
     /// Connection mode
+    /// Only used if `servers` is empty
     #[clap(short, long, value_enum, default_value_t = ConnectionType::Tcp)]
     pub mode: ConnectionType,
+
+    /// Server domain name
+    /// Only used if `servers` is empty
+    #[clap(long, default_value = None)]
+    pub server_dn: Option<String>,
+
+    /// Cipher to use for encryption
+    /// Only used if `servers` is empty
+    #[clap(long, value_enum, default_value_t = Cipher::Aes256)]
+    pub cipher: Cipher,
 
     /// Auth token
     /// If both token and user/pass are provided, token auth will
@@ -56,10 +79,6 @@ pub struct Config {
     /// DNS IP to use in Tun device
     #[clap(long, default_value = "100.64.0.1")]
     pub tun_dns_ip: Ipv4Addr,
-
-    /// Cipher to use for encryption
-    #[clap(long, value_enum, default_value_t = Cipher::Aes256)]
-    pub cipher: Cipher,
 
     /// Enable Post Quantum Crypto
     #[cfg(feature = "postquantum")]
@@ -118,14 +137,6 @@ pub struct Config {
     #[clap(long, default_value = "100ms")]
     pub iouring_sqpoll_idle_time: Duration,
 
-    /// Server domain name
-    #[clap(long, default_value = None)]
-    pub server_dn: Option<String>,
-
-    /// Server to connect to
-    #[clap(short, long, default_value_t)]
-    pub server: String,
-
     /// Enable inside packet encoding once lightway connects
     /// Only used if a codec is set
     #[clap(short, long, default_value_t)]
@@ -151,5 +162,58 @@ impl Config {
                 "Either a token or username and password is required"
             )),
         }
+    }
+}
+
+#[config]
+#[derive(Parser, Debug, Serialize)]
+pub struct ConnectionConfig {
+    /// Server to connect to in <hostname>:<port> format
+    pub server: String,
+
+    /// Connection mode
+    #[serde(default)]
+    pub mode: ConnectionType,
+
+    /// Server domain name
+    #[serde(default)]
+    pub server_dn: Option<String>,
+
+    /// Cipher to use for encryption
+    #[serde(default)]
+    pub cipher: Cipher,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use clap::CommandFactory;
+    use test_case::test_case;
+    use twelf::Layer;
+
+    #[test_case("../tests/client/client_config.yaml", true, 0)]
+    #[test_case(
+        "../tests/client/parallel_connect/client_config.tcp_then_udp.yaml",
+        false,
+        2
+    )]
+    #[test_case("../tests/client/parallel_connect/client_config.tcp.yaml", false, 10)]
+    #[test_case(
+        "../tests/client/parallel_connect/client_config.udp_then_tcp.yaml",
+        false,
+        2
+    )]
+    #[test_case("../tests/client/parallel_connect/client_config.udp.yaml", false, 10)]
+    fn test_parse_config(config_file: &str, has_top_level_server: bool, servers_len: usize) {
+        let matches =
+            Config::command().get_matches_from(["lightway-client", "--config-file", config_file]);
+        let config_file = PathBuf::from_str(config_file).unwrap();
+        let config =
+            Config::with_layers(&[Layer::Yaml(config_file), Layer::Clap(matches)]).unwrap();
+
+        assert_eq!(config.server.is_empty(), !has_top_level_server);
+        assert_eq!(config.servers.len(), servers_len);
     }
 }

--- a/lightway-client/src/debug.rs
+++ b/lightway-client/src/debug.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use lightway_core::Tls13SecretCallbacks;
 
+#[derive(Debug, Clone)]
 pub(crate) struct WiresharkKeyLogger(pub(crate) PathBuf);
 
 impl WiresharkKeyLogger {

--- a/lightway-client/src/io/inside.rs
+++ b/lightway-client/src/io/inside.rs
@@ -15,12 +15,14 @@ use crate::ConnectionState;
 #[async_trait]
 /// Trait for InsideIORecv
 /// This will be used client app to fetch inside packets
-pub trait InsideIORecv<T: Send + Sync>: Send + Sync {
+pub trait InsideIORecv<ExtAppState: Send + Sync>: Send + Sync {
     async fn recv_buf(&self) -> IOCallbackResult<BytesMut>;
 
     fn try_send(&self, pkt: BytesMut, ip_config: Option<InsideIpConfig>) -> Result<usize>;
 
-    fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState<T>>;
+    fn into_io_send_callback(
+        self: Arc<Self>,
+    ) -> InsideIOSendCallbackArg<ConnectionState<ExtAppState>>;
 }
 
 /// Trait for InsideIO
@@ -28,15 +30,19 @@ pub trait InsideIORecv<T: Send + Sync>: Send + Sync {
 /// This is a super trait which includes both InsideIORecv and InsideIOSendCallback
 /// A default blanket implementation is provided, so users has to only implement
 /// InsideIORecv and InsideIOSendCallback in their data structures.
-pub trait InsideIO<T: Send + Sync = ()>:
-    InsideIORecv<T> + InsideIOSendCallback<ConnectionState<T>>
+pub trait InsideIO<ExtAppState: Send + Sync = ()>:
+    InsideIORecv<ExtAppState> + InsideIOSendCallback<ConnectionState<ExtAppState>>
 {
 }
 
 /// Default blanket implementation for InsideIO
 impl<
-    T: Send + Sync,
-    U: Send + Sync + Sized + InsideIOSendCallback<ConnectionState<T>> + InsideIORecv<T>,
-> InsideIO<T> for U
+    ExtAppState: Send + Sync,
+    U: Send
+        + Sync
+        + Sized
+        + InsideIOSendCallback<ConnectionState<ExtAppState>>
+        + InsideIORecv<ExtAppState>,
+> InsideIO<ExtAppState> for U
 {
 }

--- a/lightway-client/src/io/inside.rs
+++ b/lightway-client/src/io/inside.rs
@@ -15,12 +15,12 @@ use crate::ConnectionState;
 #[async_trait]
 /// Trait for InsideIORecv
 /// This will be used client app to fetch inside packets
-pub trait InsideIORecv: Sync + Send {
+pub trait InsideIORecv<T: Send + Sync>: Send + Sync {
     async fn recv_buf(&self) -> IOCallbackResult<BytesMut>;
 
     fn try_send(&self, pkt: BytesMut, ip_config: Option<InsideIpConfig>) -> Result<usize>;
 
-    fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState>;
+    fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState<T>>;
 }
 
 /// Trait for InsideIO
@@ -29,14 +29,14 @@ pub trait InsideIORecv: Sync + Send {
 /// A default blanket implementation is provided, so users has to only implement
 /// InsideIORecv and InsideIOSendCallback in their data structures.
 pub trait InsideIO<T: Send + Sync = ()>:
-    InsideIORecv + InsideIOSendCallback<ConnectionState<T>>
+    InsideIORecv<T> + InsideIOSendCallback<ConnectionState<T>>
 {
 }
 
 /// Default blanket implementation for InsideIO
 impl<
     T: Send + Sync,
-    U: Send + Sync + Sized + InsideIOSendCallback<ConnectionState<T>> + InsideIORecv,
+    U: Send + Sync + Sized + InsideIOSendCallback<ConnectionState<T>> + InsideIORecv<T>,
 > InsideIO<T> for U
 {
 }

--- a/lightway-client/src/io/inside/tun.rs
+++ b/lightway-client/src/io/inside/tun.rs
@@ -45,7 +45,7 @@ impl Tun {
 }
 
 #[async_trait]
-impl<T: Send + Sync> InsideIORecv<T> for Tun {
+impl<ExtAppState: Send + Sync> InsideIORecv<ExtAppState> for Tun {
     async fn recv_buf(&self) -> IOCallbackResult<BytesMut> {
         self.tun.recv_buf().await
     }
@@ -70,13 +70,19 @@ impl<T: Send + Sync> InsideIORecv<T> for Tun {
         Ok(pkt_len)
     }
 
-    fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState<T>> {
+    fn into_io_send_callback(
+        self: Arc<Self>,
+    ) -> InsideIOSendCallbackArg<ConnectionState<ExtAppState>> {
         self
     }
 }
 
-impl<T: Send + Sync> InsideIOSendCallback<ConnectionState<T>> for Tun {
-    fn send(&self, mut buf: BytesMut, state: &mut ConnectionState<T>) -> IOCallbackResult<usize> {
+impl<ExtAppState: Send + Sync> InsideIOSendCallback<ConnectionState<ExtAppState>> for Tun {
+    fn send(
+        &self,
+        mut buf: BytesMut,
+        state: &mut ConnectionState<ExtAppState>,
+    ) -> IOCallbackResult<usize> {
         // Update destination IP from server provided inside ip to TUN device ip
         ipv4_update_destination(buf.as_mut(), self.ip);
 

--- a/lightway-client/src/io/inside/tun.rs
+++ b/lightway-client/src/io/inside/tun.rs
@@ -45,7 +45,7 @@ impl Tun {
 }
 
 #[async_trait]
-impl InsideIORecv for Tun {
+impl<T: Send + Sync> InsideIORecv<T> for Tun {
     async fn recv_buf(&self) -> IOCallbackResult<BytesMut> {
         self.tun.recv_buf().await
     }
@@ -70,7 +70,7 @@ impl InsideIORecv for Tun {
         Ok(pkt_len)
     }
 
-    fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState<()>> {
+    fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState<T>> {
         self
     }
 }

--- a/lightway-client/src/io/inside/tun.rs
+++ b/lightway-client/src/io/inside/tun.rs
@@ -22,14 +22,14 @@ pub struct Tun {
 }
 
 impl Tun {
-    pub async fn new(tun: TunConfig, ip: Ipv4Addr, dns_ip: Ipv4Addr) -> Result<Self> {
+    pub async fn new(tun: &TunConfig, ip: Ipv4Addr, dns_ip: Ipv4Addr) -> Result<Self> {
         let tun = AppUtilsTun::direct(tun).await?;
         Ok(Tun { tun, ip, dns_ip })
     }
 
     #[cfg(feature = "io-uring")]
     pub async fn new_with_iouring(
-        tun: TunConfig,
+        tun: &TunConfig,
         ip: Ipv4Addr,
         dns_ip: Ipv4Addr,
         iouring_ring_size: usize,

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -567,7 +567,7 @@ impl<T: Send + Sync> ClientConnection<T> {
         inside_io,
     )
 )]
-pub async fn connect<EventHandler: 'static + Send + EventCallback, T: Send + Sync>(
+pub async fn connect<EventHandler: 'static + Send + EventCallback, T: Default + Send + Sync>(
     config: &ClientConfig<'_, T>,
     mut server_config: ClientConnectionConfig<EventHandler>,
     inside_io: Arc<dyn io::inside::InsideIO<T>>,
@@ -615,7 +615,7 @@ pub async fn connect<EventHandler: 'static + Send + EventCallback, T: Send + Syn
         ticker,
         ip_config: None,
         codec_ticker,
-        extended: (),
+        extended: Default::default(),
     };
     let (pmtud_timer, pmtud_timer_task) = DplpmtudTimer::new();
 
@@ -840,7 +840,7 @@ fn apply_platform_specific_config(
 }
 
 /// Launches connections concurrently and waits for the first one to complete.
-pub async fn client<EventHandler: 'static + Send + EventCallback, T: Send + Sync>(
+pub async fn client<EventHandler: 'static + Send + EventCallback, T: Default + Send + Sync>(
     mut config: ClientConfig<'_, T>,
     servers: Vec<ClientConnectionConfig<EventHandler>>,
 ) -> Result<ClientResult> {

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -532,16 +532,6 @@ fn validate_client_config<EventHandler: 'static + Send + EventCallback, T: Send 
                 server_config.server
             ));
         }
-
-        if let Some(inside_pkt_codec_config) = &config.inside_pkt_codec_config 
-            &&inside_pkt_codec_config.enable_encoding_at_connect
-            && matches!(server_config.mode, ClientConnectionMode::Stream(_))
-        {
-            return Err(anyhow!(
-                "inside pkt encoding should not be enabled with TCP. (Server: {})",
-                server_config.server
-            ));
-        }
     }
 
     Ok(())

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -86,8 +86,18 @@ async fn main() -> Result<()> {
         .next()
         .ok_or_else(|| anyhow!("No addresses resolved for server: {}", config.server))?;
 
-    let config = ClientConfig {
+    let server_config = ClientConnectionConfig {
+        server: server_addr,
         mode,
+        server_dn: config.server_dn,
+        cipher: config.cipher,
+        inside_plugins: Default::default(),
+        outside_plugins: Default::default(),
+        inside_pkt_codec: None,
+        event_handler: Some(EventHandler),
+    };
+
+    let config = ClientConfig {
         auth,
         root_ca_cert,
         outside_mtu: config.outside_mtu,
@@ -96,7 +106,6 @@ async fn main() -> Result<()> {
         tun_local_ip: config.tun_local_ip,
         tun_peer_ip: config.tun_peer_ip,
         tun_dns_ip: config.tun_dns_ip,
-        cipher: config.cipher,
         #[cfg(feature = "postquantum")]
         enable_pqc: config.enable_pqc,
         keepalive_interval: config.keepalive_interval.into(),
@@ -114,20 +123,14 @@ async fn main() -> Result<()> {
         iouring_entry_count: config.iouring_entry_count,
         #[cfg(feature = "io-uring")]
         iouring_sqpoll_idle_time: config.iouring_sqpoll_idle_time.into(),
-        server_dn: config.server_dn,
-        server: server_addr,
-        inside_plugins: Default::default(),
-        outside_plugins: Default::default(),
-        inside_pkt_codec: None,
         inside_pkt_codec_config: None,
         stop_signal: ctrlc_rx,
         network_change_signal: None,
-        event_handler: Some(EventHandler),
         #[cfg(feature = "debug")]
         tls_debug: config.tls_debug,
         #[cfg(feature = "debug")]
         keylog: config.keylog,
     };
 
-    client(config).await.map(|_| ())
+    client(config, server_config).await.map(|_| ())
 }

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -132,6 +132,7 @@ async fn main() -> Result<()> {
         keepalive_interval: config.keepalive_interval.into(),
         keepalive_timeout: config.keepalive_timeout.into(),
         continuous_keepalive: true,
+        preferred_connection_wait_interval: config.preferred_connection_wait_interval.into(),
         sndbuf: config.sndbuf,
         rcvbuf: config.rcvbuf,
         #[cfg(any(target_os = "linux", target_os = "macos",))]

--- a/lightway-server/src/io/inside/tun.rs
+++ b/lightway-server/src/io/inside/tun.rs
@@ -19,14 +19,14 @@ use std::time::Duration;
 pub(crate) struct Tun(AppUtilsTun);
 
 impl Tun {
-    pub async fn new(tun: TunConfig) -> Result<Self> {
+    pub async fn new(tun: &TunConfig) -> Result<Self> {
         let tun = AppUtilsTun::direct(tun).await?;
         Ok(Tun(tun))
     }
 
     #[cfg(feature = "io-uring")]
     pub async fn new_with_iouring(
-        tun: TunConfig,
+        tun: &TunConfig,
         ring_size: usize,
         sqpoll_idle_time: Duration,
     ) -> Result<Self> {

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -280,17 +280,17 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
         None => {
             use io::inside::Tun;
             #[cfg(not(feature = "io-uring"))]
-            let tun = Tun::new(config.tun_config).await;
+            let tun = Tun::new(&config.tun_config).await;
             #[cfg(feature = "io-uring")]
             let tun = if config.enable_tun_iouring {
                 Tun::new_with_iouring(
-                    config.tun_config,
+                    &config.tun_config,
                     config.iouring_entry_count,
                     config.iouring_sqpoll_idle_time,
                 )
                 .await
             } else {
-                Tun::new(config.tun_config).await
+                Tun::new(&config.tun_config).await
             };
 
             let tun = tun.context("Tun creation")?;

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -19,12 +19,21 @@ TEST:
     ARG SERVER_PORT
     ARG SERVER_EXTRA_ARGS=""
     ARG CLIENT_EXTRA_ARGS=""
+    ARG CLIENT_CONFIG_FILE="client_config.yaml"
+    ARG COMPOSE_FILE="./docker-compose.yml"
     ARG TEST_SCRIPT=./run-simple-test.sh
 
     ARG KYBER_CLIENT
 
-    ARG SERVER_ARGS="--config-file server_config.yaml --log-level trace --mode ${MODE} ${SERVER_EXTRA_ARGS} --bind-address 0.0.0.0:${SERVER_PORT}"
-    ARG CLIENT_ARGS="--config-file client_config.yaml --log-level trace --mode ${MODE} ${CLIENT_EXTRA_ARGS} --server server:${SERVER_PORT}"
+    ARG SERVER_ARGS="--config-file server_config.yaml --log-level trace ${SERVER_EXTRA_ARGS} --bind-address 0.0.0.0:${SERVER_PORT}"
+    ARG CLIENT_ARGS="--config-file ${CLIENT_CONFIG_FILE} --log-level trace ${CLIENT_EXTRA_ARGS} --server server:${SERVER_PORT}"
+
+    LET SERVER_ARGS=$SERVER_ARGS
+    LET CLIENT_ARGS=$CLIENT_ARGS
+    IF [ -n "$MODE" ]
+        SET SERVER_ARGS="$SERVER_ARGS --mode=$MODE"
+        SET CLIENT_ARGS="$CLIENT_ARGS --mode=$MODE"
+    END
 
     LET CLIENT_IMAGE_CMD="./client+build-container --TOKIO_WORKER_THREADS=$CLIENT_TOKIO_WORKER_THREADS --debian=$debian"
     IF [ "$KYBER_CLIENT" = "true" ]
@@ -40,7 +49,7 @@ TEST:
         --load lightway-test-server:latest=$SERVER_IMAGE \
         --load lightway-test-nginx:latest=$NGINX_IMAGE \
         --load lightway-test-iperf:latest=$IPERF_IMAGE
-        RUN --no-cache ./run-with-compose-stack.sh $TEST_SCRIPT
+        RUN --no-cache ./run-with-compose-stack.sh $COMPOSE_FILE $TEST_SCRIPT
     END
 
 # run-tcp-aes256-test runs e2e test using TCP and AES256 cipher
@@ -107,6 +116,22 @@ run-udp-single-threaded-test:
 run-tcp-single-threaded-test:
     DO +TEST --MODE=tcp --SERVER_PORT=443 --SERVER_TOKIO_WORKER_THREADS=1 --CLIENT_TOKIO_WORKER_THREADS=1 --CLIENT_EXTRA_ARGS="--keepalive-interval=2s --keepalive-timeout=6s --enable-pmtud"
 
+# run-tcp-parallel-connect-test runs e2e test of client connecting to multiple wrong servers and one TCP server
+run-tcp-parallel-connect-test:
+    DO +TEST --MODE=tcp --SERVER_PORT=27690 --CLIENT_CONFIG_FILE="parallel_connect/client_config.tcp.yaml" --TEST_SCRIPT="./run-simple-test.sh server_tcp"
+
+# run-udp-parallel-connect-test runs e2e test of client connecting to multiple wrong servers and one UDP server
+run-udp-parallel-connect-test:
+    DO +TEST --MODE=udp --SERVER_PORT=27690 --CLIENT_CONFIG_FILE="parallel_connect/client_config.udp.yaml" --TEST_SCRIPT="./run-simple-test.sh server_udp"
+
+# run-tcp-then-udp-parallel-connect-test runs e2e test of client connecting to a TCP and UDP server, with the TCP server as priority
+run-tcp-then-udp-parallel-connect-test:
+    DO +TEST --SERVER_PORT=27690 --CLIENT_CONFIG_FILE="parallel_connect/client_config.tcp_then_udp.yaml" --COMPOSE_FILE="docker-compose.parallel_connect.yml" --TEST_SCRIPT="./run-parallel-connect-test.sh server_tcp"
+
+# run-udp-then-tcp-parallel-connect-test runs e2e test of client connecting to a UDP and TCP server, with the UDP server as priority
+run-udp-then-tcp-parallel-connect-test:
+    DO +TEST --SERVER_PORT=27690 --CLIENT_CONFIG_FILE="parallel_connect/client_config.udp_then_tcp.yaml" --COMPOSE_FILE="docker-compose.parallel_connect.yml" --TEST_SCRIPT="./run-parallel-connect-test.sh server_udp"
+
 # run-token-auth-test runs a test of the token auth
 run-token-auth-test:
     DO +TEST --MODE=udp --SERVER_PORT=27690 --CLIENT_EXTRA_ARGS="--token eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjQ4ODMxMTM0MTZ9.gb0U7xTwxl7GDeKftKSZvnkkIDnoz8NmzJ4etukCjtZWzA4kSNbt84iTKOE14paRZdfE67tLGfcLsqA9uh-zuA_-ecZbiC4znz2CVVjhD2CIrW_0LQbHRbzYlOozjc108pct-VivtiPr7SqcIgRTjH59HTCDXtgp0kELhhr3NNfYP0-6DtadXQ_Twn2tcC3A-rTpfjwo7HDqnc43niCALXFhqR0F4DkEC3amKuOiP9afQ6dFmWVAzWXWEpQ_kK-EsCeBZ6K89GaF5quIErrV3U_FSwbX8biFB7S8VhkLqCoyabRKKprwp_mi24e91URgGqNvbCrXs2zrJMat-1zUvw" --SERVER_EXTRA_ARGS="--token-rsa-pub-key-pem /token.pub"
@@ -129,3 +154,7 @@ run-all-tests:
     BUILD +run-tcp-keepalive-test
     BUILD +run-udp-single-threaded-test
     BUILD +run-tcp-single-threaded-test
+    BUILD +run-tcp-parallel-connect-test
+    BUILD +run-udp-parallel-connect-test
+    BUILD +run-tcp-then-udp-parallel-connect-test
+    BUILD +run-udp-then-tcp-parallel-connect-test

--- a/tests/client/Earthfile
+++ b/tests/client/Earthfile
@@ -2,6 +2,7 @@ VERSION 0.8
 ARG --global debian
 
 build-container:
+    ARG SERVER_ADDR
     ARG TOKIO_WORKER_THREADS
     ARG KYBER_CLIENT
     FROM ../base+container --debian=$debian
@@ -11,9 +12,10 @@ build-container:
         COPY (../..+build/lightway-client --debian=$debian) .
     END
     COPY --dir ../certs+client/* tests/certs/
-    COPY --dir --chmod 0600 client_config.yaml .
-    COPY --dir docker-entrypoint.sh run-test-inside.sh .
+    COPY --dir --chmod 0600 client_config.yaml parallel_connect/ .
+    COPY --dir docker-entrypoint.sh run-test-inside.sh check-server.sh .
     HEALTHCHECK --interval=1s --timeout=1s --start-period=0s --retries=30 CMD ping -c1 nginx
+    ENV SERVER_ADDR=$SERVER_ADDR
     IF [ -n "$TOKIO_WORKER_THREADS" ]
         ENV TOKIO_WORKER_THREADS=$TOKIO_WORKER_THREADS
     END

--- a/tests/client/check-server.sh
+++ b/tests/client/check-server.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+expected_server_ip=$(dig +short A "$1" | head -1)
+connected_server_ip=$(ip --json route | jq -r '.[] | select((.dev == "eth0" and .protocol == "static")) | .dst')
+
+if [ "$connected_server_ip" != "$expected_server_ip" ]; then
+    echo "Server IP is incorrect: ${connected_server_ip}, expected: ${expected_server_ip} ($1)"
+    exit 1
+fi
+
+echo "Server IP is correct: ${connected_server_ip}"
+exit 0

--- a/tests/client/docker-entrypoint.sh
+++ b/tests/client/docker-entrypoint.sh
@@ -8,7 +8,13 @@ echo ""
 echo "====================================================================="
 echo "Ping server"
 echo "====================================================================="
-ping -W 1 -c 3 server
+
+config_file=$(echo "$@" | grep -oP '(?<=--config-file )\S+')
+echo "Using config file: $config_file"
+# Take the first entry of `servers` or the top-level `server` field
+server=$(grep -m1 'server: ' "$config_file" | sed -E 's/^[- ]*server: *(.+):.+$/\1/')
+echo "Server found: $server"
+ping -W 1 -c 3 "$server"
 
 echo ""
 echo "====================================================================="

--- a/tests/client/parallel_connect/client_config.tcp.yaml
+++ b/tests/client/parallel_connect/client_config.tcp.yaml
@@ -1,0 +1,72 @@
+---
+servers:
+  # Wrong port 1
+  - server: server:27691
+    mode: tcp
+    server_dn: goaway.com
+    cipher: aes256
+  # Wrong port 2
+  - server: server:27692
+    mode: tcp
+    server_dn: goaway.com
+    cipher: aes256
+  # Wrong port 3
+  - server: server:27693
+    mode: tcp
+    server_dn: goaway.com
+    cipher: aes256
+  # Wrong port 4
+  - server: server:27694
+    mode: tcp
+    server_dn: goaway.com
+    cipher: aes256
+  # Wrong port 5
+  - server: server:27695
+    mode: tcp
+    server_dn: goaway.com
+    cipher: aes256
+  # Wrong port 6
+  - server: server:27696
+    mode: tcp
+    server_dn: goaway.com
+    cipher: aes256
+  # Wrong port 7
+  - server: server:27697
+    mode: tcp
+    server_dn: goaway.com
+    cipher: aes256
+  # Wrong port 8
+  - server: server:27698
+    mode: tcp
+    server_dn: goaway.com
+    cipher: aes256
+  # Right server 1
+  - server: server:27690
+    mode: tcp
+    server_dn: goaway.com
+    cipher: aes256
+  # Right server 2
+  - server: server:27690
+    mode: tcp
+    server_dn: goaway.com
+    cipher: aes256
+ca_cert: "tests/certs/ca.crt"
+tun_name: lightway
+tun_local_ip: 100.64.0.6
+tun_peer_ip: 100.64.0.5
+tun_dns_ip: 100.64.0.1
+log_level: info
+user: user
+password: password
+outside_mtu: 1500
+enable_pqc: false
+enable_tun_iouring: false
+# iouring_sqpoll_idle_time: 100ms
+iouring_entry_count: 1024
+keepalive_interval: 0s
+keepalive_timeout: 0s
+enable_pmtud: false
+# sndbuf: 1.5 MiB
+# rcvbuf: 1.5 MiB
+route_mode: default
+preferred_connection_wait_interval: 2s

--- a/tests/client/parallel_connect/client_config.tcp_then_udp.yaml
+++ b/tests/client/parallel_connect/client_config.tcp_then_udp.yaml
@@ -1,0 +1,30 @@
+---
+servers:
+  - server: server_tcp:27690
+    mode: tcp
+    server_dn: goaway.com
+    cipher: aes256
+  - server: server_udp:27690
+    mode: udp
+    server_dn: goaway.com
+    cipher: aes256
+ca_cert: "tests/certs/ca.crt"
+tun_name: lightway
+tun_local_ip: 100.64.0.6
+tun_peer_ip: 100.64.0.5
+tun_dns_ip: 100.64.0.1
+log_level: info
+user: user
+password: password
+outside_mtu: 1500
+enable_pqc: false
+enable_tun_iouring: false
+# iouring_sqpoll_idle_time: 100ms
+iouring_entry_count: 1024
+keepalive_interval: 0s
+keepalive_timeout: 0s
+enable_pmtud: false
+# sndbuf: 1.5 MiB
+# rcvbuf: 1.5 MiB
+route_mode: default
+preferred_connection_wait_interval: 2s

--- a/tests/client/parallel_connect/client_config.udp.yaml
+++ b/tests/client/parallel_connect/client_config.udp.yaml
@@ -1,0 +1,72 @@
+---
+servers:
+  # Wrong port 1
+  - server: server:27691
+    mode: udp
+    server_dn: goaway.com
+    cipher: aes256
+  # Wrong port 2
+  - server: server:27692
+    mode: udp
+    server_dn: goaway.com
+    cipher: aes256
+  # Wrong port 3
+  - server: server:27693
+    mode: udp
+    server_dn: goaway.com
+    cipher: aes256
+  # Wrong port 4
+  - server: server:27694
+    mode: udp
+    server_dn: goaway.com
+    cipher: aes256
+  # Wrong port 5
+  - server: server:27695
+    mode: udp
+    server_dn: goaway.com
+    cipher: aes256
+  # Wrong port 6
+  - server: server:27696
+    mode: udp
+    server_dn: goaway.com
+    cipher: aes256
+  # Wrong port 7
+  - server: server:27697
+    mode: udp
+    server_dn: goaway.com
+    cipher: aes256
+  # Wrong port 8
+  - server: server:27698
+    mode: udp
+    server_dn: goaway.com
+    cipher: aes256
+  # Right server 1
+  - server: server:27690
+    mode: udp
+    server_dn: goaway.com
+    cipher: aes256
+  # Right server 2
+  - server: server:27690
+    mode: udp
+    server_dn: goaway.com
+    cipher: aes256
+ca_cert: "tests/certs/ca.crt"
+tun_name: lightway
+tun_local_ip: 100.64.0.6
+tun_peer_ip: 100.64.0.5
+tun_dns_ip: 100.64.0.1
+log_level: info
+user: user
+password: password
+outside_mtu: 1500
+enable_pqc: false
+enable_tun_iouring: false
+# iouring_sqpoll_idle_time: 100ms
+iouring_entry_count: 1024
+keepalive_interval: 0s
+keepalive_timeout: 0s
+enable_pmtud: false
+# sndbuf: 1.5 MiB
+# rcvbuf: 1.5 MiB
+route_mode: default
+preferred_connection_wait_interval: 2s

--- a/tests/client/parallel_connect/client_config.udp_then_tcp.yaml
+++ b/tests/client/parallel_connect/client_config.udp_then_tcp.yaml
@@ -1,0 +1,30 @@
+---
+servers:
+  - server: server_udp:27690
+    mode: udp
+    server_dn: goaway.com
+    cipher: aes256
+  - server: server_tcp:27690
+    mode: tcp
+    server_dn: goaway.com
+    cipher: aes256
+ca_cert: "tests/certs/ca.crt"
+tun_name: lightway
+tun_local_ip: 100.64.0.6
+tun_peer_ip: 100.64.0.5
+tun_dns_ip: 100.64.0.1
+log_level: info
+user: user
+password: password
+outside_mtu: 1500
+enable_pqc: false
+enable_tun_iouring: false
+# iouring_sqpoll_idle_time: 100ms
+iouring_entry_count: 1024
+keepalive_interval: 0s
+keepalive_timeout: 0s
+enable_pmtud: false
+# sndbuf: 1.5 MiB
+# rcvbuf: 1.5 MiB
+route_mode: default
+preferred_connection_wait_interval: 2s

--- a/tests/e2e/Earthfile
+++ b/tests/e2e/Earthfile
@@ -2,5 +2,12 @@ VERSION 0.8
 
 build-container:
     FROM earthly/dind:ubuntu
-    COPY docker-compose.yml run-with-compose-stack.sh run-simple-test.sh run-udp-floating-test.sh .
+    COPY \
+        docker-compose.yml \
+        docker-compose.parallel_connect.yml \
+        run-with-compose-stack.sh \
+        run-simple-test.sh \
+        run-udp-floating-test.sh \
+        run-parallel-connect-test.sh \
+        .
 

--- a/tests/e2e/docker-compose.parallel_connect.yml
+++ b/tests/e2e/docker-compose.parallel_connect.yml
@@ -1,0 +1,85 @@
+name: lightway-e2e
+
+networks:
+  frontend: # client <-> server
+    driver: bridge
+    internal: true
+    ipam:
+      config:
+        - subnet: 192.168.200.0/24
+
+  backend: # server <-> The World
+    driver: bridge
+    internal: true
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.0.0.0/16
+
+services:
+  server_udp:
+    image: lightway-test-server:latest
+    command: ${SERVER_ARGS} --mode udp
+    stop_signal: SIGTERM
+    stop_grace_period: 10s
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - "/dev/net/tun:/dev/net/tun"
+    networks:
+      - frontend
+      - backend
+
+  server_tcp:
+    image: lightway-test-server:latest
+    command: ${SERVER_ARGS} --mode tcp
+    stop_signal: SIGTERM
+    stop_grace_period: 10s
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - "/dev/net/tun:/dev/net/tun"
+    networks:
+      - frontend
+      - backend
+
+  nginx:
+    image: lightway-test-nginx:latest
+    networks:
+      backend:
+        ipv4_address: 10.0.0.42
+
+  iperf:
+    image: lightway-test-iperf:latest
+    networks:
+      backend:
+        ipv4_address: 10.0.0.43
+
+  client:
+    image: lightway-test-client:latest
+    command: ${CLIENT_ARGS}
+    stop_signal: SIGTERM
+    stop_grace_period: 10s
+    sysctls:
+      # Ensure that `$new_ip` becomes the primary when `$current_ip`
+      # is removed. Otherwise all addresses are removed which breaks
+      # the UDP floating test.
+      - net.ipv4.conf.all.promote_secondaries=1
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - "/dev/net/tun:/dev/net/tun"
+    depends_on:
+      server_udp:
+        condition: service_healthy
+      server_tcp:
+        condition: service_healthy
+      nginx:
+        condition: service_healthy
+      iperf:
+        condition: service_healthy
+    networks:
+      - frontend
+    extra_hosts:
+      nginx: "10.0.0.42"
+      iperf: "10.0.0.43"

--- a/tests/e2e/run-parallel-connect-test.sh
+++ b/tests/e2e/run-parallel-connect-test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+
+docker compose exec client ./check-server.sh "$1"
+
+docker compose exec client ./run-test-inside.sh


### PR DESCRIPTION
Adds support for multiple server connections in lightway-client. The servers are connected in parallel and after the "best connection" is chosen, all other connections are disconnected.

## Description
The configuration file now supports specifying multiple servers via the `servers` field, and falls back to the single-server configuration if `servers` is not specified. This maintains full backward compatibility with existing server configurations.

The client attempts to connect to all servers at once. After the first connection is established, if `defer_connect_timeout` is set, we wait that duration before choosing the best connection. The best connection is the first connection in the order of the original list of servers that manages to connect within the specified `defer_connect_timeout`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improves connection speed compared to connecting to each server sequentially.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Configuration parsing tests for single and multi-server configurations
e2e test for connecting to multiple servers at once

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
