### PR TITLE
client: graceful disconnect

### DIFF
--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -790,8 +790,10 @@ pub async fn connect<
         let result = tokio::select! {
             _ = stop_rx => {
                 info!("client shutting down ..");
-                let _ = stop_conn.lock().unwrap().disconnect();
-                Ok(ClientResult::UserDisconnect)
+                match stop_conn.lock().unwrap().disconnect() {
+                    Ok(()) => Ok(ClientResult::UserDisconnect),
+                    Err(e) => Err(e.into())
+                }
             },
             Some(_) = keepalive_task => Err(anyhow!("Keepalive timeout")),
             io = &mut outside_io_loop => Err(anyhow!("Outside IO loop exited: {io:?}")),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
During an intended disconnect, ensure we wait for the Disconnect state before we abort tasks. This allows the graceful disconnect to take place.

## Motivation and Context
The existing implementation does not wait for the Lightway connection to fully disconnect before aborting tasks. This causes the connection to not go through the usual disconnect state changes.

This is fixed by waiting for the `Disconnect` state if the client requests a disconnect before the client can exit.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually test and check that all state transitions are correctly logged.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
