### PR TITLE
CVPN-2511: Process multiple packets at once in outside_io_task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,6 @@ dependencies = [
  "objc2-system-configuration",
  "pnet_packet",
  "route_manager",
- "rtrb",
  "serde",
  "serial_test",
  "socket2",
@@ -2597,12 +2596,6 @@ dependencies = [
  "tokio",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "rtrb"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7204ed6420f698836b76d4d5c2ec5dec7585fd5c3a788fd1cde855d1de598239"
 
 [[package]]
 name = "rustc-demangle"

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -21,7 +21,7 @@ mobile = ["uniffi", "tracing-core", "tracing-panic"]
 debug = ["lightway-core/debug","lightway-app-utils/debug"]
 io-uring = ["lightway-app-utils/io-uring"]
 postquantum = ["lightway-core/postquantum"]
-batch_receive = ["rtrb"]
+batch_receive = []
 
 [lints]
 workspace = true
@@ -48,7 +48,6 @@ tokio-util.workspace = true
 tracing = { workspace = true, features = ["attributes"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 twelf.workspace = true
-rtrb = { version = "0.3.3", optional = true }
 
 # mobile feature
 uniffi = { workspace = true, optional = true }

--- a/lightway-client/src/io/outside.rs
+++ b/lightway-client/src/io/outside.rs
@@ -11,6 +11,10 @@ use async_trait::async_trait;
 use lightway_core::{IOCallbackResult, OutsideIOSendCallbackArg};
 use std::{net::SocketAddr, sync::Arc};
 
+/// Maximum number of packets to receive in a single batch syscall.
+#[cfg(batch_receive)]
+pub const BATCH_RECV_SIZE: usize = 32;
+
 #[async_trait]
 pub trait OutsideIO: Sync + Send {
     fn set_send_buffer_size(&self, size: usize) -> Result<()>;
@@ -18,14 +22,22 @@ pub trait OutsideIO: Sync + Send {
 
     async fn poll(&self, interest: tokio::io::Interest) -> Result<tokio::io::Ready>;
 
-    /// Poll whenever this socket is readable or not. By default, it will call
-    /// `poll(tokio::io::Interest::READABLE)` on the socket itself.
-    async fn readable(&self) -> Result<()> {
-        self.poll(tokio::io::Interest::READABLE).await?;
-        Ok(())
-    }
-
+    /// Receive a single packet into `buf`. Returns how many bytes were read.
     fn recv_buf(&self, buf: &mut bytes::BytesMut) -> IOCallbackResult<usize>;
+
+    /// Receive packets into `bufs`, filling up to `bufs.len()` entries.
+    /// Returns how many buffers were actually written (always `>= 1` on `Ok`).
+    ///
+    /// The default implementation reads a single packet into `bufs[0]` and is
+    /// appropriate for stream transports (e.g. TCP) or UDP without batch support.
+    /// Transports with a native batch-receive syscall should override this.
+    #[cfg(batch_receive)]
+    fn recv_bufs(&self, bufs: &mut [bytes::BytesMut; BATCH_RECV_SIZE]) -> IOCallbackResult<usize> {
+        match self.recv_buf(&mut bufs[0]) {
+            IOCallbackResult::Ok(_size) => IOCallbackResult::Ok(1),
+            others => others,
+        }
+    }
 
     fn into_io_send_callback(self: Arc<Self>) -> OutsideIOSendCallbackArg;
 

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -18,7 +18,7 @@ pub struct Udp {
     peer_addr: SocketAddr,
     default_ip_pmtudisc: sockopt::IpPmtudisc,
     #[cfg(batch_receive)]
-    batch_receiver: Option<BatchReceiver>,
+    batch_receive_enabled: bool,
 }
 
 impl Udp {
@@ -48,7 +48,7 @@ impl Udp {
             peer_addr,
             default_ip_pmtudisc,
             #[cfg(batch_receive)]
-            batch_receiver: None,
+            batch_receive_enabled: false,
         })
     }
 
@@ -62,7 +62,7 @@ impl Udp {
             return;
         }
         tracing::info!("Using batch receiver");
-        self.batch_receiver = Some(BatchReceiver::new(self.sock.clone()));
+        self.batch_receive_enabled = true;
     }
 
     fn peer_addr(&self) -> SocketAddr {
@@ -102,18 +102,6 @@ impl OutsideIO for Udp {
     }
 
     fn recv_buf(&self, buf: &mut bytes::BytesMut) -> IOCallbackResult<usize> {
-        #[cfg(batch_receive)]
-        if let Some(receiver) = self.batch_receiver.as_ref() {
-            return match receiver.pop_recv_consumer() {
-                Ok(b) => {
-                    let len = b.len();
-                    *buf = b;
-                    IOCallbackResult::Ok(len)
-                }
-                Err(BatchReceiverConsumerError::EmptyBuffer(_)) => IOCallbackResult::WouldBlock,
-                Err(BatchReceiverConsumerError::SemaphoreClosed(e)) => IOCallbackResult::Err(e),
-            };
-        }
         match self.sock.try_recv_buf(buf) {
             Ok(nr) => IOCallbackResult::Ok(nr),
             Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -1,8 +1,6 @@
 use super::OutsideIO;
 #[cfg(batch_receive)]
-use crate::io::outside::udp_batch_receiver::BatchReceiver;
-#[cfg(batch_receive)]
-use crate::io::outside::udp_batch_receiver::BatchReceiverConsumerError;
+use crate::io::outside::udp_batch_receiver;
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use lightway_app_utils::sockopt;
@@ -88,19 +86,6 @@ impl OutsideIO for Udp {
         Ok(r)
     }
 
-    #[cfg(batch_receive)]
-    /// If `batch_receiver` is on, it will try to acquire a permit
-    /// of a Semaphore to see if the ring buffer has any packets in it.
-    async fn readable(&self) -> Result<()> {
-        if let Some(receiver) = self.batch_receiver.as_ref() {
-            // Wait until the recv task has pushed at least one packet into recv_queue.
-            receiver.recv_queue_ready().await?;
-        } else {
-            self.poll(tokio::io::Interest::READABLE).await?;
-        }
-        Ok(())
-    }
-
     fn recv_buf(&self, buf: &mut bytes::BytesMut) -> IOCallbackResult<usize> {
         match self.sock.try_recv_buf(buf) {
             Ok(nr) => IOCallbackResult::Ok(nr),
@@ -108,6 +93,41 @@ impl OutsideIO for Udp {
                 IOCallbackResult::WouldBlock
             }
             Err(err) => IOCallbackResult::Err(err),
+        }
+    }
+
+    #[cfg(batch_receive)]
+    /// If the config explicitly turned off batch receive, it will just run regular `recv_from` function.
+    fn recv_bufs(
+        &self,
+        bufs: &mut [bytes::BytesMut; super::BATCH_RECV_SIZE],
+    ) -> IOCallbackResult<usize> {
+        if !self.batch_receive_enabled {
+            return match self.recv_buf(&mut bufs[0]) {
+                IOCallbackResult::Ok(_size) => IOCallbackResult::Ok(1),
+                others => others,
+            };
+        }
+
+        use std::os::fd::AsRawFd;
+
+        let fd = self.sock.as_raw_fd();
+
+        loop {
+            match self.sock.try_io(tokio::io::Interest::READABLE, || {
+                udp_batch_receiver::recv_multiple(fd, bufs, super::BATCH_RECV_SIZE)
+            }) {
+                Ok(n) => return IOCallbackResult::Ok(n),
+                // try_io may return WouldBlock even if the socket isn't actually
+                // readable. Break with 0 to wait for another readable event emitted.
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    return IOCallbackResult::WouldBlock;
+                }
+                // Interrupted means the syscall was interrupted by a signal and can be
+                // retried immediately without waiting for another readable event.
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) => return IOCallbackResult::Err(e),
+            }
         }
     }
 

--- a/lightway-client/src/io/outside/udp_batch_receiver.rs
+++ b/lightway-client/src/io/outside/udp_batch_receiver.rs
@@ -1,82 +1,19 @@
 #![cfg(batch_receive)]
 
-use anyhow::Result;
+use super::BATCH_RECV_SIZE;
 use bytes::BytesMut;
 use lightway_core::MAX_OUTSIDE_MTU;
-use rtrb::{PopError, RingBuffer};
 use std::io;
-use std::os::fd::AsRawFd;
-use std::sync::{Arc, Mutex};
-use tokio::net::UdpSocket;
-use tokio::sync::Semaphore;
-use tokio_util::sync::{CancellationToken, DropGuard};
-use tracing::{error, info};
 
-pub(crate) struct BatchReceiver {
-    recv_ready: Arc<Semaphore>,
-    recv_consumer: Mutex<rtrb::Consumer<BytesMut>>,
-    io_error: Arc<Mutex<Option<io::Error>>>,
-    _drop_guard: DropGuard,
-}
-
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum BatchReceiverConsumerError {
-    #[error("Empty ring buffer: {0}")]
-    EmptyBuffer(#[from] PopError),
-    #[error("Semaphore is closed by the task: {0}")]
-    SemaphoreClosed(#[from] io::Error),
-}
-
-const MAX_BUFFER_SIZE: usize = 1024;
-impl BatchReceiver {
-    pub fn new(sock: Arc<UdpSocket>) -> Self {
-        let recv_ready = Arc::new(Semaphore::new(0));
-        let (recv_producer, recv_consumer) = RingBuffer::new(MAX_BUFFER_SIZE);
-        let cancellation_token = CancellationToken::new();
-        let io_error = Arc::new(Mutex::new(None));
-        tokio::task::spawn(handle_udp_recv::<PlatformBatchRecv>(
-            sock.clone(),
-            recv_producer,
-            recv_ready.clone(),
-            cancellation_token.clone(),
-            io_error.clone(),
-        ));
-        Self {
-            recv_ready,
-            recv_consumer: Mutex::new(recv_consumer),
-            io_error,
-            _drop_guard: cancellation_token.drop_guard(),
-        }
-    }
-
-    pub async fn recv_queue_ready(&self) -> Result<()> {
-        // Using a semaphore so bursts are counted correctly: each
-        // received packet adds exactly one permit, and each readable() consumes one.
-        self.recv_ready
-            .acquire()
-            .await
-            .map_err(|e| anyhow::anyhow!("recv_ready semaphore closed: {e}"))?
-            .forget(); // consume the permit without dropping it back
-        Ok(())
-    }
-
-    pub fn pop_recv_consumer(&self) -> std::result::Result<BytesMut, BatchReceiverConsumerError> {
-        if !self.recv_ready.is_closed() {
-            self.recv_consumer
-                .lock()
-                .unwrap()
-                .pop()
-                .map_err(|e| e.into())
-        } else {
-            let io_err = self
-                .io_error
-                .lock()
-                .unwrap()
-                .take()
-                .unwrap_or_else(|| io::Error::other("batch receiver task closed unexpectedly"));
-            Err(io_err.into())
-        }
-    }
+/// Platform-specific batch receive syscall.
+trait BatchRecvSyscall {
+    /// Receive up to `msg_count` packets from `fd` into `recv_bufs`.
+    /// Returns the number of packets actually received.
+    fn recv_multiple(
+        fd: libc::c_int,
+        recv_bufs: &mut [BytesMut; BATCH_RECV_SIZE],
+        msg_count: usize,
+    ) -> io::Result<usize>;
 }
 
 /// Check whether the platform supports batch receiving via `recvmsg_x`.
@@ -85,97 +22,12 @@ pub(crate) fn is_batch_receive_available() -> bool {
     apple::is_batch_receive_available()
 }
 
-/// Maximum number of messages to send/receive in a single syscall.
-const BATCH_SIZE: usize = 32;
-
-/// Platform-specific batch receive syscall.
-trait BatchRecvSyscall {
-    /// Receive up to `msg_count` packets from `fd` into `recv_bufs`.
-    /// Returns the number of packets actually received.
-    fn recv_multiple(
-        fd: libc::c_int,
-        recv_bufs: &mut [BytesMut; BATCH_SIZE],
-        msg_count: usize,
-    ) -> io::Result<usize>;
-}
-
 #[cfg(apple)]
-type PlatformBatchRecv = apple::RecvmsgX;
-
-/// Tokio task: receives packets from the socket using the platform-specific
-/// batch syscall and pushes them into the rx ring buffer.
-async fn handle_udp_recv<S: BatchRecvSyscall>(
-    sock: Arc<UdpSocket>,
-    mut rx_queue: rtrb::Producer<BytesMut>,
-    rx_ready: Arc<Semaphore>,
-    cancel: CancellationToken,
-    io_error: Arc<Mutex<Option<io::Error>>>,
-) {
-    let mut recv_bufs: [BytesMut; BATCH_SIZE] =
-        std::array::from_fn(|_| BytesMut::with_capacity(MAX_OUTSIDE_MTU));
-
-    loop {
-        tokio::select! {
-            _ = cancel.cancelled() => {
-                info!("Batch receiver shutting down");
-                return;
-            }
-            ready = sock.readable() => {
-                if let Err(e) = ready {
-                    error!("Batch receive task failed on readable: {e}");
-                    rx_ready.close();
-                    io_error.lock().unwrap().replace(e);
-                    return;
-                }
-                let msg_count = rx_queue.slots().min(BATCH_SIZE);
-                if msg_count == 0 {
-                    // The ring buffer is full. We must yield here because
-                    // the socket is still readable (data in the kernel buffer),
-                    // so `readable()` would return immediately on the next
-                    // iteration — creating a busy spin that starves the
-                    // consumer task and prevents it from draining the buffer.
-                    tokio::task::yield_now().await;
-                    continue;
-                }
-
-                // Retry if we received Interrupted
-                let recv_count = loop {
-                    match sock.try_io(tokio::io::Interest::READABLE, || {
-                        S::recv_multiple(sock.as_raw_fd(), &mut recv_bufs, msg_count)
-                    }) {
-                        Ok(n) => break n,
-                        // try_io may return WouldBlock even if the socket isn't actually
-                        // readable. Break with 0 to wait for another readable event emitted.
-                        Err(e) if e.kind() == io::ErrorKind::WouldBlock => break 0,
-                        // Interrupted means the syscall was interrupted by a signal and can be
-                        // retried immediately without waiting for another readable event.
-                        Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
-                        Err(e) => {
-                            error!("Batch receive task failed: {e}");
-                            rx_ready.close();
-                            io_error.lock().unwrap().replace(e);
-                            return;
-                        }
-                    }
-                };
-
-                if recv_count > 0 {
-                    let chunk = rx_queue
-                        .write_chunk_uninit(recv_count)
-                        .expect("slots() guaranteed enough space");
-                    let pushed = chunk.fill_from_iter((0..recv_count).map(|i| {
-                        std::mem::replace(&mut recv_bufs[i], BytesMut::with_capacity(MAX_OUTSIDE_MTU))
-                    }));
-                    rx_ready.add_permits(pushed);
-                }
-            }
-        }
-    }
-}
+pub(crate) type PlatformBatchRecv = apple::RecvmsgX;
 
 #[cfg(apple)]
 mod apple {
-    use crate::io::outside::udp_batch_receiver::BATCH_SIZE;
+    use super::BATCH_RECV_SIZE;
     use bytes::BytesMut;
     use lightway_core::MAX_OUTSIDE_MTU;
     use std::sync::LazyLock;
@@ -235,13 +87,13 @@ mod apple {
         #[allow(unsafe_code)]
         fn recv_multiple(
             fd: libc::c_int,
-            recv_bufs: &mut [BytesMut; BATCH_SIZE],
+            recv_bufs: &mut [BytesMut; BATCH_RECV_SIZE],
             msg_count: usize,
         ) -> io::Result<usize> {
             // SAFETY: zeroed iovec is valid (null pointer + zero length).
-            let mut iovecs = unsafe { mem::zeroed::<[libc::iovec; BATCH_SIZE]>() };
+            let mut iovecs = unsafe { mem::zeroed::<[libc::iovec; BATCH_RECV_SIZE]>() };
             // SAFETY: zeroed msghdr_x is valid (null pointers + zero lengths).
-            let mut hdrs = unsafe { mem::zeroed::<[msghdr_x; BATCH_SIZE]>() };
+            let mut hdrs = unsafe { mem::zeroed::<[msghdr_x; BATCH_RECV_SIZE]>() };
             for i in 0..msg_count {
                 iovecs[i].iov_base =
                     recv_bufs[i].spare_capacity_mut().as_mut_ptr() as *mut libc::c_void;
@@ -297,303 +149,65 @@ mod apple {
 #[serial_test::serial]
 mod tests {
     use super::*;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use lightway_core::MAX_OUTSIDE_MTU;
     use std::time::Duration;
     use tokio::net::UdpSocket;
 
-    async fn make_socket_pair() -> (UdpSocket, Arc<UdpSocket>) {
+    async fn make_socket_pair() -> (UdpSocket, UdpSocket) {
         let sender = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let receiver = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         sender
             .connect(receiver.local_addr().unwrap())
             .await
             .unwrap();
-        (sender, Arc::new(receiver))
+        (sender, receiver)
     }
 
     #[tokio::test]
-    async fn single_packet_received() {
+    async fn recv_multiple_single_packet() {
         let (sender, receiver) = make_socket_pair().await;
-        let batch = BatchReceiver::new(receiver);
 
         sender.send(b"hello").await.unwrap();
 
-        tokio::time::timeout(Duration::from_secs(2), batch.recv_queue_ready())
+        let mut bufs: [BytesMut; BATCH_RECV_SIZE] =
+            std::array::from_fn(|_| BytesMut::with_capacity(MAX_OUTSIDE_MTU));
+
+        tokio::time::timeout(Duration::from_secs(2), receiver.readable())
             .await
             .unwrap()
             .unwrap();
-        let pkt = batch.pop_recv_consumer().unwrap();
-        assert_eq!(&pkt[..], b"hello");
+
+        let fd = std::os::fd::AsRawFd::as_raw_fd(&receiver);
+        let count = PlatformBatchRecv::recv_multiple(fd, &mut bufs, BATCH_RECV_SIZE).unwrap();
+        assert!(count >= 1);
+        assert_eq!(&bufs[0][..], b"hello");
     }
 
     #[tokio::test]
-    async fn multiple_packets_received_in_order() {
+    async fn recv_multiple_multiple_packets() {
         let (sender, receiver) = make_socket_pair().await;
-        let batch = BatchReceiver::new(receiver);
 
         for i in 0..10u8 {
             sender.send(&[i]).await.unwrap();
         }
 
-        for i in 0..10u8 {
-            tokio::time::timeout(Duration::from_secs(2), batch.recv_queue_ready())
-                .await
-                .unwrap()
-                .unwrap();
-            let pkt = batch.pop_recv_consumer().unwrap();
-            assert_eq!(pkt[0], i);
-        }
-    }
+        // Give packets time to arrive in kernel buffer.
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
-    #[tokio::test]
-    async fn pop_on_empty_returns_error() {
-        let (_sender, receiver) = make_socket_pair().await;
-        let batch = BatchReceiver::new(receiver);
-        assert!(matches!(
-            batch.pop_recv_consumer(),
-            Err(BatchReceiverConsumerError::EmptyBuffer(_))
-        ));
-    }
+        let mut bufs: [BytesMut; BATCH_RECV_SIZE] =
+            std::array::from_fn(|_| BytesMut::with_capacity(MAX_OUTSIDE_MTU));
 
-    #[tokio::test]
-    async fn ring_buffer_full_no_data_loss() {
-        let (sender, receiver) = make_socket_pair().await;
-        let batch = BatchReceiver::new(receiver);
-
-        // Fill the ring buffer to capacity.
-        for i in 0..MAX_BUFFER_SIZE as u32 {
-            sender.send(&i.to_le_bytes()).await.unwrap();
-        }
-
-        // Drain and verify every packet arrived in order.
-        for i in 0..MAX_BUFFER_SIZE as u32 {
-            tokio::time::timeout(Duration::from_secs(5), batch.recv_queue_ready())
-                .await
-                .unwrap()
-                .unwrap();
-            let pkt = batch.pop_recv_consumer().unwrap();
-            assert_eq!(
-                u32::from_le_bytes(pkt[..4].try_into().unwrap()),
-                i,
-                "packet {i} out of order"
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn packets_after_drain() {
-        let (sender, receiver) = make_socket_pair().await;
-        let batch = BatchReceiver::new(receiver);
-
-        // First burst.
-        sender.send(b"first").await.unwrap();
-        tokio::time::timeout(Duration::from_secs(2), batch.recv_queue_ready())
+        tokio::time::timeout(Duration::from_secs(2), receiver.readable())
             .await
             .unwrap()
             .unwrap();
-        let pkt = batch.pop_recv_consumer().unwrap();
-        assert_eq!(&pkt[..], b"first");
 
-        // Second burst after draining.
-        sender.send(b"second").await.unwrap();
-        tokio::time::timeout(Duration::from_secs(2), batch.recv_queue_ready())
-            .await
-            .unwrap()
-            .unwrap();
-        let pkt = batch.pop_recv_consumer().unwrap();
-        assert_eq!(&pkt[..], b"second");
-    }
-
-    #[tokio::test]
-    async fn closed_sender_socket_propagates_error() {
-        let (sender, receiver) = make_socket_pair().await;
-        let batch = BatchReceiver::new(receiver);
-
-        // Send one packet, then drop the sender.
-        sender.send(b"bye").await.unwrap();
-        drop(sender);
-
-        // The already-queued packet should still be readable.
-        tokio::time::timeout(Duration::from_secs(2), batch.recv_queue_ready())
-            .await
-            .unwrap()
-            .unwrap();
-        let pkt = batch.pop_recv_consumer().unwrap();
-        assert_eq!(&pkt[..], b"bye");
-    }
-
-    #[tokio::test]
-    async fn pop_after_semaphore_closed_returns_semaphore_closed() {
-        let (_sender, receiver) = make_socket_pair().await;
-        let batch = BatchReceiver::new(receiver);
-
-        // Manually close the semaphore to simulate the recv task dying with an IO error.
-        batch.recv_ready.close();
-        batch
-            .io_error
-            .lock()
-            .unwrap()
-            .replace(io::Error::other("simulated IO failure"));
-
-        assert!(matches!(
-            batch.pop_recv_consumer(),
-            Err(BatchReceiverConsumerError::SemaphoreClosed(_))
-        ));
-    }
-
-    // ---- Direct handle_udp_recv tests ----
-
-    /// Helper: spawn handle_udp_recv with our own ring buffer and semaphore.
-    #[allow(clippy::type_complexity)]
-    fn spawn_handle_udp_recv<S: BatchRecvSyscall + 'static>(
-        sock: Arc<UdpSocket>,
-        buffer_size: usize,
-    ) -> (
-        rtrb::Consumer<BytesMut>,
-        Arc<Semaphore>,
-        CancellationToken,
-        Arc<Mutex<Option<io::Error>>>,
-        tokio::task::JoinHandle<()>,
-    ) {
-        let rx_ready = Arc::new(Semaphore::new(0));
-        let (producer, consumer) = RingBuffer::new(buffer_size);
-        let cancel = CancellationToken::new();
-        let io_error = Arc::new(Mutex::new(None));
-        let handle = tokio::task::spawn(handle_udp_recv::<S>(
-            sock,
-            producer,
-            rx_ready.clone(),
-            cancel.clone(),
-            io_error.clone(),
-        ));
-        (consumer, rx_ready, cancel, io_error, handle)
-    }
-
-    #[tokio::test]
-    async fn handle_recv_cancellation_stops_task() {
-        let (_sender, receiver) = make_socket_pair().await;
-        let (_, _, cancel, _, handle) =
-            spawn_handle_udp_recv::<PlatformBatchRecv>(receiver, MAX_BUFFER_SIZE);
-
-        cancel.cancel();
-
-        // Task should exit promptly.
-        tokio::time::timeout(Duration::from_secs(2), handle)
-            .await
-            .expect("task did not finish in time")
-            .expect("task panicked");
-    }
-
-    #[tokio::test]
-    async fn handle_recv_pushes_packets_and_adds_permits() {
-        let (sender, receiver) = make_socket_pair().await;
-        let (mut consumer, rx_ready, cancel, _, _handle) =
-            spawn_handle_udp_recv::<PlatformBatchRecv>(receiver, MAX_BUFFER_SIZE);
-
-        sender.send(b"pkt1").await.unwrap();
-        sender.send(b"pkt2").await.unwrap();
-
-        // Wait for both permits.
-        for _ in 0..2 {
-            tokio::time::timeout(Duration::from_secs(2), rx_ready.acquire())
-                .await
-                .unwrap()
-                .unwrap()
-                .forget();
+        let fd = std::os::fd::AsRawFd::as_raw_fd(&receiver);
+        let count = PlatformBatchRecv::recv_multiple(fd, &mut bufs, BATCH_RECV_SIZE).unwrap();
+        assert!(count >= 1);
+        // Verify received packets are in order.
+        for i in 0..count {
+            assert_eq!(bufs[i][0], i as u8);
         }
-
-        let p1 = consumer.pop().unwrap();
-        let p2 = consumer.pop().unwrap();
-        assert_eq!(&p1[..], b"pkt1");
-        assert_eq!(&p2[..], b"pkt2");
-
-        cancel.cancel();
-    }
-
-    const INJECTED_ERROR_STRING: &str = "woah totally real io error sad";
-    struct FailingRecv;
-
-    impl BatchRecvSyscall for FailingRecv {
-        fn recv_multiple(
-            _fd: libc::c_int,
-            _recv_bufs: &mut [BytesMut; BATCH_SIZE],
-            _msg_count: usize,
-        ) -> io::Result<usize> {
-            Err(io::Error::other(INJECTED_ERROR_STRING))
-        }
-    }
-
-    #[tokio::test]
-    async fn handle_recv_fatal_error_closes_semaphore_and_stores_error() {
-        let (sender, receiver) = make_socket_pair().await;
-        let (_, rx_ready, _, io_error, handle) =
-            spawn_handle_udp_recv::<FailingRecv>(receiver, MAX_BUFFER_SIZE);
-
-        // Send a packet so the socket becomes readable, triggering the failing recv.
-        sender.send(b"trigger").await.unwrap();
-
-        // The task should exit after the fatal error.
-        tokio::time::timeout(Duration::from_secs(2), handle)
-            .await
-            .expect("task did not finish in time")
-            .expect("task panicked");
-
-        assert!(rx_ready.is_closed());
-        let err = io_error
-            .lock()
-            .unwrap()
-            .take()
-            .expect("expected stored IO error");
-        assert_eq!(err.to_string(), INJECTED_ERROR_STRING);
-    }
-
-    static INTERRUPTED_CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
-
-    struct InterruptedOnceRecv;
-
-    impl BatchRecvSyscall for InterruptedOnceRecv {
-        fn recv_multiple(
-            _fd: libc::c_int,
-            recv_bufs: &mut [BytesMut; BATCH_SIZE],
-            _msg_count: usize,
-        ) -> io::Result<usize> {
-            let call = INTERRUPTED_CALL_COUNT.fetch_add(1, Ordering::SeqCst);
-            if call == 0 {
-                Err(io::Error::from(io::ErrorKind::Interrupted))
-            } else {
-                recv_bufs[0].clear();
-                recv_bufs[0].extend_from_slice(b"after_interrupt");
-                Ok(1)
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn handle_recv_interrupted_retries_immediately() {
-        INTERRUPTED_CALL_COUNT.store(0, Ordering::SeqCst);
-        let (sender, receiver) = make_socket_pair().await;
-        let (mut consumer, rx_ready, cancel, io_error, _handle) =
-            spawn_handle_udp_recv::<InterruptedOnceRecv>(receiver, MAX_BUFFER_SIZE);
-
-        // Send a packet so the socket becomes readable.
-        sender.send(b"trigger").await.unwrap();
-
-        // First recv_multiple returns Interrupted, which is retried
-        // immediately within the inner loop. Second call succeeds.
-        tokio::time::timeout(Duration::from_secs(2), rx_ready.acquire())
-            .await
-            .unwrap()
-            .unwrap()
-            .forget();
-
-        let pkt = consumer.pop().unwrap();
-        assert_eq!(&pkt[..], b"after_interrupt");
-
-        // Interrupted is not fatal — semaphore must still be open.
-        assert!(!rx_ready.is_closed());
-        assert!(io_error.lock().unwrap().is_none());
-
-        cancel.cancel();
     }
 }

--- a/lightway-client/src/io/outside/udp_batch_receiver.rs
+++ b/lightway-client/src/io/outside/udp_batch_receiver.rs
@@ -2,7 +2,6 @@
 
 use super::BATCH_RECV_SIZE;
 use bytes::BytesMut;
-use lightway_core::MAX_OUTSIDE_MTU;
 use std::io;
 
 /// Platform-specific batch receive syscall.
@@ -23,7 +22,15 @@ pub(crate) fn is_batch_receive_available() -> bool {
 }
 
 #[cfg(apple)]
-pub(crate) type PlatformBatchRecv = apple::RecvmsgX;
+type PlatformBatchRecv = apple::RecvmsgX;
+
+pub(crate) fn recv_multiple(
+    fd: libc::c_int,
+    recv_bufs: &mut [BytesMut; BATCH_RECV_SIZE],
+    max_batch_size: usize,
+) -> io::Result<usize> {
+    PlatformBatchRecv::recv_multiple(fd, recv_bufs, max_batch_size)
+}
 
 #[cfg(apple)]
 mod apple {

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -35,6 +35,8 @@ use tokio::sync::mpsc::UnboundedReceiver;
 use crate::debug::WiresharkKeyLogger;
 #[cfg(desktop)]
 use crate::dns_manager::{DnsConfigMode, DnsManager, DnsManagerError, DnsSetup};
+#[cfg(batch_receive)]
+use crate::io::outside::BATCH_RECV_SIZE;
 use crate::keepalive::Config as KeepaliveConfig;
 #[cfg(desktop)]
 use crate::route_manager::{RouteManager, RouteMode};
@@ -384,35 +386,53 @@ pub async fn outside_io_task<ExtAppState: Send + Sync>(
     keepalive: Keepalive,
     mut ready_signal: Option<oneshot::Sender<()>>,
 ) -> Result<()> {
-    let mut buf = BytesMut::with_capacity(mtu);
-    loop {
-        // Recover full capacity
-        buf.clear();
-        buf.reserve(mtu);
+    #[cfg(batch_receive)]
+    const BUF_COUNT: usize = BATCH_RECV_SIZE;
+    #[cfg(not(batch_receive))]
+    const BUF_COUNT: usize = 1;
 
+    let mut bufs: [BytesMut; BUF_COUNT] = std::array::from_fn(|_| BytesMut::with_capacity(mtu));
+
+    loop {
         // Unrecoverable errors: https://github.com/tokio-rs/tokio/discussions/5552
-        outside_io.readable().await?;
+        outside_io.poll(tokio::io::Interest::READABLE).await?;
 
         // Send ready signal after first successful poll
         if let Some(tx) = ready_signal.take() {
             let _ = tx.send(());
         }
 
-        match outside_io.recv_buf(&mut buf) {
-            IOCallbackResult::Ok(_nr) => {}
-            IOCallbackResult::WouldBlock => continue, // Spuriously failed to read, keep waiting
-            IOCallbackResult::Err(err) => {
-                // Fatal error
-                return Err(err.into());
-            }
+        #[cfg(batch_receive)]
+        let count = match outside_io.recv_bufs(&mut bufs) {
+            IOCallbackResult::Ok(n) => n,
+            IOCallbackResult::WouldBlock => continue,
+            IOCallbackResult::Err(err) => return Err(err.into()),
         };
 
-        let pkt = OutsidePacket::Wire(&mut buf, connection_type);
-        if let Err(err) = conn.lock().unwrap().outside_data_received(pkt) {
-            if err.is_fatal(connection_type) {
-                return Err(err.into());
+        #[cfg(not(batch_receive))]
+        let count = match outside_io.recv_buf(&mut bufs[0]) {
+            IOCallbackResult::Ok(_) => 1,
+            IOCallbackResult::WouldBlock => continue,
+            IOCallbackResult::Err(err) => return Err(err.into()),
+        };
+
+        // TODO: Batch send the packets into the tun device at once
+        {
+            let mut conn = conn.lock().unwrap();
+            for b in &mut bufs[..count] {
+                let pkt = OutsidePacket::Wire(b, connection_type);
+                if let Err(err) = conn.outside_data_received(pkt) {
+                    if err.is_fatal(connection_type) {
+                        return Err(err.into());
+                    }
+                    tracing::error!("Failed to process outside data: {err}");
+                }
             }
-            tracing::error!("Failed to process outside data: {err}");
+        }
+
+        for b in &mut bufs[..count] {
+            b.clear();
+            b.reserve(mtu);
         }
 
         keepalive.outside_activity().await


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR further simplify batch receive packets logic by receiving multiple packets directly in outside_io_task without the need of ring buffer. Easier to maintain + more direct

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Simplify the logic of receiving multiple packet + solve weird tokio yielding issue where it might cause an performance degradation on other platforms (Linux)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested this newer macOS against the older client that uses the old batch_receiver implementation, both have similar performance in general:
| (in Mbps) | Speedtest Download | Speedtest Upload | iPerf3 Download | iPerf3 Upload |
|---|---|---|---|---|
| recvmsg_x old | 1497.29 | 557.54 | 1481 | 584 |
| recvmsg_x new | 1514.38 | 558.09 | 1480 | 567 |

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
