### PR TITLE
Server: Add debug option for disabling Ippool randomize 

### DIFF
--- a/lightway-core/src/utils.rs
+++ b/lightway-core/src/utils.rs
@@ -146,7 +146,7 @@ pub fn ipv4_adjust_packet_checksum(mut packet: MutableIpv4Packet, updates: Check
 pub fn ipv4_update_source(buf: &mut [u8], ip: Ipv4Addr) {
     let packet = MutableIpv4Packet::new(buf);
     let Some(mut packet) = packet else {
-        warn!("Invalid packet size (less than Ipv4 header)!");
+        warn!("Ipv4 src update: Invalid packet size {:?}!", buf.len());
         return;
     };
 
@@ -162,7 +162,7 @@ pub fn ipv4_update_source(buf: &mut [u8], ip: Ipv4Addr) {
 pub fn ipv4_update_destination(buf: &mut [u8], ip: Ipv4Addr) {
     let packet = MutableIpv4Packet::new(buf);
     let Some(mut packet) = packet else {
-        warn!("Invalid packet size (less than Ipv4 header)!");
+        warn!("Ipv4 dest update: Invalid packet size {:?}!", buf.len());
         return;
     };
 

--- a/lightway-server/src/args.rs
+++ b/lightway-server/src/args.rs
@@ -115,4 +115,10 @@ pub struct Config {
     #[cfg(feature = "debug")]
     #[clap(long)]
     pub tls_debug: bool,
+
+    /// Disable IP pool randomization
+    /// Should be used for debugging only
+    #[cfg(feature = "debug")]
+    #[clap(long, default_value_t = true)]
+    pub randomize_ippool: bool,
 }

--- a/lightway-server/src/ip_manager.rs
+++ b/lightway-server/src/ip_manager.rs
@@ -72,8 +72,14 @@ impl<T> IpManager<T> {
         reserved_ips: impl IntoIterator<Item = Ipv4Addr>,
         static_ip_config: InsideIpConfig,
         use_dynamic_client_ip: bool,
+        randomize_ippool: bool,
     ) -> Self {
         let mut ip_pool = IpPool::new(ip_pool, reserved_ips);
+        if randomize_ippool {
+            ip_pool.shuffle_ips();
+        } else {
+            tracing::warn!("IpPool not randomized");
+        }
 
         let ip_map = ip_map
             .into_iter()
@@ -203,6 +209,7 @@ mod tests {
             [local_ip, dns_ip],
             get_static_ip_config(),
             use_dynamic_client_ip,
+            true,
         )
     }
 
@@ -394,6 +401,7 @@ mod tests {
             [local_ip, dns_ip, reserved_ip1, reserved_ip2],
             get_static_ip_config(),
             false,
+            true,
         );
         // Allocate every possible IP and check we never get a reserved one
         let mut count = 0;

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -177,6 +177,8 @@ async fn main() -> Result<()> {
         bind_address: config.bind_address,
         proxy_protocol: config.proxy_protocol,
         udp_buffer_size: config.udp_buffer_size,
+        #[cfg(feature = "debug")]
+        randomize_ippool: config.randomize_ippool,
     };
 
     server(config).await


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add cli option to disable ip pool randomization

This configuration is not available as default, and should not be used in production.
It can be used for debugging purposes only.

## Motivation and Context

Make testing or debugging easier, by disable Ip pool randomization.

## How Has This Been Tested?
Verified the config is enabled only when `debug` feature is enabled.

Added unit tests to test Ip pool with and without randomization

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
