### PR TITLE
COVPN-27: add EncodingStateChanged event

### DIFF
--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -324,6 +324,9 @@ async fn handle_events<A: 'static + Send + EventCallback, ExtAppState: Send + Sy
             Event::FirstPacketReceived => {
                 info!("First outside packet received");
             }
+            Event::EncodingStateChanged { enabled } => {
+                info!("Encoding state changed to {enabled}");
+            }
 
             // Server only events
             Event::SessionIdRotationAcknowledged { .. }

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -19,8 +19,14 @@ struct EventHandler;
 
 impl EventCallback for EventHandler {
     fn event(&mut self, event: lightway_core::Event) {
-        if let Event::StateChanged(state) = event {
-            tracing::debug!("State changed to {:?}", state);
+        match event {
+            Event::StateChanged(state) => {
+                tracing::debug!("State changed to {:?}", state);
+            }
+            Event::EncodingStateChanged { enabled } => {
+                tracing::debug!("Encoding state changed to {:?}", enabled);
+            }
+            _ => {}
         }
     }
 }

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -1640,6 +1640,8 @@ impl<AppState: Send> Connection<AppState> {
             encoder.get_encoding_state()
         );
 
+        self.event(Event::EncodingStateChanged { enabled: er.enable });
+
         // Reply to the client.
         let msg = wire::Frame::EncodingResponse(wire::EncodingResponse {
             id: er.id,
@@ -1695,6 +1697,10 @@ impl<AppState: Send> Connection<AppState> {
 
         encoder.set_encoding_state(new_setting);
         info!("inside packet encoding state is now set to {}", new_setting);
+
+        self.event(Event::EncodingStateChanged {
+            enabled: new_setting,
+        });
 
         // Removes from pending pkt store such that it is no longer retransmitted
         self.encoding_request_states.pending_request_pkt = None;

--- a/lightway-core/src/connection/event.rs
+++ b/lightway-core/src/connection/event.rs
@@ -30,4 +30,12 @@ pub enum Event {
     ///
     /// Client connections only
     FirstPacketReceived,
+    /// The inside packet codec encoding state has changed
+    ///
+    /// Fired when the server agrees to enable or disable the inside packet codec
+    /// after the client requests it, or when the server enables/disables it.
+    EncodingStateChanged {
+        /// Whether encoding is now enabled
+        enabled: bool,
+    },
 }

--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -465,6 +465,9 @@ async fn client<S: TestSock>(
                     println!("First packet received");
                     is_first_packet_received = true;
                 }
+                Event::EncodingStateChanged { enabled } => {
+                    println!("Encoding state change to {enabled}")
+                }
             }
         }
     });

--- a/lightway-server/src/connection_manager.rs
+++ b/lightway-server/src/connection_manager.rs
@@ -160,6 +160,7 @@ async fn handle_events(mut stream: EventStream, conn: Weak<Connection>) {
             Event::FirstPacketReceived => {
                 unreachable!("client only event received");
             }
+            Event::EncodingStateChanged { .. } => {}
         }
     }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
EncodingStateChanged event is now emitted when the server's encoding state is updated or when a client request to change the encoding state is processed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For consumers of lightway-client/server to be aware of encoding state changes. Previously, we have to read the logs to know when encoding state has been changed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested to make sure the event is being passed properly on both client and server

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
