### PR TITLE
client: remove unsupported operating systems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,7 +1288,6 @@ dependencies = [
  "tracing-subscriber",
  "tun",
  "twelf",
- "windows",
 ]
 
 [[package]]
@@ -2942,28 +2941,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-link",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,17 +2951,6 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
 ]
 
 [[package]]
@@ -3014,16 +2980,6 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core",
- "windows-link",
-]
 
 [[package]]
 name = "windows-result"
@@ -3101,15 +3057,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -47,8 +47,5 @@ test-case.workspace = true
 tun.workspace = true
 serial_test = "3.2.0"
 
-[target.'cfg(any(target_os = "freebsd", target_os = "linux", target_os = "macos", target_os = "openbsd", target_os = "windows"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 route_manager = { git = "https://github.com/rustp2p/route_manager.git", rev = "refs/pull/10/head", features = ["async"] }
-
-[target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.61.3", features = ["Win32_Foundation"] }

--- a/lightway-client/src/args.rs
+++ b/lightway-client/src/args.rs
@@ -87,13 +87,7 @@ pub struct Config {
     ///     noexec : Does not setup any routes
     ///     lan    : Sets up default + additional lan routes
     #[clap(long, value_enum, default_value_t = RouteMode::Default)]
-    #[cfg(any(
-        target_os = "freebsd",
-        target_os = "linux",
-        target_os = "macos",
-        target_os = "openbsd",
-        target_os = "windows"
-    ))]
+    #[cfg(any(target_os = "linux", target_os = "macos",))]
     pub route_mode: RouteMode,
 
     /// Log level to use

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -1,13 +1,7 @@
 mod debug;
 pub mod io;
 pub mod keepalive;
-#[cfg(any(
-    target_os = "freebsd",
-    target_os = "linux",
-    target_os = "macos",
-    target_os = "openbsd",
-    target_os = "windows"
-))]
+#[cfg(any(target_os = "linux", target_os = "macos",))]
 pub mod routing_table;
 
 use anyhow::{Context, Result, anyhow};
@@ -31,13 +25,7 @@ use tokio::sync::mpsc::UnboundedReceiver;
 
 #[cfg(feature = "debug")]
 use crate::debug::WiresharkKeyLogger;
-#[cfg(any(
-    target_os = "freebsd",
-    target_os = "linux",
-    target_os = "macos",
-    target_os = "openbsd",
-    target_os = "windows"
-))]
+#[cfg(any(target_os = "linux", target_os = "macos",))]
 use crate::routing_table::{RouteMode, RoutingTable};
 #[cfg(feature = "debug")]
 use lightway_app_utils::wolfssl_tracing_callback;
@@ -144,13 +132,7 @@ pub struct ClientConfig<'cert, A: 'static + Send + EventCallback, T: Send + Sync
     pub rcvbuf: Option<ByteSize>,
 
     /// Route Mode
-    #[cfg(any(
-        target_os = "freebsd",
-        target_os = "linux",
-        target_os = "macos",
-        target_os = "openbsd",
-        target_os = "windows"
-    ))]
+    #[cfg(any(target_os = "linux", target_os = "macos",))]
     pub route_mode: RouteMode,
 
     /// Enable PMTU discovery for Udp connections
@@ -609,21 +591,9 @@ pub async fn client<A: 'static + Send + EventCallback, T: Send + Sync>(
     };
 
     let tun_index: u32 = inside_io.if_index()?.try_into()?;
-    #[cfg(any(
-        target_os = "freebsd",
-        target_os = "linux",
-        target_os = "macos",
-        target_os = "openbsd",
-        target_os = "windows"
-    ))]
+    #[cfg(any(target_os = "linux", target_os = "macos",))]
     let mut route_table = RoutingTable::new(config.route_mode)?;
-    #[cfg(any(
-        target_os = "freebsd",
-        target_os = "linux",
-        target_os = "macos",
-        target_os = "openbsd",
-        target_os = "windows"
-    ))]
+    #[cfg(any(target_os = "linux", target_os = "macos",))]
     route_table
         .initialize_routing_table(
             &outside_io.peer_addr().ip(),

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -104,13 +104,7 @@ async fn main() -> Result<()> {
         continuous_keepalive: true,
         sndbuf: config.sndbuf,
         rcvbuf: config.rcvbuf,
-        #[cfg(any(
-            target_os = "freebsd",
-            target_os = "linux",
-            target_os = "macos",
-            target_os = "openbsd",
-            target_os = "windows"
-        ))]
+        #[cfg(any(target_os = "linux", target_os = "macos",))]
         route_mode: config.route_mode,
         enable_pmtud: config.enable_pmtud,
         pmtud_base_mtu: config.pmtud_base_mtu,

--- a/lightway-client/src/routing_table.rs
+++ b/lightway-client/src/routing_table.rs
@@ -153,16 +153,8 @@ impl RoutingTable {
 
     fn is_route_exists_error(&self, error: &std::io::Error) -> bool {
         match error.raw_os_error() {
-            #[cfg(any(
-                target_os = "linux",
-                target_os = "macos",
-                target_os = "freebsd",
-                target_os = "openbsd",
-                target_os = "netbsd"
-            ))]
+            #[cfg(any(target_os = "linux", target_os = "macos",))]
             Some(libc::EEXIST) => true,
-            #[cfg(target_os = "windows")]
-            Some(val) if val == windows::Win32::Foundation::ERROR_ALREADY_EXISTS.0 as i32 => true,
             _ => false,
         }
     }


### PR DESCRIPTION
Changing target_os configuration to be macos and linux only.

This is to prevent the impression of supporting
platforms we do not currently intend to support

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed target_os for windows and BSD variants, keeping only macos and linux.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
target_os configuration currently is set to match the route_manager crate.
This may mislead end users to think that the repo supports all those platforms.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
cargo test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
