### PR TITLE
Fix RUST_LOG implementation by using default directive

### DIFF
--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -78,16 +78,14 @@ async fn main() -> Result<()> {
         Layer::Clap(matches),
     ])?;
 
+    let level: tracing::level_filters::LevelFilter = config.log_level.into();
     let filter = tracing_subscriber::EnvFilter::builder()
+        .with_default_directive(level.into())
         // https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.Builder.html#method.with_regex
         // recommends to disable REGEX when using envfilter from untrusted sources
         .with_regex(false)
-        .from_env()
-        .unwrap_or_else(|_| {
-            // If RUST_LOG is not set, use config.log_level as default
-            let level: tracing::level_filters::LevelFilter = config.log_level.into();
-            tracing_subscriber::EnvFilter::new(level.to_string())
-        });
+        .with_env_var("LW_CLIENT_RUST_LOG")
+        .from_env_lossy();
     let fmt = tracing_subscriber::fmt().with_env_filter(filter);
 
     LogFormat::Full.init_with_env_filter(fmt);

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -107,16 +107,14 @@ async fn main() -> Result<()> {
         set_logging_callback(Some(wolfssl_tracing_callback));
     }
 
+    let level: tracing::level_filters::LevelFilter = config.log_level.into();
     let filter = tracing_subscriber::EnvFilter::builder()
+        .with_default_directive(level.into())
         // https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.Builder.html#method.with_regex
         // recommends to disable REGEX when using envfilter from untrusted sources
         .with_regex(false)
-        .from_env()
-        .unwrap_or_else(|_| {
-            // If RUST_LOG is not set, use config.log_level as default
-            let level: tracing::level_filters::LevelFilter = config.log_level.into();
-            tracing_subscriber::EnvFilter::new(level.to_string())
-        });
+        .with_env_var("LW_SERVER_RUST_LOG")
+        .from_env_lossy();
     let fmt = tracing_subscriber::fmt().with_env_filter(filter);
 
     config.log_format.init_with_env_filter(fmt);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The issue was using `EnvFilter::builder().from_env()` which returns `Ok` even when `RUST_LOG` is unset, preventing the `unwrap_or_else` fallback from executing. This meant whatever fallback settings we had were ignored.

~Changed to use `try_from_env()` instead, which properly returns `Err` when `RUST_LOG` is not set, allowing the `unwrap_or_else` fallback to use `config.log_level` (from CLI args, env vars, or config file).~

From [docs](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#method.from_env) on `from_env`, it will use a "error" default when seeing unset/empty env var:

> If the environment variable is empty or not set, or if it contains only invalid directives, a default directive enabling the [ERROR](https://docs.rs/tracing-core/0.1.35/x86_64-unknown-linux-gnu/tracing_core/metadata/struct.Level.html#associatedconstant.ERROR) level is added.

And from [docs](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#method.try_from_env) on `try_from_env`, it will give an `Err` when seeing unset env var:

> Returns a new EnvFilter from the value of the given environment variable, or an error if the environment variable is unset or contains any invalid filter directives.

Edit: a even nicer approach is to use default directive, eliminating the extra `unwrap_or_else`.

Thanks to https://github.com/expressvpn/lightway/issues/322 for the pointers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
