### PR TITLE
COVPN-32: Support X25519 x ML-KEM-768 hybrid method

### DIFF
--- a/lightway-core/src/context.rs
+++ b/lightway-core/src/context.rs
@@ -355,6 +355,8 @@ const SERVER_CURVE_PQC_GROUPS: &[wolfssl::CurveGroup] = &[
     wolfssl::CurveGroup::P521MLKEM1024,
     wolfssl::CurveGroup::P521KyberLevel5,
     #[cfg(not(feature = "kyber_only"))]
+    wolfssl::CurveGroup::X25519MLKEM768,
+    #[cfg(not(feature = "kyber_only"))]
     wolfssl::CurveGroup::P256MLKEM512,
     wolfssl::CurveGroup::P256KyberLevel1,
     wolfssl::CurveGroup::EccSecp256R1,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Support one additional post-quantum key exchange method, X25519 with ML-KEM-768.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The method is drafted in IETF's [Post-quantum hybrid ECDHE-MLKEM Key Agreement for TLSv1.3](https://www.ietf.org/archive/id/draft-ietf-tls-ecdhe-mlkem-00.html).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This PR only changes the server-side groups, to test this effectively we need to change the client's as well.

https://github.com/expressvpn/lightway/blob/7c9eec9173e5afbc9388e1b2576bb86f3cca7a47/lightway-core/src/connection/builders.rs#L174

Change this to `X25519MLKEM768`. Running `earthly --allow-privileged +e2e` succeeds.

## Related
- https://github.com/expressvpn/wolfssl-rs/pull/311

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`