### PR TITLE
nix: Add support for `xcodes` on Darwin systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,8 @@
             automake
             libtool
             rustPlatform.bindgenHook
+          ] ++ lib.optionals pkgs.stdenv.isDarwin [
+            xcodes
           ];
           devDeps = with pkgs; [
             cargo-deny
@@ -74,6 +76,9 @@
             pkgs.mkShell {
               shellHook = ''
                 export RUST_SRC_PATH=${pkgs.rustPlatform.rustLibSrc}
+                ${lib.optionalString pkgs.stdenv.isDarwin ''
+                  xcodes select 26.0.1
+                ''}
               '';
               buildInputs = runtimeDeps;
               nativeBuildInputs = buildDeps ++ devDeps ++ [ rustc ];


### PR DESCRIPTION
Enable `xcodes` as a development dependency and configure `xcodes` selection in the shell for macOS builds.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
