### PR TITLE
COVPN-16: Use lowercase for all config enums

### DIFF
--- a/lightway-app-utils/src/args/cipher.rs
+++ b/lightway-app-utils/src/args/cipher.rs
@@ -5,6 +5,7 @@ use lightway_core::Cipher as LWCipher;
 
 #[derive(Copy, Clone, Debug, ValueEnum, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
+#[value(rename_all = "lowercase")]
 /// [`LWCipher`] wrapper compatible with clap and twelf
 pub enum Cipher {
     /// AES256 Cipher

--- a/lightway-app-utils/src/args/connection_type.rs
+++ b/lightway-app-utils/src/args/connection_type.rs
@@ -5,6 +5,7 @@ use lightway_core::ConnectionType as LWConnectionType;
 
 #[derive(Copy, Clone, ValueEnum, Debug, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
+#[value(rename_all = "lowercase")]
 /// [`lightway_core::ConnectionType`] wrapper compatible with clap and twelf
 pub enum ConnectionType {
     /// UDP (Datagram)

--- a/lightway-app-utils/src/args/logging.rs
+++ b/lightway-app-utils/src/args/logging.rs
@@ -4,6 +4,7 @@ use tracing_subscriber::{filter::LevelFilter, fmt::SubscriberBuilder};
 
 #[derive(Copy, Clone, ValueEnum, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[value(rename_all = "lowercase")]
 /// Tracing log format type compatible with clap and twelf
 pub enum LogFormat {
     /// human-readable, single-line logs for each event that occurs
@@ -30,6 +31,7 @@ impl LogFormat {
 
 #[derive(Copy, Clone, ValueEnum, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[value(rename_all = "lowercase")]
 /// Tracing log level type compatible with clap and twelf
 pub enum LogLevel {
     /// Trace

--- a/lightway-client/src/dns_manager.rs
+++ b/lightway-client/src/dns_manager.rs
@@ -7,6 +7,7 @@ use tracing::warn;
 /// DNS configuration mode
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
+#[value(rename_all = "lowercase")]
 pub enum DnsConfigMode {
     #[default]
     Default,

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -61,6 +61,7 @@ const TUNNEL_ROUTES: [(IpAddr, u8); 2] = [
 
 #[derive(Debug, PartialEq, Copy, Clone, clap::ValueEnum, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
+#[value(rename_all = "lowercase")]
 pub enum RouteMode {
     #[default]
     Default,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
clap's ValueEnum defaults to rename using kebab-case. This changes it to lowercase to match serde.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
serde renames enums with lowercase, clap renames with kebab-case. This causes an issue when trying to input some enums via cli, such as route-mode.

COVPN-16

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
CI should pass. No change to existing configuration needed, this fixes CLI usage only.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
