### PR TITLE
core: Allow EventCallback to be mutable

### DIFF
--- a/lightway-app-utils/src/event_stream.rs
+++ b/lightway-app-utils/src/event_stream.rs
@@ -23,7 +23,7 @@ impl EventStreamCallback {
 }
 
 impl EventCallback for EventStreamCallback {
-    fn event(&self, event: Event) {
+    fn event(&mut self, event: Event) {
         let sender = self.0.clone();
         tokio::spawn(async move {
             let _ = sender.send(event).await;

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -281,7 +281,7 @@ async fn handle_events<A: 'static + Send + EventCallback, ExtAppState: Send + Sy
     keepalive: Keepalive,
     weak: Weak<Mutex<Connection<ConnectionState<ExtAppState>>>>,
     enable_encoding_when_online: bool,
-    event_handler: Option<A>,
+    mut event_handler: Option<A>,
     connected_signal: oneshot::Sender<()>,
     disconnected_signal: oneshot::Sender<()>,
 ) {
@@ -322,7 +322,7 @@ async fn handle_events<A: 'static + Send + EventCallback, ExtAppState: Send + Sy
                 unreachable!("server only event received");
             }
         }
-        if let Some(ref handler) = event_handler {
+        if let Some(ref mut handler) = event_handler {
             handler.event(event);
         }
     }

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -18,7 +18,7 @@ use crate::args::ConnectionConfig;
 struct EventHandler;
 
 impl EventCallback for EventHandler {
-    fn event(&self, event: lightway_core::Event) {
+    fn event(&mut self, event: lightway_core::Event) {
         if let Event::StateChanged(state) = event {
             tracing::debug!("State changed to {:?}", state);
         }

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -268,7 +268,7 @@ impl ConnectionError {
 /// Callbacks for this particular connection
 pub trait EventCallback {
     /// Called when Lightway wishes to notify about an event
-    fn event(&self, event: Event);
+    fn event(&mut self, event: Event);
 }
 
 /// Convenience type to use as function arguments
@@ -1030,8 +1030,8 @@ impl<AppState: Send> Connection<AppState> {
     }
 
     /// Generate an event
-    fn event(&self, event: Event) {
-        if let Some(event_cb) = &self.event_cb {
+    fn event(&mut self, event: Event) {
+        if let Some(event_cb) = &mut self.event_cb {
             debug!(?event, "event");
             event_cb.event(event);
         }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In all the contexts where it is used, `EventCallback` is already mutable. We expose this mutability to it so it can maintain its own state.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows an `EventCallback` implementation to be stateful without interior mutability.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests should pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
