### PR TITLE
COVPN-31: server: Add encoding_enabled metric

### DIFF
--- a/docs/logs_and_metrics.md
+++ b/docs/logs_and_metrics.md
@@ -71,6 +71,7 @@ Lightway server also supports metrics to monitor. The following are the metrics 
 | sessions_pending_id_rotations | server | Gauge | The number of connections for which a session ID rotation is in progress |
 | sessions_active_5m<br>sessions_active_15m<br>sessions_active_60m | server | Gauge | The number of connections which were “active” in most recent N minutes.<br>An “active” connection is one where traffic has been seen from the client to the Internet |
 | sessions_standby_5m<br>sessions_standby_15m<br>sessions_standby_60m | server | Gauge | The number of connections which were “on standby” in most recent N minutes.<br>An “on standby” connection is one where traffic has been seen from the Internet to the client |
+| sessions_encoding_enabled | server | Gauge | The number of connections which currently have encoding enabled |
 | assigned_internal_ips | server | Gauge | The current number of IPs which are allocated to connections |
 
 

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -1729,6 +1729,14 @@ impl<AppState: Send> Connection<AppState> {
         }
     }
 
+    /// Get the current encoding state from the encoder
+    pub fn is_encoding_enabled(&self) -> bool {
+        self.inside_pkt_encoder
+            .as_ref()
+            .map(|encoder| encoder.get_encoding_state())
+            .unwrap_or(false)
+    }
+
     /// Create and send an encoding request to the server. (Client only)
     pub fn set_encoding(&mut self, enable: bool) -> ConnectionResult<()> {
         if self.inside_pkt_encoder.is_none() {

--- a/lightway-server/src/connection.rs
+++ b/lightway-server/src/connection.rs
@@ -207,6 +207,10 @@ impl Connection {
 impl Drop for Connection {
     fn drop(&mut self) {
         trace!("Dropping Connection!");
+        let conn = self.lw_conn.lock().unwrap();
+        if conn.is_encoding_enabled() {
+            metrics::connection_encoding_disabled();
+        }
         metrics::connection_closed();
     }
 }

--- a/lightway-server/src/connection_manager.rs
+++ b/lightway-server/src/connection_manager.rs
@@ -147,6 +147,15 @@ fn handle_tls_keys_update_complete() {
 }
 
 #[instrument(level = "trace", skip_all)]
+fn handle_encoding_state_changed(enabled: bool) {
+    if enabled {
+        metrics::connection_encoding_enabled();
+    } else {
+        metrics::connection_encoding_disabled();
+    }
+}
+
+#[instrument(level = "trace", skip_all)]
 async fn handle_events(mut stream: EventStream, conn: Weak<Connection>) {
     while let Some(event) = stream.next().await {
         match event {
@@ -160,7 +169,7 @@ async fn handle_events(mut stream: EventStream, conn: Weak<Connection>) {
             Event::FirstPacketReceived => {
                 unreachable!("client only event received");
             }
-            Event::EncodingStateChanged { .. } => {}
+            Event::EncodingStateChanged { enabled } => handle_encoding_state_changed(enabled),
         }
     }
 }

--- a/lightway-server/src/metrics.rs
+++ b/lightway-server/src/metrics.rs
@@ -95,6 +95,8 @@ static METRIC_SESSIONS_STANDBY_15M: LazyLock<Gauge> =
     LazyLock::new(|| gauge!("sessions_standby_15m"));
 static METRIC_SESSIONS_STANDBY_60M: LazyLock<Gauge> =
     LazyLock::new(|| gauge!("sessions_standby_60m"));
+static METRIC_SESSIONS_ENCODING_ENABLED: LazyLock<Gauge> =
+    LazyLock::new(|| gauge!("sessions_encoding_enabled"));
 
 static METRIC_ASSIGNED_INTERNAL_IPS: LazyLock<Gauge> =
     LazyLock::new(|| gauge!("assigned_internal_ips"));
@@ -359,6 +361,16 @@ pub(crate) fn sessions_statistics(
     METRIC_SESSIONS_STANDBY_5M.set(standby.five_minutes as f64);
     METRIC_SESSIONS_STANDBY_15M.set(standby.fifteen_minutes as f64);
     METRIC_SESSIONS_STANDBY_60M.set(standby.sixty_minutes as f64);
+}
+
+/// Connection's [`lightway_app_utils::PacketCodec`] enabled
+pub(crate) fn connection_encoding_enabled() {
+    METRIC_SESSIONS_ENCODING_ENABLED.increment(1.0);
+}
+
+/// Connection's [`lightway_app_utils::PacketCodec`] disabled
+pub(crate) fn connection_encoding_disabled() {
+    METRIC_SESSIONS_ENCODING_ENABLED.decrement(1.0);
 }
 
 /// Number of IP addresses in use


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a new `encoding_enabled` counter metric to server.

This is incremented when the server accepts a client's encoding request.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To monitor codec enable rate

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Should compile. EncodingStateChanged event handler has been tested previously.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
