### PR TITLE
client: replace --enable-pqc with --keyshare selection

### DIFF
--- a/lightway-app-utils/Cargo.toml
+++ b/lightway-app-utils/Cargo.toml
@@ -14,6 +14,7 @@ default = [ "tokio" ]
 io-uring = [ "dep:io-uring", "dep:tokio", "dep:tokio-eventfd" ]
 tokio = [ "dep:tokio", "dep:tokio-stream" ]
 debug = [ ]
+postquantum = [ "lightway-core/postquantum" ]
 
 [lints]
 workspace = true

--- a/lightway-app-utils/src/args.rs
+++ b/lightway-app-utils/src/args.rs
@@ -4,6 +4,8 @@ mod cipher;
 mod connection_type;
 mod duration;
 mod ip_map;
+#[cfg(feature = "postquantum")]
+mod keyshare;
 mod logging;
 mod nonzero_duration;
 
@@ -11,5 +13,7 @@ pub use cipher::Cipher;
 pub use connection_type::ConnectionType;
 pub use duration::Duration;
 pub use ip_map::IpMap;
+#[cfg(feature = "postquantum")]
+pub use keyshare::KeyShare;
 pub use logging::{LogFormat, LogLevel};
 pub use nonzero_duration::NonZeroDuration;

--- a/lightway-app-utils/src/args/keyshare.rs
+++ b/lightway-app-utils/src/args/keyshare.rs
@@ -1,0 +1,25 @@
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+
+use lightway_core::KeyShare as LWKeyShare;
+
+#[derive(Copy, Clone, Debug, ValueEnum, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+#[value(rename_all = "lowercase")]
+/// [`LWKeyShare`] wrapper compatible with clap and twelf
+pub enum KeyShare {
+    /// P-521 + ML-KEM-1024
+    #[default]
+    P521Mlkem1024,
+    /// X25519 + ML-KEM-768
+    X25519Mlkem768,
+}
+
+impl From<KeyShare> for LWKeyShare {
+    fn from(item: KeyShare) -> LWKeyShare {
+        match item {
+            KeyShare::P521Mlkem1024 => LWKeyShare::P521MLKEM1024,
+            KeyShare::X25519Mlkem768 => LWKeyShare::X25519MLKEM768,
+        }
+    }
+}

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -20,7 +20,7 @@ default = ["postquantum"]
 mobile = ["uniffi", "tracing-core", "tracing-panic"]
 debug = ["lightway-core/debug","lightway-app-utils/debug"]
 io-uring = ["lightway-app-utils/io-uring"]
-postquantum = ["lightway-core/postquantum"]
+postquantum = ["lightway-core/postquantum", "lightway-app-utils/postquantum"]
 
 [lints]
 workspace = true

--- a/lightway-client/src/args.rs
+++ b/lightway-client/src/args.rs
@@ -5,6 +5,8 @@ use super::route_manager::RouteMode;
 use anyhow::{Result, anyhow};
 use bytesize::ByteSize;
 use clap::Parser;
+#[cfg(feature = "postquantum")]
+use lightway_app_utils::args::KeyShare;
 use lightway_app_utils::args::{Cipher, ConnectionType, Duration, LogLevel, NonZeroDuration};
 use lightway_core::{AuthMethod, MAX_OUTSIDE_MTU};
 use std::{net::Ipv4Addr, path::PathBuf};
@@ -91,8 +93,8 @@ pub struct Config {
 
     /// Enable Post Quantum Crypto
     #[cfg(feature = "postquantum")]
-    #[clap(long, default_value_t)]
-    pub enable_pqc: bool,
+    #[clap(long, value_enum, default_value_t = KeyShare::P521Mlkem1024)]
+    pub keyshare: KeyShare,
 
     /// Interval between keepalives
     #[clap(long, default_value = "10s")]

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -20,6 +20,8 @@ use bytesize::ByteSize;
 use futures::{FutureExt, stream::FuturesUnordered};
 pub use io::inside::{InsideIO, InsideIORecv};
 use keepalive::Keepalive;
+#[cfg(feature = "postquantum")]
+use lightway_app_utils::args::KeyShare;
 use lightway_app_utils::{
     ConnectionTicker, ConnectionTickerState, DplpmtudTimer, EventStream, EventStreamCallback,
     PacketCodecFactoryType, TunConfig, args::Cipher, connection_ticker_cb,
@@ -146,9 +148,9 @@ pub struct ClientConfig<'cert, ExtAppState: Send + Sync> {
     /// DNS IP to use in Tun device
     pub tun_dns_ip: Ipv4Addr,
 
-    /// Enable Post Quantum Crypto
+    /// Key share group for post-quantum key exchange
     #[cfg(feature = "postquantum")]
-    pub enable_pqc: bool,
+    pub keyshare: KeyShare,
 
     /// Interval between keepalives
     pub keepalive_interval: Duration,
@@ -805,7 +807,7 @@ pub async fn connect<
     });
 
     #[cfg(feature = "postquantum")]
-    let conn_builder = conn_builder.when(config.enable_pqc, |b| b.with_pq_crypto());
+    let conn_builder = conn_builder.with_pq_crypto(config.keyshare.into());
 
     #[cfg(feature = "debug")]
     let conn_builder = conn_builder.when_some(config.keylog.clone(), |b, k| {

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -207,7 +207,7 @@ async fn main() -> Result<()> {
         tun_peer_ip: config.tun_peer_ip,
         tun_dns_ip: config.tun_dns_ip,
         #[cfg(feature = "postquantum")]
-        enable_pqc: config.enable_pqc,
+        keyshare: config.keyshare,
         enable_expresslane: config.enable_expresslane,
         keepalive_interval: config.keepalive_interval.into(),
         keepalive_timeout: config.keepalive_timeout.into(),

--- a/lightway-core/src/connection/builders.rs
+++ b/lightway-core/src/connection/builders.rs
@@ -7,6 +7,8 @@ use thiserror::Error;
 #[cfg(feature = "debug")]
 use wolfssl::Tls13SecretCallbacksArg;
 
+#[cfg(feature = "postquantum")]
+use crate::KeyShare;
 use crate::{
     AuthMethod, BuilderPredicates, ClientContext, Connection, ConnectionType, MAX_OUTSIDE_MTU,
     MIN_OUTSIDE_MTU, OutsideIOSendCallbackArg, PacketDecoderType, PacketEncoderType, ServerContext,
@@ -169,11 +171,11 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
 
     /// Enable Post Quantum Crypto
     #[cfg(feature = "postquantum")]
-    pub fn with_pq_crypto(self) -> Self {
-        let curve = wolfssl::CurveGroup::P521MLKEM1024;
-
+    pub fn with_pq_crypto(self, keyshare: KeyShare) -> Self {
         Self {
-            session_config: self.session_config.with_keyshare_group(curve),
+            session_config: self
+                .session_config
+                .with_keyshare_group(keyshare.as_curve_group()),
             ..self
         }
     }

--- a/lightway-core/src/keyshare.rs
+++ b/lightway-core/src/keyshare.rs
@@ -1,0 +1,21 @@
+/// Key share group for post-quantum key exchange.
+/// Client can choose one based on server compatibility.
+#[derive(Copy, Clone, Debug, Default)]
+pub enum KeyShare {
+    /// P-521 + ML-KEM-1024
+    #[default]
+    P521MLKEM1024,
+
+    /// X25519 + ML-KEM-768
+    X25519MLKEM768,
+}
+
+impl KeyShare {
+    /// Get the corresponding curve group
+    pub fn as_curve_group(&self) -> wolfssl::CurveGroup {
+        match self {
+            KeyShare::P521MLKEM1024 => wolfssl::CurveGroup::P521MLKEM1024,
+            KeyShare::X25519MLKEM768 => wolfssl::CurveGroup::X25519MLKEM768,
+        }
+    }
+}

--- a/lightway-core/src/lib.rs
+++ b/lightway-core/src/lib.rs
@@ -10,6 +10,8 @@ mod context;
 mod encoding_request_states;
 mod features;
 mod io;
+#[cfg(feature = "postquantum")]
+mod keyshare;
 mod metrics;
 mod packet;
 mod packet_codec;
@@ -42,6 +44,8 @@ pub use features::LightwayFeature;
 pub use io::{
     InsideIOSendCallback, InsideIOSendCallbackArg, OutsideIOSendCallback, OutsideIOSendCallbackArg,
 };
+#[cfg(feature = "postquantum")]
+pub use keyshare::KeyShare;
 pub use packet::OutsidePacket;
 pub use packet_codec::{
     CodecStatus, PacketCodecResult, PacketDecoder, PacketDecoderType, PacketEncoder,

--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -420,7 +420,7 @@ async fn client<S: TestSock>(
     .with_auth_token("LET ME IN")
     .with_event_cb(Box::new(event_cb))
     .with_inside_pkt_codec(packet_codec)
-    .when(pqc.enable_client(), |b| b.with_pq_crypto())
+    .when_some(pqc.client_keyshare(), |b, ks| b.with_pq_crypto(ks))
     .when_some(server_dn, |b, sdn| {
         b.with_server_domain_name_validation(sdn.to_string())
     })
@@ -618,42 +618,28 @@ async fn client<S: TestSock>(
 }
 
 #[derive(Clone, Copy)]
-enum PQCrypto {
-    // PQC enabled client and server
-    Enabled,
-    // PQC disabled client and server
-    Disabled,
-    // PQC available on server, but not on client
-    ServerOnly,
-    // PQC not enabled on server, but client tries to use
-    ClientOnly,
+struct PQCrypto {
+    server_pqc: bool,
+    keyshare: Option<KeyShare>,
 }
 
 impl PQCrypto {
     fn enable_server(&self) -> bool {
-        match self {
-            PQCrypto::Enabled => true,
-            PQCrypto::Disabled => false,
-            PQCrypto::ServerOnly => true,
-            PQCrypto::ClientOnly => false,
-        }
+        self.server_pqc
     }
 
-    fn enable_client(&self) -> bool {
-        match self {
-            PQCrypto::Enabled => true,
-            PQCrypto::Disabled => false,
-            PQCrypto::ServerOnly => false,
-            PQCrypto::ClientOnly => true,
-        }
+    fn client_keyshare(&self) -> Option<KeyShare> {
+        self.keyshare
     }
 
     fn expected_curve(&self) -> &str {
-        match self {
-            PQCrypto::Enabled => "SecP521r1MLKEM1024",
-            PQCrypto::Disabled => "SECP256R1",
-            PQCrypto::ServerOnly => "X25519MLKEM768",
-            PQCrypto::ClientOnly => "SECP256R1",
+        if !self.server_pqc {
+            return "SECP256R1";
+        }
+        match self.keyshare {
+            Some(KeyShare::P521MLKEM1024) => "SecP521r1MLKEM1024",
+            Some(KeyShare::X25519MLKEM768) => "X25519MLKEM768",
+            None => "X25519MLKEM768", // wolfSSL 5.0.0 default
         }
     }
 }
@@ -703,14 +689,15 @@ async fn run_test<S: TestSock>(
         .expect("Timed out");
 }
 
-#[test_case(None,                   PQCrypto::Enabled,    false, false; "Default cipher + PQC")]
-#[test_case(Some(Cipher::Aes256),   PQCrypto::Enabled,    false, false; "aes + PQC")]
-#[test_case(Some(Cipher::Chacha20), PQCrypto::Enabled,    false, false; "chacha20 +_PQC")]
-#[test_case(None,                   PQCrypto::Disabled,   false, false; "PQC disabled")]
-#[test_case(None,                   PQCrypto::ServerOnly, false, false; "PQC server only")]
-#[test_case(None,                   PQCrypto::ClientOnly, false, false; "PQC client only")]
-#[test_case(Some(Cipher::Aes256),   PQCrypto::Enabled,     true, false; "Inside packet codec")]
-#[test_case(None,                   PQCrypto::Enabled,    false,  true; "Default cipher + PQC + Expresslane")]
+#[test_case(None,                   PQCrypto { server_pqc: true,  keyshare: Some(KeyShare::P521MLKEM1024) },  false, false; "PQC P521MLKEM1024")]
+#[test_case(None,                   PQCrypto { server_pqc: true,  keyshare: Some(KeyShare::X25519MLKEM768) }, false, false; "PQC X25519MLKEM768")]
+#[test_case(Some(Cipher::Aes256),   PQCrypto { server_pqc: true,  keyshare: Some(KeyShare::P521MLKEM1024) },  false, false; "aes + PQC")]
+#[test_case(Some(Cipher::Chacha20), PQCrypto { server_pqc: true,  keyshare: Some(KeyShare::P521MLKEM1024) },  false, false; "chacha20 + PQC")]
+#[test_case(None,                   PQCrypto { server_pqc: false, keyshare: Some(KeyShare::P521MLKEM1024) },  false, false; "server PQC disabled")]
+#[test_case(None,                   PQCrypto { server_pqc: false, keyshare: Some(KeyShare::X25519MLKEM768) }, false, false; "server PQC disabled + X25519MLKEM768")]
+#[test_case(None,                   PQCrypto { server_pqc: true,  keyshare: None },                           false, false; "PQC wolfSSL default")]
+#[test_case(Some(Cipher::Aes256),   PQCrypto { server_pqc: true,  keyshare: Some(KeyShare::P521MLKEM1024) },   true, false; "Inside packet codec")]
+#[test_case(None,                   PQCrypto { server_pqc: true,  keyshare: Some(KeyShare::P521MLKEM1024) },  false,  true; "PQC + Expresslane")]
 #[tokio::test]
 async fn test_datagram_connection(
     cipher: Option<Cipher>,
@@ -739,12 +726,13 @@ async fn test_datagram_connection(
     .await;
 }
 
-#[test_case(None,                   PQCrypto::Enabled;    "Default cipher + PQC")]
-#[test_case(Some(Cipher::Aes256),   PQCrypto::Enabled;    "aes + PQC")]
-#[test_case(Some(Cipher::Chacha20), PQCrypto::Enabled;    "chacha20 + PQC")]
-#[test_case(None,                   PQCrypto::Disabled;   "PQC disabled")]
-#[test_case(None,                   PQCrypto::ServerOnly; "PQC server only")]
-#[test_case(None,                   PQCrypto::ClientOnly; "PQC client only")]
+#[test_case(None,                   PQCrypto { server_pqc: true,  keyshare: Some(KeyShare::P521MLKEM1024) };  "PQC P521MLKEM1024")]
+#[test_case(None,                   PQCrypto { server_pqc: true,  keyshare: Some(KeyShare::X25519MLKEM768) }; "PQC X25519MLKEM768")]
+#[test_case(Some(Cipher::Aes256),   PQCrypto { server_pqc: true,  keyshare: Some(KeyShare::P521MLKEM1024) };  "aes + PQC")]
+#[test_case(Some(Cipher::Chacha20), PQCrypto { server_pqc: true,  keyshare: Some(KeyShare::P521MLKEM1024) };  "chacha20 + PQC")]
+#[test_case(None,                   PQCrypto { server_pqc: false, keyshare: Some(KeyShare::P521MLKEM1024) };  "server PQC disabled")]
+#[test_case(None,                   PQCrypto { server_pqc: false, keyshare: Some(KeyShare::X25519MLKEM768) }; "server PQC disabled + X25519MLKEM768")]
+#[test_case(None,                   PQCrypto { server_pqc: true,  keyshare: None };                           "PQC wolfSSL default")]
 #[tokio::test]
 async fn test_stream_connection(cipher: Option<Cipher>, pqc: PQCrypto) {
     // Communicate over a local stream socket for simplicity
@@ -768,22 +756,18 @@ async fn test_server_dn(server_dn: Option<&str>) {
     let (client_sock, server_sock) = UnixStream::pair().expect("UnixStream");
     let server_sock = Arc::new(TestStreamSock(server_sock));
     let client_sock = Arc::new(TestStreamSock(client_sock));
-
+    let pqc = PQCrypto {
+        server_pqc: true,
+        keyshare: Some(KeyShare::P521MLKEM1024),
+    };
     // We need the server end to be ready to receive before we can get
     // started, else we'll get a `WouldBlock`.
     let _ = client_sock.writable().await;
 
     let test = async move {
         tokio::join!(
-            server(server_sock, PQCrypto::Enabled, false),
-            client(
-                client_sock,
-                None,
-                PQCrypto::Enabled,
-                server_dn,
-                false,
-                false
-            )
+            server(server_sock, pqc, false),
+            client(client_sock, None, pqc, server_dn, false, false)
         )
     };
 

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -56,7 +56,11 @@ run-tcp-chacha20-test:
 
 # run-tcp-pqc-test runs e2e test using TCP and default cipher with PQC enabled
 run-tcp-pqc-test:
-    DO +TEST --MODE=tcp --SERVER_PORT=443 --SERVER_EXTRA_ARGS="--enable-pqc" --CLIENT_EXTRA_ARGS="--enable-pqc"
+    DO +TEST --MODE=tcp --SERVER_PORT=443 --SERVER_EXTRA_ARGS="--enable-pqc"
+
+# run-tcp-pqc-x25519mlkem768-test runs e2e test using TCP with X25519MLKEM768 keyshare
+run-tcp-pqc-x25519mlkem768-test:
+    DO +TEST --MODE=tcp --SERVER_PORT=443 --SERVER_EXTRA_ARGS="--enable-pqc" --CLIENT_EXTRA_ARGS="--keyshare x25519mlkem768"
 
 # run-udp-aes256-test runs e2e test using UDP and AES256 cipher
 run-udp-aes256-test:
@@ -68,7 +72,11 @@ run-udp-chacha20-test:
 
 # run-udp-pqc-test runs e2e test using UDP and default cipher with PQC enabled
 run-udp-pqc-test:
-    DO +TEST --MODE=udp --SERVER_PORT=27690 --SERVER_EXTRA_ARGS="--enable-pqc" --CLIENT_EXTRA_ARGS="--enable-pqc"
+    DO +TEST --MODE=udp --SERVER_PORT=27690 --SERVER_EXTRA_ARGS="--enable-pqc"
+
+# run-udp-pqc-x25519mlkem768-test runs e2e test using UDP with X25519MLKEM768 keyshare
+run-udp-pqc-x25519mlkem768-test:
+    DO +TEST --MODE=udp --SERVER_PORT=27690 --SERVER_EXTRA_ARGS="--enable-pqc" --CLIENT_EXTRA_ARGS="--keyshare x25519mlkem768"
 
 # run-udp-floating-ip-test runs e2e test of UDP floating IP support
 run-udp-floating-ip-test:
@@ -140,9 +148,11 @@ run-all-tests:
     BUILD +run-tcp-aes256-test
     BUILD +run-tcp-chacha20-test
     BUILD +run-tcp-pqc-test
+    BUILD +run-tcp-pqc-x25519mlkem768-test
     BUILD +run-udp-aes256-test
     BUILD +run-udp-chacha20-test
     BUILD +run-udp-pqc-test
+    BUILD +run-udp-pqc-x25519mlkem768-test
     BUILD +run-udp-floating-ip-test
     BUILD +run-udp-pmtud-test
     BUILD +run-udp-iouring-test

--- a/tests/client/client_config.yaml
+++ b/tests/client/client_config.yaml
@@ -12,7 +12,7 @@ user: user
 password: password
 outside_mtu: 1500
 cipher: aes256
-enable_pqc: false
+# keyshare: p251mlkem1024
 enable_tun_iouring: false
 # iouring_sqpoll_idle_time: 100ms
 iouring_entry_count: 1024

--- a/tests/client/parallel_connect/client_config.tcp.yaml
+++ b/tests/client/parallel_connect/client_config.tcp.yaml
@@ -62,7 +62,6 @@ log_level: info
 user: user
 password: password
 outside_mtu: 1500
-enable_pqc: false
 enable_tun_iouring: false
 # iouring_sqpoll_idle_time: 100ms
 iouring_entry_count: 1024

--- a/tests/client/parallel_connect/client_config.tcp_then_udp.yaml
+++ b/tests/client/parallel_connect/client_config.tcp_then_udp.yaml
@@ -17,7 +17,6 @@ log_level: info
 user: user
 password: password
 outside_mtu: 1500
-enable_pqc: false
 enable_tun_iouring: false
 # iouring_sqpoll_idle_time: 100ms
 iouring_entry_count: 1024

--- a/tests/client/parallel_connect/client_config.udp.yaml
+++ b/tests/client/parallel_connect/client_config.udp.yaml
@@ -63,7 +63,6 @@ log_level: info
 user: user
 password: password
 outside_mtu: 1500
-enable_pqc: false
 enable_tun_iouring: false
 # iouring_sqpoll_idle_time: 100ms
 iouring_entry_count: 1024

--- a/tests/client/parallel_connect/client_config.udp_then_tcp.yaml
+++ b/tests/client/parallel_connect/client_config.udp_then_tcp.yaml
@@ -17,7 +17,6 @@ log_level: info
 user: user
 password: password
 outside_mtu: 1500
-enable_pqc: false
 enable_tun_iouring: false
 # iouring_sqpoll_idle_time: 100ms
 iouring_entry_count: 1024


### PR DESCRIPTION
wolfSSL 5.0.0 includes PQC groups inside its default supported curves for clients, making --enable-pqc boolean misleading.

Replace it with an explict --keyshare flag that selects between P521MLKEM1024 (default) and X25519MLKEM768. PQC will always be ON for the client, while the server's --enable-pqc can remain the kill switch.

## Description
- Remove usage of --enable-pqc flag on client
- Added --keyshare flag on client
- Added KeyShare enums
- Updated test cases and earthly CIs
- Updated configs (to remove enable-pqc and add keyshare)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
