### PR TITLE
CI: Use `windows-11-arm` for Windows ARM

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -222,13 +222,19 @@ jobs:
 
   windows-build:
     name: Windows Build
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     env:
       FORCE_COLOR: 1
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64-pc-windows-msvc]
+        include:
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            arch: x64
+          - target: aarch64-pc-windows-msvc
+            os: windows-11-arm
+            arch: arm64
     steps:
       - uses: actions/checkout@v4
       - name: Get Rust version
@@ -264,5 +270,5 @@ jobs:
         run: >-
           cargo build --release --bin lightway-client --target ${{ matrix.target }}
 
-      - name: Run tests
+      - name: Run tests (${{ matrix.arch }})
         run: cargo test --target ${{ matrix.target }} -p lightway-client


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since `aarch64-pc-windows-msvc` target got promoted to tier 1, we now build and test windwos ARM device on the an actual machine to validate everything is working fine on the new platform.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Rust moving windows ARM target to tier 1:
https://blog.rust-lang.org/2025/10/30/Rust-1.91.0/#aarch64-pc-windows-msvc-is-now-a-tier-1-platform

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passed CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
