### PR TITLE
CVPN-2534: Don't block on slow connection setup before selecting best connection

### DIFF
--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -17,7 +17,7 @@ uniffi::setup_scaffolding!();
 use anyhow::{Context, Result, anyhow};
 use bytes::BytesMut;
 use bytesize::ByteSize;
-use futures::{FutureExt, future::join_all};
+use futures::{FutureExt, future::join_all, stream::FuturesUnordered};
 pub use io::inside::{InsideIO, InsideIORecv};
 use keepalive::Keepalive;
 use lightway_app_utils::{
@@ -934,26 +934,37 @@ pub async fn connect<
     })
 }
 
-/// Returns the index of the best connection
-/// If `config.preferred_connection_wait_interval` is set, it will wait that
-/// duration before returning the highest priority connection (in the specified
-/// array order).
-/// If there is only one connection, or the preferred connection
+/// Returns the index of the best connection.
+///
+/// Receives `(index, connected_signal)` pairs from `connection_setup_rx` as connections
+/// are set up, rather than requiring all connections to be ready upfront.
+/// The channel closing signals that no more connections will arrive.
+///
+/// If `preferred_connection_wait_interval` is non-zero it will wait that
+/// duration before returning the highest priority connection (lowest index).
+/// If there is only one connection, or the preferred connection (index 0)
 /// is the first to connect, it will not wait.
 async fn find_best_connection(
-    connected_signals: Vec<oneshot::Receiver<()>>,
+    mut connection_setup_rx: mpsc::Receiver<(usize, oneshot::Receiver<()>)>,
     preferred_connection_wait_interval: Duration,
 ) -> Result<usize> {
     let mut wait_timer_task = tokio::spawn(tokio::time::sleep(preferred_connection_wait_interval));
 
-    let mut connected_stream = StreamMap::with_capacity(connected_signals.len());
-    for (i, rx) in connected_signals.into_iter().enumerate() {
-        connected_stream.insert(i, rx.into_stream());
-    }
-
+    let mut connected_stream = StreamMap::new();
     let mut best_connection_index: Option<usize> = None;
+    let mut channel_open = true;
+
     loop {
         tokio::select! {
+            biased;
+            // Highest priority to make sure we add connections to the stream as soon as they are ready
+            item = connection_setup_rx.recv(), if channel_open => {
+                if let Some((index, signal)) = item {
+                    connected_stream.insert(index, signal.into_stream());
+                } else {
+                    channel_open = false;
+                }
+            }
             _ = &mut wait_timer_task, if !wait_timer_task.is_finished() => {
                 if let Some(index) = best_connection_index {
                     tracing::debug!("Preferred connection wait finished, using best connection so far: {index}");
@@ -1062,57 +1073,96 @@ pub async fn client<
             peer_ip = %config.tun_peer_ip,
         );
     }
-    let (original_indices, mut connections): (Vec<_>, Vec<_>) = join_all(
-        servers
+
+    let server_count = servers.len();
+    let preferred_connection_wait_interval = config.preferred_connection_wait_interval;
+    let mut connections: Vec<(usize, ClientConnection<_>)> = Vec::new();
+
+    let mut stop_signal = config.stop_signal.take().expect("stop_signal must be set");
+
+    let best_connection_index = {
+        let mut connect_futs: FuturesUnordered<_> = servers
             .into_iter()
-            .map(|server_config| connect(&config, server_config, inside_io.clone())),
-    )
-    .await
-    .into_iter()
-    .map(|result| result.inspect_err(|e| tracing::error!("Creating connection failed: {e}")))
-    .enumerate()
-    .flat_map(|(index, result)| result.map(|result| (index, result)))
-    .unzip();
+            .enumerate()
+            .map(|(index, server_config)| {
+                let config = &config;
+                let inside_io = inside_io.clone();
+                async move { (index, connect(config, server_config, inside_io).await) }
+            })
+            .collect();
 
-    if connections.is_empty() {
-        return Err(anyhow!("No servers available"));
-    }
+        let (connection_setup_tx, connection_setup_rx) = mpsc::channel(server_count);
+        let mut connection_setup_tx = Some(connection_setup_tx);
+        let mut setup_complete = false;
 
-    let best_connection_index = tokio::select! {
-        index = find_best_connection(
-            connections.iter_mut().map(|c| c.connected_signal.take().unwrap()).collect(),
-            config.preferred_connection_wait_interval
-        ) => {
-            index?
-        }
-        results = join_all(connections.iter_mut().map(|c| &mut c.task)) => {
-            for result in results {
-                if let Err(e) = result {
-                    tracing::error!("Connection failed: {e}");
+        let mut find_best = std::pin::pin!(find_best_connection(
+            connection_setup_rx,
+            preferred_connection_wait_interval,
+        ));
+
+        loop {
+            tokio::select! {
+                biased;
+
+                // User disconnect — highest priority
+                _ = &mut stop_signal => {
+                    return Ok(ClientResult::UserDisconnect);
+                }
+
+                // Connection setup — feeds signals to find_best_connection
+                Some((orig_idx, result)) = connect_futs.next(), if !setup_complete => {
+                    match result {
+                        Ok(mut conn) => {
+                            let signal = conn.connected_signal.take().unwrap();
+                            let _ = connection_setup_tx.as_ref().unwrap().try_send((orig_idx, signal));
+                            connections.push((orig_idx, conn));
+                        }
+                        Err(e) => {
+                            tracing::error!("Creating connection failed: {e}");
+                        }
+                    }
+                    if connect_futs.is_empty() {
+                        setup_complete = true;
+                        drop(connection_setup_tx.take()); // close the signal channel
+                        if connections.is_empty() {
+                            return Err(anyhow!("No servers available"));
+                        }
+                    }
+                }
+
+                // Signal selection — picks the best connection
+                index = &mut find_best => {
+                    break index?;
+                }
+
+                // Task monitoring — all connection tasks exited without success
+                results = join_all(connections.iter_mut().map(|(_, c)| &mut c.task)), if setup_complete => {
+                    for result in results {
+                        if let Err(e) = result {
+                            tracing::error!("Connection failed: {e}");
+                        }
+                    }
+                    return Err(anyhow!("All connections failed to connect."));
                 }
             }
-            return Err(anyhow!("All connections failed to connect."));
-        }
-        _ = &mut config.stop_signal => {
-            return Ok(ClientResult::UserDisconnect);
         }
     };
+    // connect_futs dropped here — releases &config borrow
 
-    tracing::trace!(
-        "Best connection selected: {}",
-        original_indices[best_connection_index]
-    );
+    tracing::trace!("Best connection selected: {best_connection_index}");
     if let Some(signal) = config.best_connection_selected_signal.take()
-        && signal
-            .send(original_indices[best_connection_index])
-            .is_err()
+        && signal.send(best_connection_index).is_err()
     {
         tracing::error!("Failed to send best_connection_selected_signal");
     }
 
-    let mut connection = connections.swap_remove(best_connection_index);
+    let pos = connections
+        .iter()
+        .position(|(idx, _)| *idx == best_connection_index)
+        .unwrap();
+    let (_, mut connection) = connections.swap_remove(pos);
 
-    for conn in connections.iter_mut() {
+    for (_, conn) in connections.iter_mut() {
         let _ = conn.stop_signal.take().unwrap().send(());
     }
 
@@ -1140,7 +1190,7 @@ pub async fn client<
 
     let connection_stop_signal = connection.stop_signal.take().unwrap();
     tokio::spawn(async move {
-        let _ = config.stop_signal.await;
+        let _ = stop_signal.await;
         if let Err(()) = connection_stop_signal.send(()) {
             tracing::error!("Failed to send stop signal");
         }
@@ -1195,6 +1245,7 @@ mod tests {
         connected_signal_order: Vec<usize>,
         should_connect_before_wait_finishes: bool,
     ) -> Option<usize> {
+        let (connection_setup_tx, connection_setup_rx) = mpsc::channel(signals_len);
         let (mut connected_txs, connected_rxs): (
             Vec<Option<oneshot::Sender<()>>>,
             Vec<oneshot::Receiver<()>>,
@@ -1205,8 +1256,13 @@ mod tests {
             })
             .unzip();
 
+        for (i, rx) in connected_rxs.into_iter().enumerate() {
+            connection_setup_tx.try_send((i, rx)).unwrap();
+        }
+        drop(connection_setup_tx);
+
         let task = tokio::spawn(find_best_connection(
-            connected_rxs,
+            connection_setup_rx,
             Duration::from_millis(200),
         ));
 
@@ -1235,11 +1291,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_best_connection_connects_after_wait_finishes() {
+        let (connection_setup_tx, connection_setup_rx) = mpsc::channel(2);
         let (_, rx0) = tokio::sync::oneshot::channel::<()>();
         let (tx1, rx1) = tokio::sync::oneshot::channel::<()>();
 
+        connection_setup_tx.try_send((0, rx0)).unwrap();
+        connection_setup_tx.try_send((1, rx1)).unwrap();
+        drop(connection_setup_tx);
+
         let task = tokio::spawn(find_best_connection(
-            vec![rx0, rx1],
+            connection_setup_rx,
             Duration::from_millis(200),
         ));
 

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -17,7 +17,7 @@ uniffi::setup_scaffolding!();
 use anyhow::{Context, Result, anyhow};
 use bytes::BytesMut;
 use bytesize::ByteSize;
-use futures::{FutureExt, future::join_all, stream::FuturesUnordered};
+use futures::{FutureExt, stream::FuturesUnordered};
 pub use io::inside::{InsideIO, InsideIORecv};
 use keepalive::Keepalive;
 use lightway_app_utils::{
@@ -54,6 +54,7 @@ use std::net::IpAddr;
 use std::path::PathBuf;
 use std::time::Instant;
 use std::{
+    future::Future,
     net::{Ipv4Addr, SocketAddr},
     sync::{Arc, Mutex, Weak},
     time::Duration,
@@ -998,6 +999,67 @@ async fn find_best_connection(
     }
 }
 
+/// Runs connection futures concurrently, feeds their connected signals to
+/// [`find_best_connection`], and returns the best connection index along with
+/// all successful connections.
+///
+/// Each connect future must yield `(index, Result<(connected_signal, connection)>)`.
+/// The `connected_signal` is forwarded to the selection logic; the `connection` is
+/// stored and returned alongside the winning index.
+async fn select_best_from_futures<C, Fut>(
+    mut connect_futs: FuturesUnordered<Fut>,
+    preferred_connection_wait_interval: Duration,
+) -> Result<(usize, Vec<(usize, C)>)>
+where
+    Fut: Future<Output = (usize, Result<(oneshot::Receiver<()>, C)>)>,
+{
+    if connect_futs.is_empty() {
+        return Err(anyhow!("No servers available"));
+    }
+
+    let server_count = connect_futs.len();
+    let mut connections: Vec<(usize, C)> = Vec::new();
+
+    let (connection_setup_tx, connection_setup_rx) = mpsc::channel(server_count);
+    let mut connection_setup_tx = Some(connection_setup_tx);
+    let mut setup_complete = false;
+
+    let mut find_best = std::pin::pin!(find_best_connection(
+        connection_setup_rx,
+        preferred_connection_wait_interval,
+    ));
+
+    loop {
+        tokio::select! {
+            biased;
+
+            // Higher priority to ensure we add the connection to find_best_connection asap
+            Some((orig_idx, result)) = connect_futs.next(), if !setup_complete => {
+                match result {
+                    Ok((signal, conn)) => {
+                        let _ = connection_setup_tx.as_ref().unwrap().send((orig_idx, signal)).await.inspect_err(|e| tracing::warn!("Failed to send connection signal: {e}"));
+                        connections.push((orig_idx, conn));
+                    }
+                    Err(e) => {
+                        tracing::error!("Creating connection failed: {e}");
+                    }
+                }
+                if connect_futs.is_empty() {
+                    setup_complete = true;
+                    drop(connection_setup_tx.take()); // close the signal channel
+                    if connections.is_empty() {
+                        return Err(anyhow!("No servers are able to connect"));
+                    }
+                }
+            }
+
+            index = &mut find_best => {
+                return Ok((index?, connections));
+            }
+        }
+    }
+}
+
 fn validate_client_config<
     EventHandler: 'static + Send + EventCallback,
     ExtAppState: Send + Sync,
@@ -1074,76 +1136,32 @@ pub async fn client<
         );
     }
 
-    let server_count = servers.len();
     let preferred_connection_wait_interval = config.preferred_connection_wait_interval;
-    let mut connections: Vec<(usize, ClientConnection<_>)> = Vec::new();
 
-    let mut stop_signal = config.stop_signal.take().expect("stop_signal must be set");
-
-    let best_connection_index = {
-        let mut connect_futs: FuturesUnordered<_> = servers
+    let (best_connection_index, mut connections) = {
+        let connect_futs: FuturesUnordered<_> = servers
             .into_iter()
             .enumerate()
             .map(|(index, server_config)| {
                 let config = &config;
                 let inside_io = inside_io.clone();
-                async move { (index, connect(config, server_config, inside_io).await) }
+                async move {
+                    let result = connect(config, server_config, inside_io)
+                        .await
+                        .map(|mut conn| (conn.connected_signal.take().unwrap(), conn));
+                    (index, result)
+                }
             })
             .collect();
 
-        let (connection_setup_tx, connection_setup_rx) = mpsc::channel(server_count);
-        let mut connection_setup_tx = Some(connection_setup_tx);
-        let mut setup_complete = false;
+        tokio::select! {
+            result = select_best_from_futures(
+                connect_futs,
+                preferred_connection_wait_interval,
+            ) => result?,
 
-        let mut find_best = std::pin::pin!(find_best_connection(
-            connection_setup_rx,
-            preferred_connection_wait_interval,
-        ));
-
-        loop {
-            tokio::select! {
-                biased;
-
-                // User disconnect — highest priority
-                _ = &mut stop_signal => {
-                    return Ok(ClientResult::UserDisconnect);
-                }
-
-                // Connection setup — feeds signals to find_best_connection
-                Some((orig_idx, result)) = connect_futs.next(), if !setup_complete => {
-                    match result {
-                        Ok(mut conn) => {
-                            let signal = conn.connected_signal.take().unwrap();
-                            let _ = connection_setup_tx.as_ref().unwrap().try_send((orig_idx, signal));
-                            connections.push((orig_idx, conn));
-                        }
-                        Err(e) => {
-                            tracing::error!("Creating connection failed: {e}");
-                        }
-                    }
-                    if connect_futs.is_empty() {
-                        setup_complete = true;
-                        drop(connection_setup_tx.take()); // close the signal channel
-                        if connections.is_empty() {
-                            return Err(anyhow!("No servers available"));
-                        }
-                    }
-                }
-
-                // Signal selection — picks the best connection
-                index = &mut find_best => {
-                    break index?;
-                }
-
-                // Task monitoring — all connection tasks exited without success
-                results = join_all(connections.iter_mut().map(|(_, c)| &mut c.task)), if setup_complete => {
-                    for result in results {
-                        if let Err(e) = result {
-                            tracing::error!("Connection failed: {e}");
-                        }
-                    }
-                    return Err(anyhow!("All connections failed to connect."));
-                }
+            _ = &mut stop_signal => {
+                return Ok(ClientResult::UserDisconnect);
             }
         }
     };
@@ -1318,5 +1336,232 @@ mod tests {
         };
 
         assert_eq!(best_connection_index, Some(1));
+    }
+
+    // select_best_from_futures tests
+
+    // Helper type alias for boxed connect futures used in select_best_from_futures tests
+    type BoxedConnectFut =
+        std::pin::Pin<Box<dyn Future<Output = (usize, Result<(oneshot::Receiver<()>, ())>)>>>;
+
+    #[tokio::test]
+    async fn test_select_best_one_connect_fails_other_succeeds() {
+        let (tx1, rx1) = oneshot::channel::<()>();
+
+        let futs = FuturesUnordered::new();
+        futs.push(Box::pin(async {
+            (
+                0usize,
+                Err::<(oneshot::Receiver<()>, ()), _>(anyhow!("timeout")),
+            )
+        }) as BoxedConnectFut);
+        futs.push(Box::pin(async move { (1usize, Ok((rx1, ()))) }));
+
+        // Signal connection 1 as online shortly after setup
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            let _ = tx1.send(());
+        });
+
+        let (best_index, connections) = select_best_from_futures(futs, Duration::ZERO)
+            .await
+            .unwrap();
+
+        assert_eq!(best_index, 1);
+        assert_eq!(connections.len(), 1);
+        assert_eq!(connections[0].0, 1);
+    }
+
+    #[test_case(0, "No servers available" ; "empty futures")]
+    #[test_case(1, "No servers are able to connect" ; "single future fails")]
+    #[test_case(2, "No servers are able to connect" ; "all futures fail")]
+    #[tokio::test]
+    async fn test_select_best_all_futures_fail(num_futures: usize, expected_error: &str) {
+        let futs: FuturesUnordered<BoxedConnectFut> = FuturesUnordered::new();
+        for i in 0..num_futures {
+            futs.push(Box::pin(async move {
+                (i, Err::<(oneshot::Receiver<()>, ()), _>(anyhow!("fail")))
+            }));
+        }
+
+        let result = select_best_from_futures(futs, Duration::ZERO).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), expected_error);
+    }
+
+    #[tokio::test]
+    async fn test_select_best_preferred_connection_wins() {
+        let (tx0, rx0) = oneshot::channel::<()>();
+        let (tx1, rx1) = oneshot::channel::<()>();
+
+        let futs = FuturesUnordered::new();
+        futs.push(Box::pin(async move { (0usize, Ok((rx0, ()))) }) as BoxedConnectFut);
+        futs.push(Box::pin(async move { (1usize, Ok((rx1, ()))) }));
+
+        // Both connect, but server 1 signals first, then server 0 signals
+        // within the preferred wait interval
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            let _ = tx1.send(());
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            let _ = tx0.send(());
+        });
+
+        let (best_index, connections) = select_best_from_futures(futs, Duration::from_millis(200))
+            .await
+            .unwrap();
+
+        // Server 0 is preferred (lowest index) and connected within wait interval
+        assert_eq!(best_index, 0);
+        assert_eq!(connections.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_select_best_returns_all_successful_connections() {
+        let (tx0, rx0) = oneshot::channel::<()>();
+        let (tx1, _rx1) = oneshot::channel::<()>();
+        let (tx2, rx2) = oneshot::channel::<()>();
+
+        let futs = FuturesUnordered::new();
+        futs.push(Box::pin(async move { (0usize, Ok((rx0, ()))) }) as BoxedConnectFut);
+        futs.push(Box::pin(async {
+            (
+                1usize,
+                Err::<(oneshot::Receiver<()>, ()), _>(anyhow!("fail")),
+            )
+        }));
+        futs.push(Box::pin(async move { (2usize, Ok((rx2, ()))) }));
+
+        // Signal connections 2 then 0
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            let _ = tx2.send(());
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            let _ = tx0.send(());
+        });
+        // tx1 intentionally dropped (connection 1 failed to connect)
+        drop(tx1);
+
+        let (best_index, connections) = select_best_from_futures(futs, Duration::from_millis(200))
+            .await
+            .unwrap();
+
+        // Server 0 is preferred and connected within wait
+        assert_eq!(best_index, 0);
+        // Only 2 successful connections (server 1 failed)
+        assert_eq!(connections.len(), 2);
+        let indices: Vec<usize> = connections.iter().map(|(idx, _)| *idx).collect();
+        assert!(indices.contains(&0));
+        assert!(indices.contains(&2));
+    }
+
+    #[test_case(Duration::ZERO ; "immediate futures")]
+    #[test_case(Duration::from_millis(50) ; "slow futures")]
+    #[tokio::test]
+    async fn test_select_best_all_succeed(future_delay: Duration) {
+        let (tx0, rx0) = oneshot::channel::<()>();
+        let (tx1, rx1) = oneshot::channel::<()>();
+        let (tx2, rx2) = oneshot::channel::<()>();
+
+        let futs = FuturesUnordered::new();
+        futs.push(Box::pin(async move {
+            tokio::time::sleep(future_delay).await;
+            (0usize, Ok((rx0, ())))
+        }) as BoxedConnectFut);
+        futs.push(Box::pin(async move {
+            tokio::time::sleep(future_delay).await;
+            (1usize, Ok((rx1, ())))
+        }));
+        futs.push(Box::pin(async move {
+            tokio::time::sleep(future_delay).await;
+            (2usize, Ok((rx2, ())))
+        }));
+
+        tokio::spawn(async move {
+            tokio::time::sleep(future_delay + Duration::from_millis(10)).await;
+            let _ = tx2.send(());
+            let _ = tx1.send(());
+            let _ = tx0.send(());
+        });
+
+        let (best_index, connections) = select_best_from_futures(futs, Duration::from_millis(200))
+            .await
+            .unwrap();
+
+        assert_eq!(best_index, 0);
+        assert_eq!(connections.len(), 3);
+    }
+
+    #[test_case(
+        vec![1],
+        1 ;
+        "single non preferred when preferred never signals"
+    )]
+    #[test_case(
+        vec![3, 2],
+        2 ;
+        "lowest non preferred selected from multiple"
+    )]
+    #[tokio::test]
+    async fn test_select_best_non_preferred_wins_after_wait(
+        signal_order: Vec<usize>,
+        expected_best: usize,
+    ) {
+        let max_idx = *signal_order.iter().max().unwrap();
+        let mut signal_txs = Vec::new();
+        let futs = FuturesUnordered::new();
+
+        for i in 0..=max_idx {
+            let (tx, rx) = oneshot::channel::<()>();
+            if signal_order.contains(&i) {
+                signal_txs.push((i, tx));
+            }
+            // Non-signaling senders dropped here, receiver sees RecvError
+            futs.push(Box::pin(async move { (i, Ok((rx, ()))) }) as BoxedConnectFut);
+        }
+
+        // Order senders to match signal_order
+        let ordered_txs: Vec<_> = signal_order
+            .iter()
+            .map(|&idx| {
+                let pos = signal_txs.iter().position(|(i, _)| *i == idx).unwrap();
+                signal_txs.remove(pos)
+            })
+            .collect();
+
+        tokio::spawn(async move {
+            for (_, tx) in ordered_txs {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                let _ = tx.send(());
+            }
+        });
+
+        let (best_index, connections) = select_best_from_futures(futs, Duration::from_millis(50))
+            .await
+            .unwrap();
+
+        assert_eq!(best_index, expected_best);
+        assert_eq!(connections.len(), max_idx + 1);
+    }
+
+    #[tokio::test]
+    async fn test_select_best_connections_never_signal() {
+        // Connections set up successfully but never signal as "online".
+        // Senders must be dropped so receivers see RecvError
+        let (tx0, rx0) = oneshot::channel::<()>();
+        let (tx1, rx1) = oneshot::channel::<()>();
+        drop(tx0);
+        drop(tx1);
+
+        let futs = FuturesUnordered::new();
+        futs.push(Box::pin(async move { (0usize, Ok((rx0, ()))) }) as BoxedConnectFut);
+        futs.push(Box::pin(async move { (1usize, Ok((rx1, ()))) }));
+
+        let result = select_best_from_futures(futs, Duration::from_millis(50)).await;
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "All connections disconnected"
+        );
     }
 }

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -210,10 +210,6 @@ pub struct ClientConfig<'cert, ExtAppState: Send + Sync> {
     /// Inside packet codec's config
     pub inside_pkt_codec_config: Option<ClientInsidePacketCodecConfig>,
 
-    /// Specifies if the program responds to INT/TERM signals
-    #[educe(Debug(ignore))]
-    pub stop_signal: oneshot::Receiver<()>,
-
     /// Signal for notifying a network change event
     /// network change being defined as a change in
     /// wifi networks or a change of network interfaces
@@ -1093,11 +1089,14 @@ fn validate_client_config<
 /// If `config.preferred_connection_wait_interval` is set, it will wait that
 /// duration after the first connection completes before returning the highest
 /// priority connection (in the specified array order).
+///
+/// stop_signal sends a signal if the program received INT/TERM signals
 pub async fn client<
     EventHandler: 'static + Send + EventCallback,
     ExtAppState: 'static + Default + Send + Sync,
 >(
     mut config: ClientConfig<'_, ExtAppState>,
+    mut stop_signal: oneshot::Receiver<()>,
     servers: Vec<ClientConnectionConfig<EventHandler>>,
 ) -> Result<ClientResult> {
     tracing::info!(

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -228,7 +228,6 @@ async fn main() -> Result<()> {
         #[cfg(feature = "io-uring")]
         iouring_sqpoll_idle_time: config.iouring_sqpoll_idle_time.into(),
         inside_pkt_codec_config: None,
-        stop_signal: ctrlc_rx,
         network_change_signal: None,
         best_connection_selected_signal: None,
         #[cfg(feature = "debug")]
@@ -237,5 +236,5 @@ async fn main() -> Result<()> {
         keylog: config.keylog,
     };
 
-    client(config, servers).await.map(|_| ())
+    client(config, ctrlc_rx, servers).await.map(|_| ())
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace join_all with FuturesUnordered so connections are fed into find_best_connection incrementally as they complete. The selection logic now runs concurrently with connection setup via an mpsc channel, meaning a fast server can be selected while a slow one is still connecting.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, join_all waited for every connect() call to complete before find_best_connection could start evaluating them. If one server was unreachable, its socket creation could hang for seconds (e.g. "No route to host"), blocking all other — already successful — connections from being selected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on client that is attempting to connect to 2 TCP servers in parallel. The first server has an invalid IP and we have set preferred `preferred_connection_wait_interval` to 0. New client finishes running instantly after the second connection goes online, while older client were still waiting for first connection to go through first before proceeding to run find_best_connection:

```
2026-04-15T12:18:11.141218Z DEBUG lightway_core::connection: event event=FirstPacketReceived
2026-04-15T12:18:11.141956Z  INFO lightway_client: First outside packet received
2026-04-15T12:18:11.141966Z TRACE xv_lightway_client::event_handler: Connection 1 forwarding event: FirstPacketReceived
2026-04-15T12:18:11.141977Z TRACE xv_lightway_client::app: Event received: connection_id=1, event=FirstPacketReceived
2026-04-15T12:18:11.146524Z  INFO lightway_core::connection: state=LinkUp
2026-04-15T12:18:11.146628Z DEBUG lightway_core::connection: event event=StateChanged(LinkUp)
2026-04-15T12:18:11.146645Z  INFO lightway_core::connection: state=Authenticating
2026-04-15T12:18:11.146678Z DEBUG lightway_core::connection: event event=StateChanged(Authenticating)
2026-04-15T12:18:11.146834Z TRACE xv_lightway_client::event_handler: Connection 1 forwarding event: StateChanged(LinkUp)
2026-04-15T12:18:11.147155Z TRACE xv_lightway_client::event_handler: Connection 1 forwarding event: StateChanged(Authenticating)
2026-04-15T12:18:11.147174Z TRACE xv_lightway_client::app: Event received: connection_id=1, event=StateChanged(LinkUp)
2026-04-15T12:18:11.147191Z TRACE xv_lightway_client::event_handler: Current state: Connecting, New state: LinkUp
2026-04-15T12:18:11.147207Z  INFO xv_lightway_client::event_handler: State Change state=LinkUp
2026-04-15T12:18:11.147222Z TRACE xv_lightway_client::app: Event received: connection_id=1, event=StateChanged(Authenticating)
2026-04-15T12:18:11.147235Z TRACE xv_lightway_client::event_handler: Current state: LinkUp, New state: Authenticating
2026-04-15T12:18:11.147247Z  INFO xv_lightway_client::event_handler: State Change state=Authenticating
2026-04-15T12:18:11.154935Z  INFO lightway_core::connection: state=Online
2026-04-15T12:18:11.154940Z DEBUG lightway_core::connection: event event=StateChanged(Online)
2026-04-15T12:18:11.154948Z DEBUG lightway_core::connection: ONLINE curve=Some("SecP521r1MLKEM1024") cipher=Some("TLS_AES_256_GCM_SHA384")
2026-04-15T12:18:11.154967Z TRACE xv_lightway_client::event_handler: Connection 1 forwarding event: StateChanged(Online)
2026-04-15T12:18:11.154979Z TRACE xv_lightway_client::app: Event received: connection_id=1, event=StateChanged(Online)
2026-04-15T12:18:11.154991Z DEBUG lightway_client: Connection 1 is online
2026-04-15T12:18:11.154995Z DEBUG lightway_client: Preferred connection wait finished, using only connection so far: 1
2026-04-15T12:18:11.155025Z TRACE lightway_client: Best connection selected: 1
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
