### PR TITLE
deny: fix allowed licenses for local sources

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -26,12 +26,12 @@ allow = [
 ]
 confidence-threshold = 0.8
 exceptions = [
-    { name = "wolfssl", allow = ["GPL-3.0"], version = "*" },
-    { name = "wolfssl-sys", allow = ["GPL-3.0"], version = "*" },
-    { name = "lightway-client", allow = ["AGPL-3.0"], version = "*" },
-    { name = "lightway-core", allow = ["AGPL-3.0"], version = "*" },
-    { name = "lightway-server", allow = ["AGPL-3.0"], version = "*" },
-    { name = "lightway-app-utils", allow = ["AGPL-3.0"], version = "*" },
+    { name = "wolfssl", allow = ["GPL-2.0-or-later"], version = "*" },
+    { name = "wolfssl-sys", allow = ["GPL-2.0-or-later"], version = "*" },
+    { name = "lightway-client", allow = ["AGPL-3.0-only"], version = "*" },
+    { name = "lightway-core", allow = ["AGPL-3.0-only"], version = "*" },
+    { name = "lightway-server", allow = ["AGPL-3.0-only"], version = "*" },
+    { name = "lightway-app-utils", allow = ["AGPL-3.0-only"], version = "*" },
 ]
 
 [licenses.private]


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Cargo-deny 0.18.4 has a breaking change where GPL licenses are handled differently from before.
https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.18.4

In short, the licenses have to match exactly.
Ref: https://github.com/EmbarkStudios/cargo-deny/pull/786/files

Updated the allowed license to follow the same as crate licenses.


## Motivation and Context

Nightly CI check failed:
https://github.com/expressvpn/lightway/actions/runs/16982524844/job/48145329549#step:4:138

## How Has This Been Tested?
CI passed for check-dependencies

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
