### PR TITLE
client: update route_manager to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,8 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "route_manager"
-version = "0.2.5"
-source = "git+https://github.com/rustp2p/route_manager.git?rev=refs%2Fpull%2F10%2Fhead#6d7e800ca6c1eb9a469c8f0b7fe27aead31a9140"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f8623f8f002a57e28fd382a3c8d99156f262cfd9f91d56337238450e41d02e"
 dependencies = [
  "bindgen",
  "flume",

--- a/deny.toml
+++ b/deny.toml
@@ -82,7 +82,6 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     "https://github.com/expressvpn/wolfssl-rs",
-    "https://github.com/rustp2p/route_manager.git",
 ]
 
 # See https://github.com/briansmith/ring/blob/main/LICENSE Ring

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,6 @@
                 ];
                 cargoLock.outputHashes = {
                   "wolfssl-3.0.0" = "sha256-eITRuPeZOb/kcFmtIddDnTtfWsS5LEhQP4S8mknFO/0=";
-                  "route_manager-0.2.5" = "sha256-7CSWbMG6NyFfipuE99k4QNGNVv7a3Ll8CytoUfcy2Mc=bu";
                 };
               };
 

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -48,4 +48,4 @@ tun.workspace = true
 serial_test = "3.2.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-route_manager = { git = "https://github.com/rustp2p/route_manager.git", rev = "refs/pull/10/head", features = ["async"] }
+route_manager = { version = "0.2.6", features = ["async"] }


### PR DESCRIPTION
This updates route_manager to the latest version which includes fixes that nullify https://github.com/expressvpn/lightway/pull/244

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
route_manager now uses version 0.2.6

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously we were tracking the version of a PR that fixed the issue. Since it has been merged we can revert to just using crate.io

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified that routes were indeed setup as expected.
cargo test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
