### PR TITLE
Remove `batch_receive` from feature flag of client crate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -299,9 +299,6 @@ jobs:
       - name: Run clippy
         run: nix develop --command cargo make clippy
 
-      - name: Run batch receiver test
-        run: nix develop --command cargo test batch_receiver --features batch_receive
-
       - name: Run privileged tests (macOS only)
         if: matrix.os == 'macos-26'
         run: sudo nix develop --command cargo test test_privileged -- --ignored

--- a/Earthfile
+++ b/Earthfile
@@ -51,13 +51,7 @@ source:
 build:
     FROM +source
 
-    ARG BATCH_RECEIVE=false
-    LET features = "io-uring"
-    IF [ "$BATCH_RECEIVE" = "true" ]
-        SET features = "$features,batch_receive"
-    END
-
-    DO lib-rust+CARGO --args="build --release --features $features" --output="release/lightway-(client|server)$"
+    DO lib-rust+CARGO --args="build --release --features io-uring" --output="release/lightway-(client|server)$"
 
     SAVE ARTIFACT ./target/release/lightway-client AS LOCAL ./target/release/
     SAVE ARTIFACT ./target/release/lightway-server AS LOCAL ./target/release/

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -21,7 +21,6 @@ mobile = ["uniffi", "tracing-core", "tracing-panic"]
 debug = ["lightway-core/debug","lightway-app-utils/debug"]
 io-uring = ["lightway-app-utils/io-uring"]
 postquantum = ["lightway-core/postquantum"]
-batch_receive = []
 
 [lints]
 workspace = true

--- a/lightway-client/build.rs
+++ b/lightway-client/build.rs
@@ -22,8 +22,8 @@ fn main() {
                 tvos
             )
         },
-        // Feature alias
-        batch_receive: { all(any(linux, apple, android), feature = "batch_receive") },
+        // Feature that is supported on specific platforms
+        batch_receive: { any(linux, apple, android) },
     }
 
     let git_hash = get_git_hash();

--- a/lightway-client/src/args.rs
+++ b/lightway-client/src/args.rs
@@ -123,7 +123,7 @@ pub struct Config {
     #[clap(long)]
     pub rcvbuf: Option<ByteSize>,
 
-    /// Enable batch receive (`recvmsg_x` on macOS)
+    /// Enable batch receive (`recvmsg_x` on macOS, `recvmmsg` on Linux/Android)
     #[cfg(batch_receive)]
     #[clap(long, default_value_t = false)]
     pub enable_batch_receive: bool,

--- a/lightway-client/src/io/outside/udp_batch_receiver.rs
+++ b/lightway-client/src/io/outside/udp_batch_receiver.rs
@@ -289,8 +289,8 @@ mod tests {
         let count = PlatformBatchRecv::recv_multiple(fd, &mut bufs, BATCH_RECV_SIZE).unwrap();
         assert!(count >= 1);
         // Verify received packets are in order.
-        for i in 0..count {
-            assert_eq!(bufs[i][0], i as u8);
+        for (i, b) in bufs.iter().enumerate().take(count) {
+            assert_eq!(b[0], i as u8);
         }
     }
 }

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -172,7 +172,7 @@ pub struct ClientConfig<'cert, ExtAppState: Send + Sync> {
     /// Socket receive buffer size
     pub rcvbuf: Option<ByteSize>,
 
-    /// Enable batch receive (`recvmsg_x` on macOS)
+    /// Enable batch receive (`recvmsg_x` on macOS, `recvmmsg` on Linux/Android)
     #[cfg(batch_receive)]
     pub enable_batch_receive: bool,
 

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -14,7 +14,6 @@ TEST:
 
     ARG CLIENT_TOKIO_WORKER_THREADS
     ARG SERVER_TOKIO_WORKER_THREADS
-    ARG BATCH_RECEIVE=false
 
     ARG MODE
     ARG SERVER_PORT
@@ -34,7 +33,7 @@ TEST:
         SET CLIENT_ARGS="$CLIENT_ARGS --mode=$MODE"
     END
 
-    ARG CLIENT_IMAGE="(./client+build-container --TOKIO_WORKER_THREADS=$CLIENT_TOKIO_WORKER_THREADS --BATCH_RECEIVE=$BATCH_RECEIVE --debian=$debian)"
+    ARG CLIENT_IMAGE="(./client+build-container --TOKIO_WORKER_THREADS=$CLIENT_TOKIO_WORKER_THREADS --debian=$debian)"
     ARG SERVER_IMAGE="(./server+build-container --TOKIO_WORKER_THREADS=$SERVER_TOKIO_WORKER_THREADS --debian=$debian)"
     ARG NGINX_IMAGE="./base+build-test-nginx-container"
     ARG IPERF_IMAGE="(./base+build-test-iperf-container --debian=$debian)"
@@ -85,7 +84,7 @@ run-udp-iouring-test:
 
 # run-udp-batch-receive-test runs e2e test using UDP with batch receive enabled
 run-udp-batch-receive-test:
-    DO +TEST --MODE=udp --SERVER_PORT=27690 --BATCH_RECEIVE=true --CLIENT_EXTRA_ARGS="--enable-batch-receive"
+    DO +TEST --MODE=udp --SERVER_PORT=27690 --CLIENT_EXTRA_ARGS="--enable-batch-receive"
 
 # run-udp-expresslane-test runs e2e test using UDP with expresslane enabled
 run-udp-expresslane-test:

--- a/tests/client/Earthfile
+++ b/tests/client/Earthfile
@@ -4,9 +4,8 @@ ARG --global debian
 build-container:
     ARG SERVER_ADDR
     ARG TOKIO_WORKER_THREADS
-    ARG BATCH_RECEIVE=false
     FROM ../base+container --debian=$debian
-    COPY (../..+build/lightway-client --debian=$debian --BATCH_RECEIVE=$BATCH_RECEIVE) .
+    COPY (../..+build/lightway-client --debian=$debian) .
     COPY --dir ../certs+client/* tests/certs/
     COPY --dir --chmod 0600 client_config.yaml parallel_connect/ .
     COPY --dir docker-entrypoint.sh run-test-inside.sh check-server.sh .


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove this feature flag from `lightway-client`. Instead, we can use cfg_alias to define which platform explicitly supports batch_receive to guard this feature so that we don't need to build 2 binaries for testing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/expressvpn/lightway/pull/384#discussion_r3128161536

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passed CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
