### PR TITLE
client: fix route_table not working on macos

### DIFF
--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -48,4 +48,4 @@ tun.workspace = true
 serial_test = "3.2.0"
 
 [target.'cfg(any(target_os = "freebsd", target_os = "linux", target_os = "macos", target_os = "openbsd", target_os = "windows"))'.dependencies]
-route_manager = { version = "0.2.0", features = ["async"] }
+route_manager = { git = "https://github.com/kp-brandon-chew/route_manager.git", branch = "fix-macos-missing-host-and-gateway-flags", features = ["async"] }


### PR DESCRIPTION
The route manager crate does not allow us to add routes with flag UGH on macos. 
This changes references a fork of the crate that has been patched to fix this.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
