### PR TITLE
client: add fixed GUID option for Wintun

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,6 +1646,7 @@ dependencies = [
  "tun-rs",
  "twelf",
  "uniffi",
+ "uuid",
  "windows-dpapi",
  "windows-sys 0.61.2",
 ]
@@ -3609,6 +3610,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -56,6 +56,11 @@ pub struct TunConfig {
     /// Wintun ring buffer capacity in bytes. Larger values improve throughput.
     /// Must be a power of two between 128KiB and 64MiB.
     pub ring_capacity: Option<u32>,
+    #[cfg(windows)]
+    /// Optional fixed GUID for the Wintun adapter. Using a stable GUID ensures
+    /// that adapter creation retries reuse the same device node rather than
+    /// leaking duplicates.
+    pub device_guid: Option<u128>,
 }
 
 impl Debug for TunConfig {
@@ -165,6 +170,13 @@ impl TunConfig {
         Ok(self)
     }
 
+    /// Set a fixed GUID for the Wintun adapter (Windows only).
+    #[cfg(windows)]
+    pub fn device_guid(&mut self, guid: u128) -> &mut Self {
+        self.device_guid = Some(guid);
+        self
+    }
+
     /// Creates an async device based on TunConfig
     #[cfg(desktop)]
     pub fn create_as_async(&self) -> std::io::Result<AsyncDevice> {
@@ -182,6 +194,10 @@ impl TunConfig {
                     opt.ring_capacity(ring_capacity);
                 });
             }
+        }
+        #[cfg(windows)]
+        if let Some(guid) = self.device_guid {
+            builder = builder.device_guid(guid);
         }
         #[cfg(macos)]
         {

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -76,6 +76,7 @@ objc2-core-foundation = "0.3.1"
 objc2-system-configuration = "0.3.1"
 
 [target.'cfg(windows)'.dependencies]
+uuid = "1"
 windows-dpapi = "0.2.0"
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",

--- a/lightway-client/src/args.rs
+++ b/lightway-client/src/args.rs
@@ -77,6 +77,13 @@ pub struct Config {
     #[clap(long, default_value = None)]
     pub wintun_file: Option<String>,
 
+    /// Fixed GUID for the Wintun adapter (Windows only).
+    /// Ensures adapter creation retries reuse the same device node.
+    /// Accepts a UUID string (e.g. "550e8400-e29b-41d4-a716-446655440000").
+    #[cfg(windows)]
+    #[clap(long, default_value = None)]
+    pub device_guid: Option<String>,
+
     /// Local IP to use in Tun device
     #[clap(long, default_value = "100.64.0.6")]
     pub tun_local_ip: Ipv4Addr,

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -153,6 +153,14 @@ async fn main() -> Result<()> {
         tun_config.ring_capacity(config.wintun_ring_capacity.as_u64().try_into()?)?;
     }
 
+    #[cfg(windows)]
+    if let Some(ref device_guid) = config.device_guid {
+        let parsed = uuid::Uuid::parse_str(device_guid)
+            .with_context(|| format!("invalid device GUID: {device_guid}"))?;
+        tracing::info!(device_guid = %parsed, "Setting device GUID");
+        tun_config.device_guid(parsed.as_u128());
+    }
+
     // TODO: Fix in future PR
     tun_config
         .mtu(1350)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add optional `device_guid` field for Windows only, to specify the GUID for the tun. The device GUID is logged when set if specified.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using a stable GUID ensures that adapter creation retries reuse the same device node rather than leaking duplicates.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested that it sets the GUID and logs correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
