### PR TITLE
client: Update server route on floating connections

### DIFF
--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -58,4 +58,12 @@ core-foundation = "0.9.4"
 system-configuration = "0.6.1"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_Foundation"] }
+windows-sys = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_NetworkManagement",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_NetworkManagement_Ndis",
+    "Win32_Networking_WinSock",
+    "Win32_System_IO",
+    "Win32_System_Threading",
+] }

--- a/lightway-client/src/platform/windows.rs
+++ b/lightway-client/src/platform/windows.rs
@@ -1,1 +1,3 @@
+pub mod addr_monitor;
 pub mod dns_manager;
+pub mod utils;

--- a/lightway-client/src/platform/windows/addr_monitor.rs
+++ b/lightway-client/src/platform/windows/addr_monitor.rs
@@ -1,0 +1,280 @@
+#![allow(unsafe_code)]
+use anyhow::Result;
+use futures::Stream;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::sync::mpsc;
+use tracing::{debug, error};
+
+use windows_sys::Win32::{
+    Foundation::{HANDLE, INVALID_HANDLE_VALUE, WAIT_OBJECT_0, WAIT_TIMEOUT},
+    NetworkManagement::IpHelper::NotifyAddrChange,
+    System::Threading::{CreateEventW, ResetEvent, WaitForSingleObject},
+    System::IO::OVERLAPPED,
+};
+
+/// Represents different types of address changes that can be monitored
+#[derive(Debug, Clone, PartialEq)]
+pub enum AddrChangeEvent {
+    /// An address was added to an interface
+    AddressAdded,
+    /// An address was removed from an interface
+    AddressRemoved,
+    /// An address configuration changed
+    AddressChanged,
+    /// Network interface state changed (up/down)
+    InterfaceStateChanged,
+}
+
+/// Async stream for monitoring Windows address changes
+pub struct AsyncAddrListener {
+    receiver: mpsc::UnboundedReceiver<AddrChangeEvent>,
+    _join_handle: tokio::task::JoinHandle<()>,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl AsyncAddrListener {
+    /// Creates a new AsyncAddrListener for monitoring address changes
+    pub fn new() -> Result<Self> {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = shutdown.clone();
+
+        let join_handle = tokio::task::spawn_blocking(move || {
+            if let Err(e) = Self::monitor_address_changes(sender, shutdown_clone) {
+                error!("Address monitoring task failed: {}", e);
+            }
+        });
+
+        Ok(Self {
+            receiver,
+            _join_handle: join_handle,
+            shutdown,
+        })
+    }
+
+    /// Internal function to monitor address changes using Windows API
+    fn monitor_address_changes(
+        sender: mpsc::UnboundedSender<AddrChangeEvent>,
+        shutdown: Arc<AtomicBool>,
+    ) -> Result<()> {
+        // RAII wrapper for Windows event handle
+        struct EventHandle(HANDLE);
+
+        impl EventHandle {
+            fn new() -> Result<Self> {
+                let handle = unsafe { CreateEventW(std::ptr::null_mut(), 1, 0, std::ptr::null()) };
+                if handle.is_null() {
+                    return Err(anyhow::anyhow!(
+                        "Failed to create event for address change notification"
+                    ));
+                }
+                Ok(EventHandle(handle))
+            }
+
+            fn get(&self) -> HANDLE {
+                self.0
+            }
+        }
+
+        impl Drop for EventHandle {
+            fn drop(&mut self) {
+                if !self.0.is_null() {
+                    unsafe {
+                        windows_sys::Win32::Foundation::CloseHandle(self.0);
+                    }
+                }
+            }
+        }
+
+        // Create event handle once for the entire monitoring session
+        let event_handle = EventHandle::new()?;
+
+        loop {
+            // Check if we should shutdown
+            if shutdown.load(Ordering::Relaxed) {
+                debug!("Address monitoring shutdown requested");
+                break;
+            }
+
+            let monitoring_result =
+                Self::perform_single_monitor_cycle(event_handle.get(), shutdown.clone());
+
+            match monitoring_result {
+                Ok(()) => {
+                    tracing::info!("Address change detected!");
+                    // Send notification - we use a general event since Windows API
+                    // doesn't provide specific details about the type of change
+                    if sender.send(AddrChangeEvent::AddressChanged).is_err() {
+                        tracing::info!("Receiver dropped, stopping address monitoring");
+                        break;
+                    }
+
+                    // Small delay to prevent flooding if multiple rapid changes occur
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Err(e) => {
+                    error!("Address monitoring cycle failed: {}", e);
+                    // Brief delay before retrying to prevent tight loop
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                }
+            }
+        }
+
+        debug!("Address monitoring task finished");
+        Ok(())
+    }
+
+    /// Performs a single monitoring cycle with proper resource cleanup
+    fn perform_single_monitor_cycle(event_handle: HANDLE, shutdown: Arc<AtomicBool>) -> Result<()> {
+        // RAII wrapper for notification cleanup
+        struct NotificationContext {
+            handle: HANDLE,
+            overlapped: windows_sys::Win32::System::IO::OVERLAPPED,
+        }
+
+        impl NotificationContext {
+            fn new(event_handle: HANDLE) -> Self {
+                let mut overlapped: OVERLAPPED = unsafe { std::mem::zeroed() };
+                overlapped.hEvent = event_handle;
+
+                Self {
+                    handle: INVALID_HANDLE_VALUE,
+                    overlapped,
+                }
+            }
+
+            fn start_notification(&mut self) -> Result<()> {
+                let result = unsafe { NotifyAddrChange(&mut self.handle, &self.overlapped) };
+
+                if result != 0 && result != 997 {
+                    // ERROR_IO_PENDING = 997
+                    return Err(anyhow::anyhow!(
+                        "NotifyAddrChange failed with error: {}",
+                        result
+                    ));
+                }
+
+                Ok(())
+            }
+        }
+
+        impl Drop for NotificationContext {
+            fn drop(&mut self) {
+                if self.handle != INVALID_HANDLE_VALUE {
+                    unsafe {
+                        windows_sys::Win32::NetworkManagement::IpHelper::CancelIPChangeNotify(
+                            &self.overlapped,
+                        );
+                    }
+                }
+            }
+        }
+
+        // Create notification context with automatic cleanup
+        let mut notification_ctx = NotificationContext::new(event_handle);
+
+        // Start the notification
+        notification_ctx.start_notification()?;
+
+        debug!("Waiting for address change notification...");
+
+        // Wait for the event to be signaled with a timeout to prevent hanging
+        // Use 1 second timeout to periodically check shutdown flag
+        const TIMEOUT_MS: u32 = 1000;
+
+        loop {
+            // Check shutdown flag before each wait
+            if shutdown.load(Ordering::Relaxed) {
+                debug!("Address monitoring cycle interrupted by shutdown");
+                return Err(anyhow::anyhow!("Monitoring interrupted by shutdown"));
+            }
+
+            let wait_result = unsafe { WaitForSingleObject(event_handle, TIMEOUT_MS) };
+
+            match wait_result {
+                WAIT_OBJECT_0 => {
+                    // Address change detected
+                    unsafe { ResetEvent(event_handle) };
+                    return Ok(());
+                }
+                WAIT_TIMEOUT => {
+                    // Timeout occurred - this is normal, check shutdown and continue
+                    // This allows the thread to check periodically if it should exit
+                    continue;
+                }
+                _ => {
+                    return Err(anyhow::anyhow!(
+                        "Wait for address change event failed: {}",
+                        wait_result
+                    ));
+                }
+            }
+        }
+    }
+
+    /// Get the next address change event
+    pub async fn next(&mut self) -> Option<AddrChangeEvent> {
+        self.receiver.recv().await
+    }
+}
+
+impl Drop for AsyncAddrListener {
+    fn drop(&mut self) {
+        // Signal the monitoring thread to shutdown
+        self.shutdown.store(true, Ordering::Relaxed);
+        debug!("AsyncAddrListener dropping, shutdown signal sent");
+    }
+}
+
+impl Stream for AsyncAddrListener {
+    type Item = AddrChangeEvent;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.receiver).poll_recv(cx)
+    }
+}
+
+/// Convenience function to create and listen for a single address change
+pub async fn wait_for_addr_change() -> Result<AddrChangeEvent> {
+    let mut listener = AsyncAddrListener::new()?;
+    listener
+        .next()
+        .await
+        .ok_or_else(|| anyhow::anyhow!("Address listener stream ended unexpectedly"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio_stream::StreamExt;
+
+    #[tokio::test]
+    async fn test_addr_listener_creation() {
+        // Test that we can create the listener without panic
+        let result = AsyncAddrListener::new();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_addr_listener_as_stream() {
+        let listener = AsyncAddrListener::new().unwrap();
+        let mut stream = listener.take(1); // Take only 1 event for test
+
+        // This test would hang waiting for actual address changes, so we just verify
+        // that we can create the stream without error
+        // To properly test, you'd need to trigger an address change during the test
+        drop(stream);
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_addr_change_function() {
+        // Just test that the function can be called without panic
+        // In a real scenario, this would wait for an actual address change
+        let future = wait_for_addr_change();
+        // Immediately drop to avoid waiting for real change
+        drop(future);
+    }
+}

--- a/lightway-client/src/platform/windows/utils.rs
+++ b/lightway-client/src/platform/windows/utils.rs
@@ -1,0 +1,46 @@
+use thiserror::Error;
+use windows_sys::Win32::NetworkManagement::IpHelper::{GetIpInterfaceEntry, MIB_IPINTERFACE_ROW};
+
+#[derive(Error, Debug)]
+pub enum PlatformError {
+    #[error("InterfaceNotConnected")]
+    InterfaceNotConnected,
+    #[error("Interface not found")]
+    InterfaceNotFound,
+}
+
+pub fn get_interface_metric(if_index: u32) -> Result<u32, PlatformError> {
+    use std::mem;
+    use windows_sys::Win32::Networking::WinSock::AF_INET;
+
+    // Initialize the IP interface row structure
+    #[allow(unsafe_code)]
+    // SAFETY: TODO
+    let mut ip_interface_row: MIB_IPINTERFACE_ROW = unsafe { mem::zeroed() };
+    ip_interface_row.Family = AF_INET as u16; // IPv4
+    ip_interface_row.InterfaceIndex = if_index;
+
+    // Get the actual IP interface entry which contains the routing metric
+    #[allow(unsafe_code)]
+    // SAFETY: TODO
+    let result = unsafe { GetIpInterfaceEntry(&mut ip_interface_row) };
+
+    if result != 0 {
+        tracing::warn!(
+            "Failed to get IP interface entry for index {}: error {}. Using fallback metric calculation.",
+            if_index,
+            result
+        );
+
+        return Err(PlatformError::InterfaceNotFound);
+    }
+
+    // Windows sometimes returns routes which are not connected
+    // Ignore those routes
+    if !ip_interface_row.Connected {
+        tracing::warn!("Interface {} not connected", if_index);
+        return Err(PlatformError::InterfaceNotConnected);
+    }
+
+    Ok(ip_interface_row.Metric)
+}

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -1,8 +1,11 @@
 use anyhow::Result;
-use route_manager::{AsyncRouteManager, Route, RouteManager as SyncRouteManager};
+use route_manager::{
+    AsyncRouteListener, AsyncRouteManager, Route, RouteManager as SyncRouteManager,
+};
 use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr};
 use thiserror::Error;
+use tokio::task::JoinHandle;
 use tracing::warn;
 
 #[cfg(windows)]
@@ -86,13 +89,24 @@ pub struct RouteManager {
     routing_mode: RouteMode,
     route_manager: SyncRouteManager,
     route_manager_async: AsyncRouteManager,
+    server_ip: IpAddr,
+    tun_index: u32,
+    tun_peer_ip: IpAddr,
+    tun_dns_ip: IpAddr,
     vpn_routes: Vec<Route>,
     lan_routes: Vec<Route>,
     server_route: Option<Route>,
+    monitor_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl RouteManager {
-    pub fn new(routing_mode: RouteMode) -> Result<Self, RoutingTableError> {
+    pub fn new(
+        routing_mode: RouteMode,
+        server_ip: IpAddr,
+        tun_index: u32,
+        tun_peer_ip: IpAddr,
+        tun_dns_ip: IpAddr,
+    ) -> Result<Self, RoutingTableError> {
         let route_manager =
             SyncRouteManager::new().map_err(RoutingTableError::RoutingManagerError)?;
         let route_manager_async =
@@ -101,9 +115,14 @@ impl RouteManager {
             routing_mode,
             route_manager,
             route_manager_async,
+            server_ip,
+            tun_index,
+            tun_peer_ip,
+            tun_dns_ip,
             vpn_routes: Vec::with_capacity(TUNNEL_ROUTES.len() + 1),
             lan_routes: Vec::with_capacity(LAN_NETWORKS.len()),
             server_route: None,
+            monitor_task: None,
         })
     }
 
@@ -214,24 +233,20 @@ impl RouteManager {
         }
     }
 
-    pub async fn initialize(
-        &mut self,
-        server_ip: &IpAddr,
-        tun_index: u32,
-        tun_peer_ip: &IpAddr,
-        tun_dns_ip: &IpAddr,
-    ) -> Result<()> {
+    async fn install_routes(&mut self) -> Result<(), RoutingTableError> {
         if self.routing_mode == RouteMode::NoExec {
             return Ok(());
         }
 
+        let server_ip = self.server_ip;
+
         // Setting up VPN Server Routes
         let (default_interface_index, default_interface_gateway) =
-            self.find_default_interface_index_and_gateway(server_ip)?;
+            self.find_default_interface_index_and_gateway(&server_ip)?;
 
         // Create server route with optional gateway - handles both direct routes (containers)
         // and routed networks (host systems with gateways)
-        let server_route = Route::new(*server_ip, 32).with_if_index(default_interface_index);
+        let server_route = Route::new(server_ip, 32).with_if_index(default_interface_index);
         let server_route = match default_interface_gateway {
             Some(gateway) => server_route.with_gateway(gateway),
             None => server_route,
@@ -258,8 +273,8 @@ impl RouteManager {
         // Add standard tunnel routes (high priority default routing)
         for (network, prefix) in TUNNEL_ROUTES {
             let tunnel_route = Route::new(network, prefix)
-                .with_gateway(*tun_peer_ip)
-                .with_if_index(tun_index);
+                .with_gateway(self.tun_peer_ip)
+                .with_if_index(self.tun_index);
 
             #[cfg(windows)]
             let tunnel_route = tunnel_route.with_metric(0);
@@ -268,13 +283,126 @@ impl RouteManager {
         }
 
         // Add DNS route separately since it's not a constant
-        let dns_route = Route::new(*tun_dns_ip, 32)
-            .with_gateway(*tun_peer_ip)
-            .with_if_index(tun_index);
+        let dns_route = Route::new(self.tun_dns_ip, 32)
+            .with_gateway(self.tun_peer_ip)
+            .with_if_index(self.tun_index);
         #[cfg(windows)]
         let dns_route = dns_route.with_metric(0);
 
         self.add_route_vpn(dns_route).await?;
+        Ok(())
+    }
+
+    /// Install routes required to use tunnel and start monitoring route changes
+    /// to update the routes if needed (mostly during connection floating)
+    pub async fn start(mut self) -> Result<Option<JoinHandle<()>>, RoutingTableError> {
+        if self.routing_mode == RouteMode::NoExec {
+            return Ok(None);
+        }
+
+        // Install all th required routes
+        self.install_routes().await?;
+
+        if self.monitor_task.is_some() {
+            return Err(RoutingTableError::RoutingManagerError(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "Route monitoring already started",
+            )));
+        }
+
+        // Spawn async task to monitor route changes using AsyncRouteListener
+        let monitor_task = tokio::spawn(async move {
+            // Create AsyncRouteListener
+            let mut listener = match AsyncRouteListener::new() {
+                Ok(listener) => listener,
+                Err(e) => {
+                    tracing::error!("Failed to create AsyncRouteListener: {}", e);
+                    return;
+                }
+            };
+
+            tracing::info!("Started route monitoring...");
+            // Listen for route changes in a loop
+            loop {
+                match listener.listen().await {
+                    Ok(route_change) => {
+                        tracing::debug!("Route change detected: {:?}", route_change);
+                        match route_change {
+                            route_manager::RouteChange::Add(route)
+                            | route_manager::RouteChange::Delete(route)
+                            | route_manager::RouteChange::Change(route) => {
+                                // skip Ipv6 route updates
+                                if route.destination().is_ipv6() {
+                                    continue;
+                                };
+                                // Update only the /32 prefix route i.e default route
+                                if route.prefix() as u32 != Ipv4Addr::BITS {
+                                    continue;
+                                }
+                                if route.gateway().is_none_or(|a| a.is_unspecified()) {
+                                    continue;
+                                }
+                                if let Err(e) = self.check_and_update_server_route().await {
+                                    tracing::warn!("Updating server route failed: {:?}", e);
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("Error listening for route changes: {}", e);
+                        // Continue monitoring even on errors
+                        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+                    }
+                }
+            }
+        });
+
+        Ok(Some(monitor_task))
+    }
+
+    /// Check if server route needs updating due to network changes
+    async fn check_and_update_server_route(&mut self) -> Result<(), RoutingTableError> {
+        // Find the current default route to the server
+        let server_ip = self.server_ip;
+        let current_route = self.find_route(&server_ip)?;
+        let current_gateway = current_route.gateway();
+        let current_if_index = current_route.if_index();
+
+        if let Some(server_route) = &self.server_route {
+            let server_gateway = server_route.gateway();
+            let server_if_index = server_route.if_index();
+
+            // Check if the route to the server has changed
+            if server_gateway != current_gateway || server_if_index != current_if_index {
+                tracing::debug!(
+                    "Default route changed - old (interface, gateway): ({:?}, {:?}), new (interface, gateway): ({:?}, {:?})",
+                    server_gateway,
+                    server_if_index,
+                    current_gateway,
+                    current_if_index
+                );
+
+                // Update server route with new gateway/interface
+                if let Some(old_route) = self.server_route.take() {
+                    // Remove old route
+                    let _ = self.route_manager_async.delete(&old_route).await;
+                }
+
+                // Add new route with current gateway and interface
+                let mut new_server_route = Route::new(self.server_ip, 32);
+                if let Some(if_index) = current_if_index {
+                    new_server_route = new_server_route.with_if_index(if_index);
+                }
+                if let Some(gateway) = current_gateway {
+                    new_server_route = new_server_route.with_gateway(gateway);
+                }
+
+                self.add_route_server(new_server_route).await?;
+
+                tracing::info!("Updated server route for network change");
+            }
+        }
+
         Ok(())
     }
 }
@@ -325,17 +453,40 @@ mod tests {
             && route1.if_index() == route2.if_index()
     }
 
-    /// Creates a test setup with RouteRestorer and RoutingTable
+    /// Creates a test setup with RouteRestorer, TUN device, and RouteManager
     /// Returns tuple where RouteRestorer is dropped last for proper cleanup
-    fn create_test_setup(route_mode: RouteMode) -> (RouteRestorer, RouteManager) {
+    async fn create_test_setup(
+        route_mode: RouteMode,
+    ) -> Result<(RouteRestorer, AsyncDevice, RouteManager), Box<dyn std::error::Error>> {
         // Capture initial state FIRST
         let restorer = RouteRestorer::new();
 
-        // Then create RoutingTable
-        let route_manager = RouteManager::new(route_mode).unwrap();
+        // Create TUN device
+        let tun_device = DeviceBuilder::new()
+            .ipv4(
+                match TUN_LOCAL_IP {
+                    IpAddr::V4(ipv4) => ipv4,
+                    IpAddr::V6(_) => return Err("IPv6 not supported for test".into()),
+                },
+                24,
+                None,
+            )
+            .enable(true)
+            .build_async()?;
 
-        // Return tuple - RoutingTable will be dropped first, RouteRestorer last
-        (restorer, route_manager)
+        // Add 50ms sleep to allow TUN device to be fully initialized
+        // NOTE: This sometimes adds an additional route after the tests have stored the initial route
+        //       which may lead to inaccurate tests. 50ms is eternity and enough to stabilise this.
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        let tun_index = tun_device.if_index()?;
+
+        // Then create RouteManager
+        let route_manager =
+            RouteManager::new(route_mode, EXTERNAL_IP, tun_index, TUN_PEER_IP, TUN_DNS_IP)?;
+
+        // Return tuple - RouteManager will be dropped first, then TUN device, RouteRestorer last
+        Ok((restorer, tun_device, route_manager))
     }
 
     /// Test wrapper around RouteManager for cleanup purposes
@@ -383,31 +534,6 @@ mod tests {
         }
     }
 
-    async fn create_test_tun(
-        local_ip: IpAddr,
-    ) -> Result<(AsyncDevice, u32), Box<dyn std::error::Error>> {
-        let tun_device = DeviceBuilder::new()
-            .ipv4(
-                match local_ip {
-                    IpAddr::V4(ipv4) => ipv4,
-                    IpAddr::V6(_) => return Err("IPv6 not supported for test".into()),
-                },
-                24,
-                None,
-            )
-            .enable(true)
-            .build_async()?;
-
-        // Add 50ms sleep to allow TUN device to be fully initialized
-        // NOTE: This sometimes adds an additional route after the tests have stored the initial route
-        //       which may lead to inaccurate tests. 50ms is eternity and enough to stabilise this.
-        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-
-        let if_index = tun_device.if_index()?;
-
-        Ok((tun_device, if_index))
-    }
-
     #[derive(Debug)]
     enum RouteAddMethod {
         Standard,
@@ -418,9 +544,10 @@ mod tests {
     #[test_case(RouteMode::Default)]
     #[test_case(RouteMode::Lan)]
     #[test_case(RouteMode::NoExec)]
+    #[tokio::test]
     #[ignore = "May falsely fail during development due to local route settings"]
-    fn test_privileged_new_route_manager(route_mode: RouteMode) {
-        let (_restorer, route_manager) = create_test_setup(route_mode);
+    async fn test_privileged_new_route_manager(route_mode: RouteMode) {
+        let (_restorer, _tun_device, route_manager) = create_test_setup(route_mode).await.unwrap();
         assert_eq!(route_manager.routing_mode, route_mode);
         assert_eq!(route_manager.vpn_routes.len(), 0);
         assert_eq!(route_manager.lan_routes.len(), 0);
@@ -430,10 +557,12 @@ mod tests {
     #[test_case(RouteMode::Default)]
     #[test_case(RouteMode::Lan)]
     #[test_case(RouteMode::NoExec)]
+    #[tokio::test]
     #[serial_test::serial(route_manager)]
     #[ignore = "May falsely fail during development due to local route settings"]
-    fn test_privileged_cleanup_sync(route_mode: RouteMode) {
-        let (_restorer, mut route_manager) = create_test_setup(route_mode);
+    async fn test_privileged_cleanup_sync(route_mode: RouteMode) {
+        let (_restorer, _tun_device, mut route_manager) =
+            create_test_setup(route_mode).await.unwrap();
 
         // Get initial route count from the system
         let initial_count = route_manager.route_manager.list().unwrap().len();
@@ -480,7 +609,8 @@ mod tests {
     #[serial_test::serial(route_manager)]
     #[ignore = "May affect system routing"]
     async fn test_privileged_is_route_exists_error_real() {
-        let (_restorer, mut route_manager) = create_test_setup(RouteMode::Default);
+        let (_restorer, _tun_device, mut route_manager) =
+            create_test_setup(RouteMode::Default).await.unwrap();
 
         // Create test routes using shared fixtures
         let (route, _, _, _) = create_test_routes_with_gateway(&mut route_manager);
@@ -505,7 +635,8 @@ mod tests {
     #[serial_test::serial(route_manager)]
     #[ignore = "May falsely fail during development due to local route settings"]
     async fn test_privileged_add_single_route(add_method: RouteAddMethod) {
-        let (_restorer, mut route_manager) = create_test_setup(RouteMode::Default);
+        let (_restorer, _tun_device, mut route_manager) =
+            create_test_setup(RouteMode::Default).await.unwrap();
 
         // Create test route using shared fixtures
         let (route1, _route2, _route3, _gateway_ip) =
@@ -537,16 +668,14 @@ mod tests {
     #[serial_test::serial(route_manager)]
     #[ignore = "May falsely fail during development due to local route settings"]
     async fn test_privileged_initialize_route_manager(route_mode: RouteMode) {
-        let (_restorer, mut route_manager) = create_test_setup(route_mode);
+        let (_restorer, _tun_device, mut route_manager) =
+            create_test_setup(route_mode).await.unwrap();
 
-        // Create a TUN device for testing using shared fixtures
-        let (_tun_device, tun_index) = create_test_tun(TUN_LOCAL_IP).await.unwrap();
+        // Get tun_index from the route_manager (it's already set during creation)
+        let tun_index = route_manager.tun_index;
 
-        // Test initialize_route_manager using shared fixtures
-        route_manager
-            .initialize(&EXTERNAL_IP, tun_index, &TUN_PEER_IP, &TUN_DNS_IP)
-            .await
-            .unwrap();
+        // Test install routes using shared fixtures
+        route_manager.install_routes().await.unwrap();
 
         // Get system routes after initialization
         let routes_after_init = route_manager.route_manager.list().unwrap();
@@ -602,10 +731,11 @@ mod tests {
     #[serial_test::serial(route_manager)]
     #[ignore = "May falsely fail during development due to local route settings"]
     async fn test_privileged_find_server_route(route_mode: RouteMode) {
-        let (_restorer, mut route_manager) = create_test_setup(route_mode);
+        let (_restorer, _tun_device, mut route_manager) =
+            create_test_setup(route_mode).await.unwrap();
 
-        // Create a TUN device for testing using different IP to avoid conflicts
-        let (_tun_device, tun_index) = create_test_tun(TUN_LOCAL_IP).await.unwrap();
+        // Get tun_index from the route_manager (it's already set during creation)
+        let tun_index = route_manager.tun_index;
 
         // Create test routes using tunnel route constants
         let route1 = Route::new(TUNNEL_ROUTES[0].0, TUNNEL_ROUTES[0].1)

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -176,6 +176,8 @@ impl RouteManagerInner {
     /// Or the first found 0.0.0.0 route.
     /// (Route metrics is applicable only in windows and linux Os)
     fn find_best_default_route(&mut self, server_ip: &IpAddr) -> Result<Route, RoutingTableError> {
+        tracing::trace!("Finding best default route for server IP: {}", server_ip);
+
         let routes = self
             .route_manager
             .list()
@@ -209,8 +211,18 @@ impl RouteManagerInner {
             // For other platforms, choose the first route available
             #[cfg(not(any(linux, windows)))]
             {
+                tracing::trace!("Using first available default route");
                 best_route = Some(route);
                 break;
+            }
+        }
+
+        match &best_route {
+            Some(route) => {
+                tracing::trace!("Best {} selected", route);
+            }
+            None => {
+                tracing::trace!("No suitable route found");
             }
         }
 
@@ -245,7 +257,10 @@ impl RouteManagerInner {
     /// Adds Route
     async fn add_route(&mut self, route: &Route) -> Result<(), RoutingTableError> {
         match self.route_manager_async.add(route).await {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                tracing::info!("Added {route}");
+                Ok(())
+            }
             Err(e) => {
                 if self.is_route_exists_error(&e) {
                     // Ignore error if route already exists and

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -11,6 +11,11 @@ use tracing::warn;
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::ERROR_OBJECT_ALREADY_EXISTS;
 
+#[cfg(windows)]
+use crate::platform::windows::addr_monitor::AsyncAddrListener;
+#[cfg(windows)]
+use crate::platform::windows::utils;
+
 // LAN networks for RouteMode::Lan
 const LAN_NETWORKS: [(IpAddr, u8); 5] = [
     (
@@ -459,7 +464,7 @@ impl RouteManagerInner {
         // Spawn async task to monitor route changes using AsyncRouteListener
         let monitor_task = tokio::spawn(async move {
             // Create AsyncRouteListener
-            let mut listener = match AsyncRouteListener::new() {
+            let mut route_listener = match AsyncRouteListener::new() {
                 Ok(listener) => listener,
                 Err(e) => {
                     tracing::error!("Failed to create AsyncRouteListener: {}", e);
@@ -467,38 +472,76 @@ impl RouteManagerInner {
                 }
             };
 
-            tracing::info!("Started route monitoring...");
-            // Listen for route changes in a loop
+            // On Windows, also create address change listener as a fallback
+            // since Windows doesn't always publish route changes on network down
+            #[cfg(windows)]
+            let mut addr_listener = match AsyncAddrListener::new() {
+                Ok(listener) => {
+                    tracing::info!("Started address change monitoring (Windows)...");
+                    Some(listener)
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to create AsyncAddrListener: {}", e);
+                    None
+                }
+            };
+
+            #[cfg(not(windows))]
+            let (_sender, addr_listener) = tokio::sync::mpsc::unbounded_channel::<()>();
+            #[cfg(not(windows))]
+            let mut addr_listener = Some(addr_listener);
+
+            tracing::info!("Started monitoring route/intf...");
+            // Listen for changes in a loop
             loop {
-                match listener.listen().await {
-                    Ok(route_change) => {
-                        tracing::debug!("Route change detected: {:?}", route_change);
-                        match route_change {
-                            route_manager::RouteChange::Add(route)
-                            | route_manager::RouteChange::Delete(route)
-                            | route_manager::RouteChange::Change(route) => {
-                                // skip Ipv6 route updates
-                                if route.destination().is_ipv6() {
-                                    continue;
-                                };
-                                // Update only the /32 prefix route i.e default route
-                                if route.prefix() as u32 != Ipv4Addr::BITS {
-                                    continue;
-                                }
-                                if route.gateway().is_none_or(|a| a.is_unspecified()) {
-                                    continue;
-                                }
-                                if let Err(e) = self.check_and_update_server_route().await {
-                                    tracing::warn!("Updating server route failed: {:?}", e);
-                                }
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        tracing::error!("Error listening for route changes: {}", e);
-                        // Continue monitoring even on errors
-                        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-                    }
+                tokio::select! {
+                   // Handle route changes
+                   route_result = route_listener.listen() => {
+                       match route_result {
+                           Ok(route_change) => {
+                               tracing::debug!("Route change detected: {:?}", route_change);
+                               match route_change {
+                                   route_manager::RouteChange::Add(route)
+                                   | route_manager::RouteChange::Delete(route)
+                                   | route_manager::RouteChange::Change(route) => {
+                                       // skip Ipv6 route updates
+                                       if route.destination().is_ipv6() {
+                                           continue;
+                                       };
+                                       // Update only the /0 prefix route i.e default route
+                                       if route.prefix() != 0 {
+                                           continue;
+                                       }
+                                       if route.gateway().is_none_or(|a| a.is_unspecified()) {
+                                           continue;
+                                       }
+                                       if let Err(e) = self.check_and_update_server_route().await {
+                                           tracing::warn!("Updating server route failed: {:?}", e);
+                                       }
+                                   }
+                               }
+                           }
+                       Err(e) => {
+                           tracing::error!("Error listening for route changes: {}", e);
+                           // Continue monitoring even on errors
+                           tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+                       }
+                   }}
+
+                   // On address/intf changes, check and update server route
+                   // This helps catch network transitions that don't trigger route changes
+                   _ = async {
+                       if let Some(listener) = &mut addr_listener {
+                           listener.next().await
+                       } else {
+                           std::future::pending().await
+                       }
+                   } => {
+                       tracing::debug!("Address change detected");
+                       if let Err(e) = self.check_and_update_server_route().await {
+                           tracing::warn!("Updating server route after address change failed: {:?}", e);
+                       }
+                   }
                 }
             }
         });

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -172,6 +172,22 @@ impl RouteManagerInner {
         })
     }
 
+    fn get_route_metric(route: &Route) -> u32 {
+        let route_metric = route.metric().unwrap_or(0);
+
+        // On Windows, get interface metric and add it to route metric
+        #[cfg(windows)]
+        let route_metric = {
+            let interface_metric = if let Some(if_index) = route.if_index() {
+                utils::get_interface_metric(if_index).unwrap_or(u32::MAX)
+            } else {
+                u32::MAX
+            };
+            route_metric.saturating_add(interface_metric)
+        };
+        route_metric
+    }
+
     /// Identifies 0.0.0.0 route with least metric if applicable
     /// Or the first found 0.0.0.0 route.
     /// (Route metrics is applicable only in windows and linux Os)
@@ -196,17 +212,41 @@ impl RouteManagerInner {
                 continue;
             }
 
-            // For windows, linux, use metric to choose best deafult route
+            tracing::trace!(
+                "Checking route: dest={}, prefix={}, gateway={:?}, if_index={:?}, metric={:?}",
+                route.destination(),
+                route.prefix(),
+                route.gateway(),
+                route.if_index(),
+                Self::get_route_metric(&route),
+            );
+
+            // For windows, linux, use metric to choose best default route
             #[cfg(any(linux, windows))]
             {
-                let route_metric = route.metric().unwrap_or(u32::MAX - 1);
-                let best_route_metric = best_route
+                let route_metric = Self::get_route_metric(&route);
+                let best_metric = best_route
                     .as_ref()
-                    .and_then(|a| a.metric())
+                    .map(Self::get_route_metric)
                     .unwrap_or(u32::MAX);
-                if route_metric < best_route_metric {
-                    best_route = Some(route);
-                }
+
+                match route_metric.cmp(&best_metric) {
+                    std::cmp::Ordering::Less => {
+                        tracing::trace!("New best route found with better route metric");
+                        best_route = Some(route);
+                    }
+                    std::cmp::Ordering::Equal => {
+                        if let Some(server_route) = self.server_route.as_ref()
+                            && *server_route == route
+                        {
+                            tracing::trace!("Same route metric, but choosing previous best route");
+                            best_route = Some(route);
+                        }
+                    }
+                    std::cmp::Ordering::Greater => {
+                        tracing::trace!("Route route metric is not better than current best");
+                    }
+                };
             }
             // For other platforms, choose the first route available
             #[cfg(not(any(linux, windows)))]

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -71,6 +71,8 @@ pub enum RoutingTableError {
     AddRouteError(std::io::Error),
     #[error("Default interface not found: {0}")]
     DefaultInterfaceNotFound(std::io::Error),
+    #[error("Default route not found")]
+    DefaultRouteNotFound,
     #[error("Interface index not found")]
     InterfaceIndexNotFound,
     #[error("Interface gateway not found")]
@@ -168,6 +170,51 @@ impl RouteManagerInner {
             server_route: None,
             monitor_task: None,
         })
+    }
+
+    /// Identifies 0.0.0.0 route with least metric if applicable
+    /// Or the first found 0.0.0.0 route.
+    /// (Route metrics is applicable only in windows and linux Os)
+    fn find_best_default_route(&mut self, server_ip: &IpAddr) -> Result<Route, RoutingTableError> {
+        let routes = self
+            .route_manager
+            .list()
+            .map_err(RoutingTableError::DefaultInterfaceNotFound)?;
+
+        let mut best_route: Option<Route> = None;
+
+        for route in routes {
+            // Skip IPv6 routes if we're looking for IPv4, and vice versa
+            if server_ip.is_ipv4() != route.destination().is_ipv4() {
+                continue;
+            }
+
+            // Not a default route, skip
+            if route.prefix() != 0 {
+                continue;
+            }
+
+            // For windows, linux, use metric to choose best deafult route
+            #[cfg(any(linux, windows))]
+            {
+                let route_metric = route.metric().unwrap_or(u32::MAX - 1);
+                let best_route_metric = best_route
+                    .as_ref()
+                    .and_then(|a| a.metric())
+                    .unwrap_or(u32::MAX);
+                if route_metric < best_route_metric {
+                    best_route = Some(route);
+                }
+            }
+            // For other platforms, choose the first route available
+            #[cfg(not(any(linux, windows)))]
+            {
+                best_route = Some(route);
+                break;
+            }
+        }
+
+        best_route.ok_or(RoutingTableError::DefaultRouteNotFound)
     }
 
     /// Identifies route used to reach a particular ip
@@ -408,7 +455,7 @@ impl RouteManagerInner {
     async fn check_and_update_server_route(&mut self) -> Result<(), RoutingTableError> {
         // Find the current default route to the server
         let server_ip = self.server_ip;
-        let current_route = self.find_route(&server_ip)?;
+        let current_route = self.find_best_default_route(&server_ip)?;
         let current_gateway = current_route.gateway();
         let current_if_index = current_route.if_index();
 

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -487,6 +487,8 @@ impl RouteManagerInner {
                 if let Some(gateway) = current_gateway {
                     new_server_route = new_server_route.with_gateway(gateway);
                 }
+                #[cfg(windows)]
+                let new_server_route = new_server_route.with_metric(0);
 
                 self.add_route_server(new_server_route).await?;
 

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -86,6 +86,11 @@ pub enum RoutingTableError {
 }
 
 pub struct RouteManager {
+    inner: Option<RouteManagerInner>,
+    task: Option<JoinHandle<()>>,
+}
+
+struct RouteManagerInner {
     routing_mode: RouteMode,
     route_manager: SyncRouteManager,
     route_manager_async: AsyncRouteManager,
@@ -101,6 +106,45 @@ pub struct RouteManager {
 
 impl RouteManager {
     pub fn new(
+        routing_mode: RouteMode,
+        server_ip: IpAddr,
+        tun_index: u32,
+        tun_peer_ip: IpAddr,
+        tun_dns_ip: IpAddr,
+    ) -> Result<Self, RoutingTableError> {
+        let inner = Some(RouteManagerInner::new(
+            routing_mode,
+            server_ip,
+            tun_index,
+            tun_peer_ip,
+            tun_dns_ip,
+        )?);
+        Ok(Self { inner, task: None })
+    }
+
+    pub async fn start(&mut self) -> Result<(), RoutingTableError> {
+        let Some(inner) = self.inner.take() else {
+            return Err(RoutingTableError::InsufficientPermissions);
+        };
+
+        self.task = inner.start().await?;
+        Ok(())
+    }
+
+    pub async fn stop(&mut self) -> Result<(), RoutingTableError> {
+        if let Some(task) = self.task.take() {
+            task.abort();
+
+            // Wait till the task finishes to clear routes
+            let _ = task.await;
+        }
+
+        Ok(())
+    }
+}
+
+impl RouteManagerInner {
+    fn new(
         routing_mode: RouteMode,
         server_ip: IpAddr,
         tun_index: u32,
@@ -295,7 +339,7 @@ impl RouteManager {
 
     /// Install routes required to use tunnel and start monitoring route changes
     /// to update the routes if needed (mostly during connection floating)
-    pub async fn start(mut self) -> Result<Option<JoinHandle<()>>, RoutingTableError> {
+    async fn start(mut self) -> Result<Option<JoinHandle<()>>, RoutingTableError> {
         if self.routing_mode == RouteMode::NoExec {
             return Ok(None);
         }
@@ -407,7 +451,7 @@ impl RouteManager {
     }
 }
 
-impl Drop for RouteManager {
+impl Drop for RouteManagerInner {
     fn drop(&mut self) {
         self.cleanup_sync();
     }
@@ -433,7 +477,7 @@ mod tests {
 
     /// Helper to create test routes with gateway lookup
     fn create_test_routes_with_gateway(
-        route_manager: &mut RouteManager,
+        route_manager: &mut RouteManagerInner,
     ) -> (Route, Route, Route, IpAddr) {
         let default_route = route_manager.find_route(&EXTERNAL_IP).unwrap();
         let gateway_ip = default_route.gateway().unwrap();
@@ -453,11 +497,11 @@ mod tests {
             && route1.if_index() == route2.if_index()
     }
 
-    /// Creates a test setup with RouteRestorer, TUN device, and RouteManager
+    /// Creates a test setup with RouteRestorer, TUN device, and RouteManagerInner
     /// Returns tuple where RouteRestorer is dropped last for proper cleanup
     async fn create_test_setup(
         route_mode: RouteMode,
-    ) -> Result<(RouteRestorer, AsyncDevice, RouteManager), Box<dyn std::error::Error>> {
+    ) -> Result<(RouteRestorer, AsyncDevice, RouteManagerInner), Box<dyn std::error::Error>> {
         // Capture initial state FIRST
         let restorer = RouteRestorer::new();
 
@@ -481,11 +525,11 @@ mod tests {
 
         let tun_index = tun_device.if_index()?;
 
-        // Then create RouteManager
+        // Create RouteManagerInner directly for testing
         let route_manager =
-            RouteManager::new(route_mode, EXTERNAL_IP, tun_index, TUN_PEER_IP, TUN_DNS_IP)?;
+            RouteManagerInner::new(route_mode, EXTERNAL_IP, tun_index, TUN_PEER_IP, TUN_DNS_IP)?;
 
-        // Return tuple - RouteManager will be dropped first, then TUN device, RouteRestorer last
+        // Return tuple - RouteManagerInner will be dropped first, then TUN device, RouteRestorer last
         Ok((restorer, tun_device, route_manager))
     }
 

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -805,4 +805,109 @@ mod tests {
         let found_route2 = route_manager.find_route(&ROUTE_TEST_IP2).unwrap();
         assert_eq!(found_route2.gateway(), route2.gateway());
     }
+
+    #[test_case(RouteMode::Default)]
+    #[test_case(RouteMode::Lan)]
+    #[test_case(RouteMode::NoExec)]
+    #[tokio::test]
+    async fn test_route_manager_start_stop(route_mode: RouteMode) {
+        let mut route_manager =
+            RouteManager::new(route_mode, EXTERNAL_IP, 0, TUN_PEER_IP, TUN_DNS_IP).unwrap();
+
+        // Test that we can start the route manager
+        let start_result = route_manager.start().await;
+        if route_mode == RouteMode::NoExec {
+            // NoExec mode should succeed but not actually do anything
+            assert!(start_result.is_ok());
+        } else {
+            // Other modes may require privileges, so we just check it doesn't panic
+            let _ = start_result;
+        }
+
+        // Test that we can stop the route manager
+        let stop_result = route_manager.stop().await;
+        assert!(stop_result.is_ok());
+
+        // Test that stopping again is safe
+        let stop_again_result = route_manager.stop().await;
+        assert!(stop_again_result.is_ok());
+    }
+
+    #[test_case(RouteMode::Default)]
+    #[test_case(RouteMode::Lan)]
+    #[tokio::test]
+    async fn test_route_manager_inner_structure(route_mode: RouteMode) {
+        // Test that RouteManagerInner can be created directly
+        let inner_result =
+            RouteManagerInner::new(route_mode, EXTERNAL_IP, 0, TUN_PEER_IP, TUN_DNS_IP);
+        assert!(inner_result.is_ok());
+
+        let inner = inner_result.unwrap();
+        assert_eq!(inner.routing_mode, route_mode);
+        assert_eq!(inner.server_ip, EXTERNAL_IP);
+        assert_eq!(inner.tun_index, 0);
+        assert_eq!(inner.tun_peer_ip, TUN_PEER_IP);
+        assert_eq!(inner.tun_dns_ip, TUN_DNS_IP);
+        assert_eq!(inner.vpn_routes.len(), 0);
+        assert_eq!(inner.lan_routes.len(), 0);
+        assert!(inner.server_route.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_route_manager_double_start_error() {
+        let mut route_manager =
+            RouteManager::new(RouteMode::NoExec, EXTERNAL_IP, 0, TUN_PEER_IP, TUN_DNS_IP).unwrap();
+
+        // First start should succeed
+        assert!(route_manager.start().await.is_ok());
+
+        // Second start should fail since inner is already taken
+        let second_start_result = route_manager.start().await;
+        assert!(second_start_result.is_err());
+        assert!(matches!(
+            second_start_result.unwrap_err(),
+            RoutingTableError::InsufficientPermissions
+        ));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(route_manager)]
+    #[ignore = "Requires network privileges and may affect system routing"]
+    async fn test_privileged_route_monitoring_server_route_update() {
+        let (_restorer, _tun_device, mut inner) =
+            create_test_setup(RouteMode::Default).await.unwrap();
+
+        // Install initial routes
+        inner.install_routes().await.unwrap();
+
+        // Verify server route was created
+        assert!(inner.server_route.is_some());
+        let initial_server_route = inner.server_route.as_ref().unwrap().clone();
+
+        // Test check_and_update_server_route when no change is needed
+        let result = inner.check_and_update_server_route().await;
+        assert!(result.is_ok());
+
+        // Server route should remain unchanged
+        assert!(inner.server_route.is_some());
+        let unchanged_route = inner.server_route.as_ref().unwrap();
+        assert_eq!(
+            initial_server_route.destination(),
+            unchanged_route.destination()
+        );
+        assert_eq!(initial_server_route.prefix(), unchanged_route.prefix());
+    }
+
+    #[tokio::test]
+    async fn test_route_manager_start_with_noexec_mode() {
+        // Don't create TUN device for NoExec mode, just test RouteManagerInner directly
+        let inner =
+            RouteManagerInner::new(RouteMode::NoExec, EXTERNAL_IP, 1, TUN_PEER_IP, TUN_DNS_IP)
+                .unwrap();
+
+        // NoExec mode should return None (no monitoring task)
+        let monitor_task = inner.start().await;
+        assert!(monitor_task.is_ok());
+        assert!(monitor_task.unwrap().is_none());
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Subscribe to route changes and update server route accordingly.
For windows, additionally listen to addr changes since routes changes are not always published.

## Motivation and Context

Lightway UDP protocol supports floating clients ie. Clients can move between different networks and the connection stays online/resume without disconnecting.

When lightway client connects to a server, it creates a static route to server to override the default tunnel route. When network change, this has to be changed appropriately to float the connection to support floating connection

## How Has This Been Tested?

Verified floating connection is working in windows using Ethernet and Wifi and switching between two connections multiple times

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
