### PR TITLE
CVPN-2114: Migration tun to tun-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,9 +205,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
-version = "0.72.0"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
 dependencies = [
  "anstream",
  "anstyle",
@@ -522,7 +522,7 @@ version = "3.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
 dependencies = [
- "nix",
+ "nix 0.30.1",
  "windows-sys 0.59.0",
 ]
 
@@ -609,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "75d7cc94194b4dd0fa12845ef8c911101b7f37633cda14997a6e82099aa0b693"
 dependencies = [
  "powerfmt",
  "serde",
@@ -727,6 +727,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endian-type"
@@ -957,6 +966,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getifaddrs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c016cebf305060d144de015c98191ede05c210af588857bc2d4f8611c04663"
+dependencies = [
+ "bitflags",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,7 +998,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.3+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1246,6 +1266,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "clap",
+ "educe",
  "fs-mistrust",
  "humantime",
  "io-uring",
@@ -1265,7 +1286,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "tun",
+ "tun-rs",
 ]
 
 [[package]]
@@ -1298,7 +1319,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "tun",
+ "tun-rs",
  "twelf",
 ]
 
@@ -1412,6 +1433,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
+]
+
+[[package]]
 name = "md-5"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,6 +1458,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "metrics"
@@ -1489,12 +1529,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
+name = "msbuild"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f10d2a26dd8489c4b0dce152371d6f1aabbc9cf52855089bca00a3ce5fdca3"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "netconfig-rs"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "207561c8758738388c2fd851c3e759f503583d8dd70ddc895baae806753ad4c9"
+dependencies = [
+ "cfg-if",
+ "core-foundation",
+ "ipnet",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-sys",
+ "nix 0.30.1",
+ "scopeguard",
+ "system-configuration-sys 0.5.0",
+ "thiserror 2.0.16",
+ "widestring",
+ "windows",
 ]
 
 [[package]]
@@ -1557,6 +1627,19 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -1565,6 +1648,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1585,12 +1669,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1685,12 +1768,6 @@ checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -2496,7 +2573,17 @@ checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2603,12 +2690,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "8ca967379f9d8eb8058d86ed467d81d03e81acd45757e4ca341c24affbe8e8e3"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -2618,15 +2704,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "a9108bb380861b07264b950ded55a44a14a4adc68b9f5efd85aafc3aa4d40a68"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "7182799245a7264ce590b349d90338f1c1affad93d2639aed5f8f69c090b334c"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2768,9 +2854,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "nu-ansi-term",
  "serde",
@@ -2784,24 +2870,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "tun"
-version = "0.8.3"
+name = "tun-rs"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f110bfadae3e3582b6b817eb5bc17937697cb352aa83fa122a482fea59e442"
+checksum = "49f0699ba6cb89fd48f243b325d5943ec8ecf46fec969ceee2228b1e2f34a74a"
 dependencies = [
+ "blocking",
+ "byteorder",
  "bytes",
- "cfg-if",
- "futures",
- "futures-core",
+ "c2rust-bitfields",
+ "encoding_rs",
+ "getifaddrs",
  "ipnet",
  "libc",
+ "libloading",
  "log",
- "nix",
- "thiserror 2.0.16",
+ "mac_address",
+ "netconfig-rs",
+ "nix 0.30.1",
+ "route_manager",
+ "scopeguard",
  "tokio",
- "tokio-util",
+ "widestring",
  "windows-sys 0.60.2",
- "wintun-bindings",
+ "winreg",
 ]
 
 [[package]]
@@ -2876,11 +2968,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.3+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2952,6 +3044,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,6 +3072,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2984,6 +3104,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3013,6 +3144,16 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -3090,6 +3231,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3208,34 +3358,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "wintun-bindings"
-version = "0.7.32"
+name = "wit-bindgen"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88303b411e20a1319b368dcd04db1480003ed46ac35193e139f542720b15fbf"
-dependencies = [
- "blocking",
- "c2rust-bitfields",
- "futures",
- "libloading",
- "log",
- "thiserror 2.0.16",
- "windows-sys 0.60.2",
- "winreg",
-]
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 
 [[package]]
 name = "wolfssl"
 version = "3.0.0"
-source = "git+https://github.com/expressvpn/wolfssl-rs#8d160c21b5ddc34d39a3a7e22247fd7bb6e42851"
+source = "git+https://github.com/expressvpn/wolfssl-rs#1e38d827acd15dd3fa09e8b7ecd5f2eddba3574a"
 dependencies = [
  "bytes",
  "log",
@@ -3246,11 +3377,12 @@ dependencies = [
 [[package]]
 name = "wolfssl-sys"
 version = "2.0.0"
-source = "git+https://github.com/expressvpn/wolfssl-rs#8d160c21b5ddc34d39a3a7e22247fd7bb6e42851"
+source = "git+https://github.com/expressvpn/wolfssl-rs#1e38d827acd15dd3fa09e8b7ecd5f2eddba3574a"
 dependencies = [
  "autotools",
  "bindgen",
  "build-target",
+ "msbuild",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,5 +59,5 @@ tokio-stream = "0.1.14"
 tokio-util = "0.7.10"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
-tun = { version = "0.8", features = ["async"] }
+tun-rs = { version = "2.5.1", features = ["async"] }
 twelf = { version = "0.15.0", default-features = false, features = ["env", "clap", "yaml"]}

--- a/deny.toml
+++ b/deny.toml
@@ -21,7 +21,6 @@ allow = [
     "MIT",
     "NCSA",
     "Unicode-3.0",
-    "WTFPL",
     "Zlib",
 ]
 confidence-threshold = 0.8
@@ -73,7 +72,9 @@ skip = [
     { name = "rand", version = "0.8.5" },
     { name = "rand_chacha", version = "0.3.1" },
     { name = "rand_core", version = "0.6.4" },
-    { name = "wasi", version = "0.11.0+wasi-snapshot-preview1" }
+    { name = "wasi", version = "0.11.0+wasi-snapshot-preview1" },
+    { name = "system-configuration-sys", version = "0.5.0" },
+    { name = "nix", version = "0.29.0" }
 ]
 
 [sources]

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
                   "--skip=routing_table::tests"
                 ];
                 cargoLock.outputHashes = {
-                  "wolfssl-3.0.0" = "sha256-xdzBOgfrhMNRqt6zlFVBU0x1z3TzzE7hXjyHuDfEs0g=";
+                  "wolfssl-3.0.0" = "sha256-k37UQ3cIIfJcFforPcVPQhoruLoIwZo7YNu7yN/Rpxo=";
                 };
               };
 

--- a/lightway-app-utils/Cargo.toml
+++ b/lightway-app-utils/Cargo.toml
@@ -39,7 +39,7 @@ tokio-stream = { workspace = true, optional = true }
 tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["json"] }
-tun.workspace = true 
+tun-rs.workspace = true 
 
 [[example]]
 name = "udprelay"

--- a/lightway-app-utils/Cargo.toml
+++ b/lightway-app-utils/Cargo.toml
@@ -22,6 +22,7 @@ workspace = true
 anyhow.workspace = true
 bytes.workspace = true
 clap.workspace = true
+educe = { workspace = true, features = ["Default"] }
 fs-mistrust = { version = "0.10.0", default-features = false }
 humantime = "2.1.0"
 io-uring = {  version = "0.7.0", optional = true }

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -74,7 +74,7 @@ impl Tun {
     }
 
     /// Interface index of 'Tun' interface
-    pub fn if_index(&self) -> std::io::Result<i32> {
+    pub fn if_index(&self) -> std::io::Result<u32> {
         match self {
             Tun::Direct(t) => t.if_index(),
             #[cfg(feature = "io-uring")]
@@ -146,8 +146,11 @@ impl TunDirect {
     }
 
     /// Interface index of Tun
-    pub fn if_index(&self) -> std::io::Result<i32> {
-        Ok(self.tun.tun_index()?)
+    pub fn if_index(&self) -> std::io::Result<u32> {
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        return self.tun.if_index();
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        return Err(std::io::Error::from(std::io::ErrorKind::Unsupported));
     }
 }
 
@@ -198,7 +201,7 @@ impl TunIoUring {
     }
 
     /// Interface index of tun
-    pub fn if_index(&self) -> std::io::Result<i32> {
+    pub fn if_index(&self) -> std::io::Result<u32> {
         self.tun_io_uring.owned_fd().if_index()
     }
 }

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -44,8 +44,8 @@ twelf.workspace = true
 [dev-dependencies]
 more-asserts.workspace = true
 test-case.workspace = true
-tun.workspace = true
 serial_test = "3.2.0"
+tun-rs.workspace = true
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 route_manager = { version = "0.2.6", features = ["async"] }

--- a/lightway-client/src/io/inside/tun.rs
+++ b/lightway-client/src/io/inside/tun.rs
@@ -39,7 +39,7 @@ impl Tun {
         Ok(Tun { tun, ip, dns_ip })
     }
 
-    pub fn if_index(&self) -> std::io::Result<i32> {
+    pub fn if_index(&self) -> std::io::Result<u32> {
         self.tun.if_index()
     }
 }
@@ -103,7 +103,7 @@ impl<ExtAppState: Send + Sync> InsideIOSendCallback<ConnectionState<ExtAppState>
         self.tun.mtu()
     }
 
-    fn if_index(&self) -> std::io::Result<i32> {
+    fn if_index(&self) -> std::io::Result<u32> {
         self.if_index()
     }
 }

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -555,7 +555,7 @@ impl<ExtAppState: Send + Sync> ClientConnection<ExtAppState> {
         tun_peer_ip: IpAddr,
         tun_dns_ip: IpAddr,
     ) -> Result<()> {
-        let tun_index = self.inside_io.if_index().map(|i| i as u32)?;
+        let tun_index = self.inside_io.if_index()?;
 
         let mut route_table = RoutingTable::new(route_mode)?;
         tracing::trace!(

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -960,12 +960,8 @@ pub async fn client<
             .await?,
         ),
         None => Arc::new(
-            io::inside::Tun::new(
-                &config.tun_config,
-                config.tun_local_ip,
-                config.tun_dns_ip,
-            )
-            .await?,
+            io::inside::Tun::new(&config.tun_config, config.tun_local_ip, config.tun_dns_ip)
+                .await?,
         ),
     };
 

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -927,16 +927,6 @@ fn validate_client_config<
     Ok(())
 }
 
-fn apply_platform_specific_config(
-    #[allow(unused_variables)] // macOS specific
-    config: &mut TunConfig,
-) {
-    #[cfg(target_os = "macos")]
-    config.platform_config(|config| {
-        config.enable_routing(false);
-    });
-}
-
 /// Launches connections concurrently and waits for the first one to complete.
 /// If `config.preferred_connection_wait_interval` is set, it will wait that
 /// duration after the first connection completes before returning the highest
@@ -955,7 +945,6 @@ pub async fn client<
     );
 
     validate_client_config(&config, &servers)?;
-    apply_platform_specific_config(&mut config.tun_config);
 
     let inside_io = match &config.inside_io {
         Some(io) => Arc::clone(io),
@@ -971,8 +960,12 @@ pub async fn client<
             .await?,
         ),
         None => Arc::new(
-            io::inside::Tun::new(&config.tun_config, config.tun_local_ip, config.tun_dns_ip)
-                .await?,
+            io::inside::Tun::new(
+                &config.tun_config,
+                config.tun_local_ip,
+                config.tun_dns_ip,
+            )
+            .await?,
         ),
     };
 

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -87,7 +87,7 @@ async fn main() -> Result<()> {
     // TODO: Fix in future PR
     tun_config
         .mtu(1350)
-        .address(config.tun_local_ip)
+        .address(config.tun_local_ip.into())
         .destination(config.tun_peer_ip)
         .up();
 

--- a/lightway-core/src/io.rs
+++ b/lightway-core/src/io.rs
@@ -16,7 +16,7 @@ pub trait InsideIOSendCallback<AppState> {
     fn mtu(&self) -> usize;
 
     /// Interface Index of tun
-    fn if_index(&self) -> std::io::Result<i32>;
+    fn if_index(&self) -> std::io::Result<u32>;
 }
 
 /// Convenience type to use as function arguments

--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -71,7 +71,7 @@ impl<T> InsideIOSendCallback<T> for ChannelTun {
         1350
     }
 
-    fn if_index(&self) -> std::io::Result<i32> {
+    fn if_index(&self) -> std::io::Result<u32> {
         Err(std::io::Error::other("Not Implemented"))
     }
 }

--- a/lightway-server/src/io/inside/tun.rs
+++ b/lightway-server/src/io/inside/tun.rs
@@ -75,7 +75,7 @@ impl InsideIOSendCallback<ConnectionState> for Tun {
         self.0.mtu()
     }
 
-    fn if_index(&self) -> std::io::Result<i32> {
+    fn if_index(&self) -> std::io::Result<u32> {
         self.0.if_index()
     }
 }

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -144,6 +144,7 @@ async fn main() -> Result<()> {
     if let Some(tun_name) = config.tun_name {
         tun_config.tun_name(tun_name);
     }
+    tun_config.up();
     let mode = match config.mode {
         lightway_app_utils::args::ConnectionType::Udp => ServerConnectionMode::Datagram(None),
         lightway_app_utils::args::ConnectionType::Tcp => ServerConnectionMode::Stream(None),


### PR DESCRIPTION
This PR moves away from using rust-tun and replaces it with tun-rs

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`config.enable_routing(false)` was previously used as otherwise the tun crate would add this route on macos
```
Destination        Gateway            Flags               Netif Expire
100.64/24          100.64.0.5         UGSc             utun1995       
```
the tun-rs crate does not exhibit this behaviour and so such an option is not implemented by `TunConfig`. However,
tun-rs crate does seem to add this route on macos

```
Destination        Gateway            Flags               Netif Expire
100.64.0.6         link#23            UHS              utun1995       
```
which is not a problem as long as we set `device.associate_route(false)` on macos


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Among other reasons, tun-rs exposes methods with `&self` rather than `&mut self` e.g. in `set_mtu()` which allows allows us to use these methods through `Arc` in `InsideIO` without having to incur the cost of a `Mutex`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ran client to connect to production servers

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
