### PR TITLE
ci: use | instead of / in sed expression

### DIFF
--- a/.github/workflows/weekly-cargo-update.yaml
+++ b/.github/workflows/weekly-cargo-update.yaml
@@ -81,7 +81,7 @@ jobs:
 
         if [ -n "$expected_hash" ]; then
           # Update with the correct hash
-          sed -i 's/"wolfssl-3.0.0" = "sha256-[^"]*"/"wolfssl-3.0.0" = "sha256-'$expected_hash'"/' flake.nix
+          sed -i 's|"wolfssl-3.0.0" = "sha256-[^"]*"|"wolfssl-3.0.0" = "sha256-'$expected_hash'"|' flake.nix
           echo "Updated wolfssl hash in flake.nix to: sha256-$expected_hash"
         else
           echo "Warning: Could not determine correct wolfssl hash from nix build output"


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

use | instead of / in sed expression 
Sha256 value of cargo is base64 encoded string. So it can have / and + in addition to alphanumeric characters.
This messes up the sed expression when the expected output have `/`

Fix it by using `|`

## Motivation and Context

CI failed when updating wolfssl
https://github.com/expressvpn/lightway/actions/runs/16587896125/job/46916736346

## How Has This Been Tested?
Verified sed expression succeeded with / in expected output

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
