### PR TITLE
security: strip debug symbols from release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "3"
 
 [profile.release]
 lto = true
-debug = 1
+strip = "symbols"
 
 [workspace.package]
 repository = "https://github.com/expressvpn/lightway"


### PR DESCRIPTION
## Summary
Strip debug symbols from release builds to reduce binary size and improve security.

## Changes
- Changed `debug = 1` to `strip = "symbols"` in `[profile.release]` section of `Cargo.toml`

## Security Impact
- Reduces binary size
- Removes debug information that could aid reverse engineering
- Makes debugging production crashes slightly harder (but production should use crash reporting tools)