### PR TITLE
CVPN-2123 Static Routing to Socket IP instead of Server IP

### DIFF
--- a/lightway-client/src/io/outside.rs
+++ b/lightway-client/src/io/outside.rs
@@ -7,7 +7,7 @@ pub use udp::Udp;
 use anyhow::Result;
 use async_trait::async_trait;
 use lightway_core::{IOCallbackResult, OutsideIOSendCallbackArg};
-use std::sync::Arc;
+use std::{net::SocketAddr, sync::Arc};
 
 #[async_trait]
 pub trait OutsideIO: Sync + Send {
@@ -19,4 +19,6 @@ pub trait OutsideIO: Sync + Send {
     fn recv_buf(&self, buf: &mut bytes::BytesMut) -> IOCallbackResult<usize>;
 
     fn into_io_send_callback(self: Arc<Self>) -> OutsideIOSendCallbackArg;
+
+    fn peer_addr(&self) -> SocketAddr;
 }

--- a/lightway-client/src/io/outside/tcp.rs
+++ b/lightway-client/src/io/outside/tcp.rs
@@ -18,6 +18,10 @@ impl Tcp {
         let peer_addr = sock.peer_addr()?;
         Ok(Arc::new(Self(sock, peer_addr)))
     }
+
+    fn peer_addr(&self) -> SocketAddr {
+        self.1
+    }
 }
 
 #[async_trait]
@@ -55,6 +59,10 @@ impl OutsideIO for Tcp {
     fn into_io_send_callback(self: Arc<Self>) -> OutsideIOSendCallbackArg {
         self
     }
+
+    fn peer_addr(&self) -> SocketAddr {
+        self.peer_addr()
+    }
 }
 
 impl OutsideIOSendCallback for Tcp {
@@ -69,6 +77,6 @@ impl OutsideIOSendCallback for Tcp {
     }
 
     fn peer_addr(&self) -> SocketAddr {
-        self.1
+        self.peer_addr()
     }
 }

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -44,6 +44,10 @@ impl Udp {
             default_ip_pmtudisc,
         }))
     }
+
+    fn peer_addr(&self) -> SocketAddr {
+        self.peer_addr
+    }
 }
 
 #[async_trait]
@@ -76,6 +80,10 @@ impl OutsideIO for Udp {
 
     fn into_io_send_callback(self: Arc<Self>) -> OutsideIOSendCallbackArg {
         self
+    }
+
+    fn peer_addr(&self) -> SocketAddr {
+        self.peer_addr()
     }
 }
 
@@ -121,7 +129,7 @@ impl OutsideIOSendCallback for Udp {
     }
 
     fn peer_addr(&self) -> SocketAddr {
-        self.peer_addr
+        self.peer_addr()
     }
 
     fn enable_pmtud_probe(&self) -> std::io::Result<()> {

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -626,7 +626,7 @@ pub async fn client<A: 'static + Send + EventCallback, T: Send + Sync>(
     ))]
     route_table
         .initialize_routing_table(
-            &config.server.ip(),
+            &outside_io.peer_addr().ip(),
             tun_index,
             &config.tun_peer_ip.into(),
             &config.tun_dns_ip.into(),


### PR DESCRIPTION
Static routing to the server IP works only when the socket connects directly. In cases where connections are relayed, this approach fails. The correct IP to exclude from the VPN route should instead be derived from the OutsideIO struct, which reflects the actual remote endpoint.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CI tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
