### PR TITLE
server: remove average dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,17 +225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "average"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c5a79a6c36c527e1c31bc0effa93af02e7278b7369b83e0674255290b6c1b0"
-dependencies = [
- "easy-cast",
- "float-ord",
- "num-traits",
-]
-
-[[package]]
 name = "aws-lc-rs"
 version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/lightway-server/Cargo.toml
+++ b/lightway-server/Cargo.toml
@@ -19,7 +19,6 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-average = "0.17.0"
 bytes.workspace = true
 bytesize.workspace = true
 clap.workspace = true

--- a/lightway-server/src/ip_manager/ip_pool.rs
+++ b/lightway-server/src/ip_manager/ip_pool.rs
@@ -368,8 +368,6 @@ mod tests {
 
     #[test]
     fn test_shuffle() {
-        use average::Mean;
-
         let mut pool = get_ip_pool();
         pool.shuffle_ips();
 
@@ -386,15 +384,19 @@ mod tests {
         // chances of this coming out as less than 512 in practice are
         // miniscule.
         let mut previous = pool.allocate_ip().unwrap().to_bits();
-        let m: Mean = std::iter::from_fn(|| {
+        let (count, total_differences) = std::iter::from_fn(|| {
             let ip = pool.allocate_ip()?.to_bits();
 
             let delta = ip.abs_diff(previous);
             previous = ip;
             Some(delta as f64)
         })
-        .collect();
-        assert_gt!(m.mean(), 512.0);
+        .fold((0, 0.0f64), |(mut count, mut total_differences), v| {
+            count += 1;
+            total_differences += v;
+            (count, total_differences)
+        });
+        assert_gt!(total_differences / count as f64, 512.0);
     }
 }
 

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -48,24 +48,25 @@ async fn metrics_debug() {
                 metrics_util::debugging::DebugValue::Gauge(value) => {
                     trace!("metric: {} {labels:?} = Guage({value:?})", name.as_str())
                 }
-                metrics_util::debugging::DebugValue::Histogram(values) => {
-                    // TODO: https://docs.rs/average/latest/average/macro.concatenate.html for min/max and avg?
-
-                    use average::{Estimate, Max, Mean, Min, concatenate};
-
-                    concatenate!(Stats, [Min, min], [Mean, mean], [Max, max]);
-                    let len = values.len();
-                    let s: Stats = values.into_iter().map(|f| f.into_inner()).collect();
-
+                metrics_util::debugging::DebugValue::Histogram(values) if !values.is_empty() => {
+                    let (sum, maximum, minimum) = values.iter().fold(
+                        (0.0f64, f64::NEG_INFINITY, f64::INFINITY),
+                        |(mut sum, maximum, minimum), v| {
+                            let v = v.into_inner();
+                            sum += v;
+                            (sum, maximum.max(v), minimum.min(v))
+                        },
+                    );
                     trace!(
                         "metric: {} {labels:?} = Histogram({} samples min/avg/max {:.2}/{:.2}/{:.2})",
                         name.as_str(),
-                        len,
-                        s.min(),
-                        s.mean(),
-                        s.max(),
+                        values.len(),
+                        minimum,
+                        sum / values.len() as f64,
+                        maximum,
                     )
                 }
+                _ => (),
             };
         }
     }


### PR DESCRIPTION
Remove average dependency in server crate

## Description
Remove average dependency and implement without additional crate

## Motivation and Context
This refactor PR follow the TODO hint in the code.
Two facts about this refactor.

- Macro takes compiling time, and we use average crate macro, but the lines of code does not significantly reduce.
- The macro implement inline functions to avoid performance costs, but the `fn new` will call the default functions, and these are not inline functions.
https://docs.rs/average/latest/src/average/macros.rs.html#129

## How Has This Been Tested?
This refactor obey the current test cases.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
