### PR TITLE
client: migrate from core-foundation to objc2-core-foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,7 +1539,6 @@ dependencies = [
  "bytesize",
  "cfg_aliases",
  "clap",
- "core-foundation",
  "ctrlc",
  "educe",
  "futures",
@@ -1547,12 +1546,13 @@ dependencies = [
  "lightway-app-utils",
  "lightway-core",
  "more-asserts",
+ "objc2-core-foundation",
+ "objc2-system-configuration",
  "pnet_packet",
  "route_manager",
  "serde",
  "serial_test",
  "socket2",
- "system-configuration",
  "test-case",
  "thiserror 2.0.17",
  "tokio",
@@ -1806,7 +1806,7 @@ dependencies = [
  "netlink-sys",
  "nix 0.30.1",
  "scopeguard",
- "system-configuration-sys 0.5.0",
+ "system-configuration-sys",
  "thiserror 2.0.17",
  "widestring",
  "windows",
@@ -2015,10 +2015,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-security",
+]
 
 [[package]]
 name = "object"
@@ -2962,31 +3000,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags",
- "core-foundation",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
 name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/deny.toml
+++ b/deny.toml
@@ -76,7 +76,6 @@ skip = [
     { name = "rand", version = "0.8.5" },
     { name = "rand_chacha", version = "0.3.1" },
     { name = "rand_core", version = "0.6.4" },
-    { name = "system-configuration-sys", version = "0.5.0" },
     { name = "nix", version = "0.29.0" }
 ]
 

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -54,8 +54,8 @@ cfg_aliases = "0.2.1"
 route_manager = { version = "0.2.6", features = ["async"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-foundation = "0.9.4"
-system-configuration = "0.6.1"
+objc2-core-foundation = "0.3.1"
+objc2-system-configuration = "0.3.1"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Replace unmaintained core-foundation and system-configuration crates with actively maintained objc2-core-foundation and objc2-system-configuration.

The objc2 crates provide better maintenance, improved safety (CfRetained), and modern API generated from Xcode SDKs directly. Another main advantage is both core-foundation and system-configuration are from same provider. So it is always in sync unlike the current ones.


## Motivation and Context

For macos, we use core-foundation and system-configuration crate for configuring DNS settings. But they are from different vendors and not always upto date
Example: https://github.com/expressvpn/lightway/actions/runs/20258044436/job/58164034119#step:11:1

Move it to better maintained and in sync crates

## How Has This Been Tested?

Verified DNS settings are set properly after the move

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
