### PR TITLE
Modify quick start guide for yq installation

### DIFF
--- a/docs/quick_start_guide.md
+++ b/docs/quick_start_guide.md
@@ -23,7 +23,9 @@ This guide will help you quickly set up a Lightway VPN server and client using t
 Install dependencies on Debian/Ubuntu:
 ```bash
 sudo apt-get update
-sudo apt-get install jq yq apache2-utils iproutes2 iptables
+sudo apt-get install jq apache2-utils iproute2 iptables
+sudo wget -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+sudo chmod +x /usr/local/bin/yq
 ```
 
 ### Client Requirements


### PR DESCRIPTION
This pull request updates the quick start guide to correct package names and installation steps for dependencies on Debian/Ubuntu systems. The instructions now ensure that the correct packages are installed and provide a reliable method for installing `yq`.

Dependency installation improvements:

* Updated the package list to use the correct package name `iproute2` instead of the incorrect `iproutes2`, and removed `yq` from the package manager installation since it's not available via `apt-get`.
* Added instructions to manually download and install the latest `yq` binary from GitHub, ensuring users get the correct version.
* Fix `iproutes2` typo