### PR TITLE
fix missing cfg declaration for dns_manager

### DIFF
--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -1,4 +1,5 @@
 mod debug;
+#[cfg(any(target_os = "linux", target_os = "macos",))]
 pub mod dns_manager;
 pub mod io;
 pub mod keepalive;
@@ -26,6 +27,7 @@ use tokio::sync::mpsc::UnboundedReceiver;
 
 #[cfg(feature = "debug")]
 use crate::debug::WiresharkKeyLogger;
+#[cfg(any(target_os = "linux", target_os = "macos",))]
 use crate::dns_manager::{DnsConfigMode, DnsManager, DnsManagerError, DnsSetup};
 #[cfg(any(target_os = "linux", target_os = "macos",))]
 use crate::routing_table::{RouteMode, RoutingTable};
@@ -822,6 +824,7 @@ pub async fn connect<
         server_ip: server_config.server.ip(),
         #[cfg(any(target_os = "linux", target_os = "macos",))]
         route_table: None,
+        #[cfg(any(target_os = "linux", target_os = "macos",))]
         dns_manager: None,
     })
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This can prevent compilation when developing on a platform that is not macos and linux.

## Description
<!--- Describe your changes in detail -->
Added cfg declarations required to prevent inclusion of dns_manager.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows development on non macos and non linux platform types

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
unittests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
