### PR TITLE
client: use feature gate for mobile

### DIFF
--- a/lightway-client/src/endpoint.rs
+++ b/lightway-client/src/endpoint.rs
@@ -4,11 +4,11 @@ use std::net::IpAddr;
 #[allow(dead_code)]
 /// Lightway endpoint details
 #[derive(Clone)]
-#[cfg_attr(mobile, derive(uniffi::Record))]
+#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct RustEndpointConfig {
-    #[cfg(mobile)]
+    #[cfg(feature = "mobile")]
     pub server_ip: IpAddress,
-    #[cfg(desktop)]
+    #[cfg(not(feature = "mobile"))]
     pub server_ip: IpAddr,
 
     pub port: u16,
@@ -22,7 +22,7 @@ pub struct RustEndpointConfig {
     pub outside_mtu: u32,
 }
 
-#[cfg(mobile)]
+#[cfg(feature = "mobile")]
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 // Some of the errors here are used in the iOS app only, so we are explicitly tagging them with dead code allowed
 pub enum EndpointError {
@@ -38,24 +38,24 @@ pub enum EndpointError {
 }
 
 // Ref: https://mozilla.github.io/uniffi-rs/0.27/proc_macro/index.html#the-unifficustom_type-and-unifficustom_newtype-macros
-#[cfg(mobile)]
+#[cfg(feature = "mobile")]
 uniffi::custom_type!(IpAddress, String);
 
-#[cfg(mobile)]
+#[cfg(feature = "mobile")]
 #[derive(Debug, Eq, PartialEq, Clone)]
 /// Custom type  with `String` as the `Builtin` bridge
 pub struct IpAddress {
     ip: IpAddr,
 }
 
-#[cfg(mobile)]
+#[cfg(feature = "mobile")]
 impl std::fmt::Display for IpAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.ip)
     }
 }
 
-#[cfg(mobile)]
+#[cfg(feature = "mobile")]
 impl crate::UniffiCustomTypeConverter for IpAddress {
     type Builtin = String;
 
@@ -71,7 +71,7 @@ impl crate::UniffiCustomTypeConverter for IpAddress {
     }
 }
 
-#[cfg(mobile)]
+#[cfg(feature = "mobile")]
 impl From<IpAddress> for IpAddr {
     fn from(val: IpAddress) -> Self {
         val.ip

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -8,10 +8,10 @@ pub mod platform;
 #[cfg(desktop)]
 pub mod route_manager;
 
-#[cfg(mobile)]
+#[cfg(feature = "mobile")]
 pub mod mobile;
 
-#[cfg(mobile)]
+#[cfg(feature = "mobile")]
 uniffi::setup_scaffolding!();
 
 use anyhow::{Context, Result, anyhow};
@@ -85,17 +85,17 @@ impl std::fmt::Debug for ClientConnectionMode {
 }
 
 #[derive(Debug)]
-#[cfg_attr(mobile, derive(uniffi::Enum))]
+#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
 pub enum ClientResult {
     UserDisconnect,
     NetworkChange,
 
-    #[cfg(mobile)]
+    #[cfg(feature = "mobile")]
     ServerGoodbye,
 }
 
 #[derive(Debug, thiserror::Error)]
-#[cfg_attr(mobile, derive(uniffi::Error), uniffi(flat_error))]
+#[cfg_attr(feature = "mobile", derive(uniffi::Error), uniffi(flat_error))]
 pub enum LightwayError {
     #[error("Connection Error: `{0}`")]
     ConnectionError(#[from] anyhow::Error),
@@ -105,10 +105,10 @@ pub enum LightwayError {
     Unauthorized,
 
     // These Endpoint Error is iOS only
-    #[cfg(mobile)]
+    #[cfg(feature = "mobile")]
     #[error("Endpoint Error: `{0}`")]
     EndpointError(#[from] crate::endpoint::EndpointError),
-    #[cfg(mobile)]
+    #[cfg(feature = "mobile")]
     #[error("Logging bridge initialization error: `{0}`")]
     LoggingBridgeError(#[from] crate::mobile::tracing_utils::LoggingBridgeError),
 }


### PR DESCRIPTION
## Description
It is easier to tailor and conditional build with feature gate than target

## Motivation and Context
Using the target alone for conditional compilation does not cover all use cases, so we keep the `mobile` feature gate. It is more explicit and gives developers finer control over what gets included in the build.

## How Has This Been Tested?
no need

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Fix downstream bug
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] The correct base branch is being used, if not `main`
