### PR TITLE
client: Added flag for dns_config options

### DIFF
--- a/lightway-client/src/args.rs
+++ b/lightway-client/src/args.rs
@@ -110,7 +110,7 @@ pub struct Config {
     ///     default: Sets up routes as specified in server, tun_local_ip, tun_peer_ip, tun_dns_ip
     ///     noexec : Does not setup any routes
     ///     lan    : Sets up default + additional lan routes
-    #[clap(long, value_enum, default_value_t = RouteMode::Default)]
+    #[clap(long, value_enum, default_value_t)]
     #[cfg(any(target_os = "linux", target_os = "macos",))]
     pub route_mode: RouteMode,
 

--- a/lightway-client/src/args.rs
+++ b/lightway-client/src/args.rs
@@ -1,3 +1,4 @@
+use super::dns_manager::DnsConfigMode;
 use super::routing_table::RouteMode;
 use anyhow::{Result, anyhow};
 use bytesize::ByteSize;
@@ -113,6 +114,14 @@ pub struct Config {
     #[clap(long, value_enum, default_value_t)]
     #[cfg(any(target_os = "linux", target_os = "macos",))]
     pub route_mode: RouteMode,
+
+    /// DNS configuration mode
+    /// Modes:
+    ///     default: Sets up DNS Configuration based on target platform
+    ///     noexec : Skips DNS Configuration setup
+    #[clap(long, value_enum, default_value_t)]
+    #[cfg(any(target_os = "linux", target_os = "macos",))]
+    pub dns_config_mode: DnsConfigMode,
 
     /// Log level to use
     #[clap(long, value_enum, default_value_t = LogLevel::Info)]

--- a/lightway-client/src/dns_manager.rs
+++ b/lightway-client/src/dns_manager.rs
@@ -1,5 +1,15 @@
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::warn;
+
+/// DNS configuration mode
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum DnsConfigMode {
+    #[default]
+    Default,
+    NoExec,
+}
 #[derive(Error, Debug)]
 pub enum DnsManagerError {
     #[error("Unable to find primary service ID")]

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -137,6 +137,8 @@ async fn main() -> Result<()> {
         rcvbuf: config.rcvbuf,
         #[cfg(any(target_os = "linux", target_os = "macos",))]
         route_mode: config.route_mode,
+        #[cfg(any(target_os = "linux", target_os = "macos",))]
+        dns_config_mode: config.dns_config_mode,
         enable_pmtud: config.enable_pmtud,
         pmtud_base_mtu: config.pmtud_base_mtu,
         #[cfg(feature = "io-uring")]

--- a/lightway-client/src/routing_table.rs
+++ b/lightway-client/src/routing_table.rs
@@ -48,9 +48,10 @@ const TUNNEL_ROUTES: [(IpAddr, u8); 2] = [
     ),
 ];
 
-#[derive(Debug, PartialEq, Copy, Clone, clap::ValueEnum, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Copy, Clone, clap::ValueEnum, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum RouteMode {
+    #[default]
     Default,
     Lan,
     NoExec,

--- a/tests/client/client_config.yaml
+++ b/tests/client/client_config.yaml
@@ -22,3 +22,4 @@ enable_pmtud: false
 # sndbuf: 1.5 MiB
 # rcvbuf: 1.5 MiB
 route_mode: default
+dns_config_mode: default

--- a/tests/client/parallel_connect/client_config.tcp.yaml
+++ b/tests/client/parallel_connect/client_config.tcp.yaml
@@ -69,4 +69,5 @@ enable_pmtud: false
 # sndbuf: 1.5 MiB
 # rcvbuf: 1.5 MiB
 route_mode: default
+dns_config_mode: default
 preferred_connection_wait_interval: 2s

--- a/tests/client/parallel_connect/client_config.tcp_then_udp.yaml
+++ b/tests/client/parallel_connect/client_config.tcp_then_udp.yaml
@@ -27,4 +27,5 @@ enable_pmtud: false
 # sndbuf: 1.5 MiB
 # rcvbuf: 1.5 MiB
 route_mode: default
+dns_config_mode: default
 preferred_connection_wait_interval: 2s

--- a/tests/client/parallel_connect/client_config.udp.yaml
+++ b/tests/client/parallel_connect/client_config.udp.yaml
@@ -69,4 +69,5 @@ enable_pmtud: false
 # sndbuf: 1.5 MiB
 # rcvbuf: 1.5 MiB
 route_mode: default
+dns_config_mode: default
 preferred_connection_wait_interval: 2s

--- a/tests/client/parallel_connect/client_config.udp_then_tcp.yaml
+++ b/tests/client/parallel_connect/client_config.udp_then_tcp.yaml
@@ -27,4 +27,5 @@ enable_pmtud: false
 # sndbuf: 1.5 MiB
 # rcvbuf: 1.5 MiB
 route_mode: default
+dns_config_mode: default
 preferred_connection_wait_interval: 2s


### PR DESCRIPTION
This PR aims to provide users the option to setup the DNS configuration.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We provide a `dns_config_mode` flag which users can set to `Default` or `NoExec` 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Grants users more power to customize runtime behaviour. On some platforms, not all runs will require DNS configuration.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
unittests
Running the VPN in both modes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
