### PR TITLE
client: Send best connection index to caller

### DIFF
--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -170,6 +170,7 @@ async fn main() -> Result<()> {
         inside_pkt_codec_config: None,
         stop_signal: ctrlc_rx,
         network_change_signal: None,
+        best_connection_selected_signal: None,
         #[cfg(feature = "debug")]
         tls_debug: config.tls_debug,
         #[cfg(feature = "debug")]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a new optional `best_connection_selected_signal` field to `ClientConfig` that allows callers of lightway client to be notified of when the best connection is chosen, and the index of it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, the parallel connect feature is a black box. The caller does not know which server it is connected, and when the best connection has been chosen.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
CI pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
