### PR TITLE
CVPN-2515/CVPN-2512: Send/receive multiple packets to TUN at once

### DIFF
--- a/lightway-app-utils/src/lib.rs
+++ b/lightway-app-utils/src/lib.rs
@@ -28,7 +28,9 @@ pub use iouring::IOUring;
 
 #[cfg(feature = "io-uring")]
 pub use tun::TunIoUring;
-pub use tun::{Tun, TunConfig, TunDirect};
+pub use tun::{DEFAULT_TUN_MTU, Tun, TunConfig, TunDirect};
+#[cfg(linux)]
+pub use tun::{RECV_MULTIPLE_MAX_SEGMENTS, RECV_MULTIPLE_TUN_BUFFER_SIZE};
 
 #[cfg(feature = "io-uring")]
 mod metrics;

--- a/lightway-app-utils/src/lib.rs
+++ b/lightway-app-utils/src/lib.rs
@@ -30,7 +30,7 @@ pub use iouring::IOUring;
 pub use tun::TunIoUring;
 pub use tun::{DEFAULT_TUN_MTU, Tun, TunConfig, TunDirect};
 #[cfg(linux)]
-pub use tun::{RECV_MULTIPLE_MAX_SEGMENTS, RECV_MULTIPLE_TUN_BUFFER_SIZE};
+pub use tun::{RECV_MULTIPLE_MAX_SEGMENTS, RECV_MULTIPLE_TUN_BUFFER_SIZE, TunOffloadBuffers};
 
 #[cfg(feature = "io-uring")]
 mod metrics;

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -61,6 +61,9 @@ pub struct TunConfig {
     /// that adapter creation retries reuse the same device node rather than
     /// leaking duplicates.
     pub device_guid: Option<u128>,
+    /// Whether to enable TUN offloading (TSO/GSO) on Linux
+    #[cfg(linux)]
+    pub offload: bool,
 }
 
 impl Debug for TunConfig {
@@ -89,6 +92,8 @@ impl Debug for TunConfig {
         }
         #[cfg(unix)]
         s.field("close_fd_on_drop", &self.close_fd_on_drop);
+        #[cfg(linux)]
+        s.field("offload", &self.offload);
         s.finish()
     }
 }
@@ -180,6 +185,13 @@ impl TunConfig {
         self
     }
 
+    /// Set whether to enable TUN offloading or not on Linux
+    #[cfg(linux)]
+    pub fn offload(&mut self, value: bool) -> &mut Self {
+        self.offload = value;
+        self
+    }
+
     /// Creates an async device based on TunConfig
     #[cfg(desktop)]
     pub fn create_as_async(&self) -> std::io::Result<AsyncDevice> {
@@ -205,6 +217,10 @@ impl TunConfig {
         #[cfg(macos)]
         {
             builder = builder.associate_route(false);
+        }
+        #[cfg(linux)]
+        {
+            builder = builder.offload(self.offload);
         }
         let device = builder.build_async()?;
 

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -405,6 +405,24 @@ impl Tun {
         }
     }
 
+    /// Recv multiple packets from `Tun`. `buffers` is caller-owned scratch
+    /// reused across calls; each variant uses only the part it needs (see
+    /// [`TunOffloadBuffers`]). `bufs` entries must be pre-sized to
+    /// MTU by the caller; populated entries are truncated to each packet's
+    /// length on return. Returns the number of packets written.
+    #[cfg(linux)]
+    pub async fn recv_multiple_buf(
+        &self,
+        offload_buffer: &mut TunOffloadBuffers,
+        bufs: &mut [BytesMut],
+    ) -> IOCallbackResult<usize> {
+        match self {
+            Tun::Direct(t) => t.recv_multiple_buf(offload_buffer, bufs).await,
+            #[cfg(feature = "io-uring")]
+            Tun::IoUring(_) => IOCallbackResult::Err(std::io::ErrorKind::Unsupported.into()),
+        }
+    }
+
     /// MTU of `Tun` interface
     pub fn mtu(&self) -> usize {
         match self {
@@ -528,6 +546,38 @@ impl TunDirect {
             tun.tcp_gso()
         } else {
             false
+        }
+    }
+
+    /// Recv multiple packets, segmenting any GRO super-packet using virtio
+    /// offload metadata. `bufs` entries must be pre-sized to MTU; on
+    /// return, populated entries are truncated to each packet's length.
+    #[cfg(linux)]
+    pub async fn recv_multiple_buf(
+        &self,
+        tun_buffer: &mut TunOffloadBuffers,
+        bufs: &mut [BytesMut],
+    ) -> IOCallbackResult<usize> {
+        assert!(
+            bufs.len() <= RECV_MULTIPLE_MAX_SEGMENTS,
+            "bufs length cannot be greater than {RECV_MULTIPLE_MAX_SEGMENTS}"
+        );
+
+        let raw_buffer = &mut tun_buffer.raw_data_buffer;
+        let sizes = &mut tun_buffer.sizes[..bufs.len()];
+
+        let tun = self.tun.as_ref().unwrap();
+        match tun.recv_multiple(raw_buffer, bufs, sizes, 0).await {
+            Ok(count) => {
+                for i in 0..count {
+                    bufs[i].truncate(sizes[i]);
+                }
+                IOCallbackResult::Ok(count)
+            }
+            Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
+                IOCallbackResult::WouldBlock
+            }
+            Err(err) => IOCallbackResult::Err(err),
         }
     }
 

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -21,6 +21,31 @@ use tun_rs::DeviceBuilder;
 #[cfg(linux)]
 use tun_rs::{GROTable, VIRTIO_NET_HDR_LEN};
 
+/// Default MTU configured on the inside (TUN) interface.
+pub const DEFAULT_TUN_MTU: u16 = 1350;
+
+/// Size of the scratch buffer required by [`Tun::recv_multiple_buf`].
+/// Holds the raw virtio super-packet read from the kernel before tun-rs
+/// segments it. Matches the recommended sizing in tun-rs docs.
+#[cfg(linux)]
+pub const RECV_MULTIPLE_TUN_BUFFER_SIZE: usize = VIRTIO_NET_HDR_LEN + 65535;
+
+/// Maximum number of segmented packets a single
+/// [`Tun::recv_multiple_buf`] call may produce.
+///
+/// Per tun-rs docs (see `recv_multiple`), the `bufs`/`sizes` arrays
+/// must satisfy `len > 65535 / MTU` because the kernel can deliver up
+/// to a 65535-byte GRO super-packet per call. 64 covers MTUs down to
+/// ~1024 with headroom;
+#[cfg(linux)]
+pub const RECV_MULTIPLE_MAX_SEGMENTS: usize = 64;
+
+#[cfg(linux)]
+const _: () = assert!(
+    RECV_MULTIPLE_MAX_SEGMENTS * DEFAULT_TUN_MTU as usize > 65535,
+    "RECV_MULTIPLE_MAX_SEGMENTS must satisfy `len > 65535 / DEFAULT_TUN_MTU` per tun-rs",
+);
+
 #[cfg(feature = "io-uring")]
 use crate::IOUring;
 
@@ -413,7 +438,7 @@ impl TunDirect {
         let mtu = tun_device.mtu()?;
         // This currently is not supported for Android and IOS
         #[cfg(mobile)]
-        let mtu = 1350;
+        let mtu = DEFAULT_TUN_MTU;
         let tun = Some(tun_device);
 
         Ok(TunDirect {

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -49,6 +49,33 @@ const _: () = assert!(
 #[cfg(feature = "io-uring")]
 use crate::IOUring;
 
+/// Caller-owned buffers required by [`Tun::recv_multiple_buf`].
+///
+/// [`Tun::Direct`] uses `tun_buffer` (virtio super-packet scratch the
+/// kernel writes into) and `sizes` (per-segment lengths populated by
+/// tun-rs after splitting the super-packet).
+#[cfg(linux)]
+pub struct TunOffloadBuffers {
+    /// Direct path: scratch the kernel writes the raw virtio super-packet
+    /// into before tun-rs splits it into segmented IP packets.
+    pub raw_data_buffer: Vec<u8>,
+    /// Direct path: tun-rs writes per-segment lengths here, one per
+    /// produced packet.
+    pub sizes: Vec<usize>,
+}
+
+#[cfg(linux)]
+impl TunOffloadBuffers {
+    /// Allocate buffers. `max_segments` sizes the Direct-path `sizes` slice
+    /// (typically [`RECV_MULTIPLE_MAX_SEGMENTS`]).
+    pub fn new(max_segments: usize) -> Self {
+        Self {
+            raw_data_buffer: vec![0u8; RECV_MULTIPLE_TUN_BUFFER_SIZE],
+            sizes: vec![0; max_segments],
+        }
+    }
+}
+
 /// Configuration options for creating a interface
 ///
 /// This struct provides a builder-like interface for configuring TUN interfaces
@@ -363,6 +390,7 @@ impl Tun {
     pub fn gso(&self) -> (bool, bool) {
         match self {
             Tun::Direct(tun) => (tun.udp_gso(), tun.tcp_gso()),
+            #[cfg(feature = "io-uring")]
             _ => (false, false),
         }
     }

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -3,22 +3,23 @@ use bytes::BytesMut;
 use educe::Educe;
 use lightway_core::IOCallbackResult;
 
+#[cfg(mobile)]
+use std::os::fd::FromRawFd;
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, IntoRawFd, RawFd};
+#[cfg(feature = "io-uring")]
+use std::sync::Arc;
 #[cfg(feature = "io-uring")]
 use std::time::Duration;
 use std::{
     fmt::Debug,
     net::{IpAddr, Ipv4Addr},
 };
-
-#[cfg(mobile)]
-use std::os::fd::FromRawFd;
-#[cfg(feature = "io-uring")]
-use std::sync::Arc;
 use tun_rs::AsyncDevice;
 #[cfg(desktop)]
 use tun_rs::DeviceBuilder;
+#[cfg(linux)]
+use tun_rs::{GROTable, VIRTIO_NET_HDR_LEN};
 
 #[cfg(feature = "io-uring")]
 use crate::IOUring;
@@ -332,6 +333,25 @@ impl Tun {
         }
     }
 
+    /// Returns whether the tun device supports offloading for UDP and TCP GSO respectively.
+    #[cfg(linux)]
+    pub fn gso(&self) -> (bool, bool) {
+        match self {
+            Tun::Direct(tun) => (tun.udp_gso(), tun.tcp_gso()),
+            _ => (false, false),
+        }
+    }
+
+    /// Send multiple packets to `Tun`
+    #[cfg(linux)]
+    pub fn try_send_multiple(&self, bufs: &mut [BytesMut]) -> IOCallbackResult<usize> {
+        match self {
+            Tun::Direct(t) => t.try_send_multiple(bufs),
+            #[cfg(feature = "io-uring")]
+            Tun::IoUring(_) => IOCallbackResult::Err(std::io::ErrorKind::Unsupported.into()),
+        }
+    }
+
     /// MTU of `Tun` interface
     pub fn mtu(&self) -> usize {
         match self {
@@ -379,6 +399,8 @@ pub struct TunDirect {
     fd: RawFd,
     #[cfg(unix)]
     close_fd_on_drop: bool,
+    #[cfg(linux)]
+    gro_table: std::sync::Mutex<GROTable>,
 }
 
 impl TunDirect {
@@ -401,6 +423,8 @@ impl TunDirect {
             fd,
             #[cfg(unix)]
             close_fd_on_drop: config.close_fd_on_drop,
+            #[cfg(linux)]
+            gro_table: std::sync::Mutex::new(GROTable::default()),
         })
     }
 
@@ -430,6 +454,48 @@ impl TunDirect {
             Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
                 IOCallbackResult::WouldBlock
             }
+            Err(err) => IOCallbackResult::Err(err),
+        }
+    }
+
+    #[cfg(linux)]
+    /// Returns whether UDP Generic Segmentation Offload (GSO) is enabled.
+    pub fn udp_gso(&self) -> bool {
+        if let Some(tun) = self.tun.as_ref() {
+            tun.udp_gso()
+        } else {
+            false
+        }
+    }
+
+    #[cfg(linux)]
+    /// Returns whether TCP Generic Segmentation Offload (GSO) is enabled.
+    pub fn tcp_gso(&self) -> bool {
+        if let Some(tun) = self.tun.as_ref() {
+            tun.tcp_gso()
+        } else {
+            false
+        }
+    }
+
+    /// Send multiple packets via GRO. Each entry of `bufs` is replaced with
+    /// a buffer containing `VIRTIO_NET_HDR_LEN` zero bytes of head room
+    /// followed by the original packet — required by the underlying virtio
+    /// offload syscall.
+    #[cfg(linux)]
+    pub fn try_send_multiple(&self, bufs: &mut [BytesMut]) -> IOCallbackResult<usize> {
+        // TODO: Preallocate the offset somewhere earlier
+        for b in bufs.iter_mut() {
+            let mut framed = BytesMut::with_capacity(VIRTIO_NET_HDR_LEN + b.len());
+            framed.resize(VIRTIO_NET_HDR_LEN, 0);
+            framed.extend_from_slice(b);
+            *b = framed;
+        }
+
+        let tun: &tun_rs::DeviceImpl = self.tun.as_ref().unwrap();
+        let mut table = self.gro_table.lock().unwrap();
+        match tun.send_multiple(&mut table, bufs, VIRTIO_NET_HDR_LEN) {
+            Ok(nr) => IOCallbackResult::Ok(nr),
             Err(err) => IOCallbackResult::Err(err),
         }
     }

--- a/lightway-client/src/config.rs
+++ b/lightway-client/src/config.rs
@@ -175,6 +175,15 @@ pub struct Config {
     ))]
     pub enable_batch_receive: bool,
 
+    #[cfg(linux)]
+    #[patch(attribute(clap(long)))]
+    #[patch(empty_value = false)]
+    #[patch(attribute(serde(default)))]
+    #[patch(attribute(
+        doc = "Enable TUN offloading. It will also enable batch receive if this is on"
+    ))]
+    pub enable_offload: bool,
+
     #[cfg(desktop)]
     #[patch(attribute(clap(long, value_enum)))]
     #[patch(attribute(doc = r#"Setup of route table
@@ -383,6 +392,8 @@ impl Default for Config {
             rcvbuf: ByteSize::mib(8),
             #[cfg(batch_receive)]
             enable_batch_receive: false,
+            #[cfg(linux)]
+            enable_offload: false,
             #[cfg(desktop)]
             route_mode: RouteMode::default(),
             #[cfg(desktop)]

--- a/lightway-client/src/io/inside.rs
+++ b/lightway-client/src/io/inside.rs
@@ -7,13 +7,14 @@ pub use tun::Tun;
 
 use async_trait::async_trait;
 #[cfg(linux)]
-use lightway_app_utils::InsideRecvMultipleBuffers;
+use lightway_app_utils::TunOffloadBuffers;
 use lightway_core::{
     IOCallbackResult, InsideIOSendCallback, InsideIOSendCallbackArg, InsideIpConfig,
 };
 
 use crate::ConnectionState;
 
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 /// Trait for InsideIORecv
 /// This will be used client app to fetch inside packets
@@ -31,7 +32,7 @@ pub trait InsideIORecv<ExtAppState: Send + Sync>: Send + Sync {
     #[cfg(linux)]
     async fn recv_multiple_buf(
         &self,
-        tun_buffer: &mut InsideRecvMultipleBuffers,
+        tun_buffer: &mut TunOffloadBuffers,
         bufs: &mut [BytesMut],
     ) -> IOCallbackResult<usize>;
 
@@ -69,4 +70,243 @@ impl<
         + InsideIORecv<ExtAppState>,
 > InsideIO<ExtAppState> for U
 {
+}
+
+/// A wrapper for receive buffers for the inside (TUN) read path.
+/// Allocated once at task startup and reused across every
+/// [`recv`](Self::recv) call so the hot loop never allocates.
+///
+/// Construct with [`new`](Self::new) for the single-packet path
+/// (non-Linux, or Linux with TUN offload disabled). On Linux, construct
+/// with [`new_batched`](Self::new_batched) when [`InsideIORecv::gso`]
+/// reports UDP or TCP GSO support — that mode also holds the additional
+/// scratch space tun-rs needs to split kernel GRO super-packets into
+/// individual IP packets.
+pub struct InsideRecvBuf {
+    bufs: Vec<BytesMut>,
+    mtu: usize,
+    #[cfg(linux)]
+    multi_buffers: Option<TunOffloadBuffers>,
+}
+
+impl InsideRecvBuf {
+    /// Single-packet recv mode. Use on non-Linux platforms, or on Linux
+    /// when TUN offload is disabled at runtime.
+    pub fn new(mtu: usize) -> Self {
+        Self {
+            bufs: vec![BytesMut::zeroed(mtu)],
+            mtu,
+            #[cfg(linux)]
+            multi_buffers: None,
+        }
+    }
+
+    /// Batched recv mode for `count` GRO-segmented packets. Caller must
+    /// verify TUN offload is actually enabled via [`InsideIORecv::gso`]
+    /// before constructing in this mode.
+    #[cfg(linux)]
+    pub fn new_batched(mtu: usize, count: usize) -> Self {
+        Self {
+            bufs: (0..count).map(|_| BytesMut::zeroed(mtu)).collect(),
+            mtu,
+            multi_buffers: Some(TunOffloadBuffers::new(count)),
+        }
+    }
+
+    /// Drop the populated contents of the first `count` scratch buffers
+    /// and resize MTU capacity in each.
+    pub fn reset(&mut self, count: usize) {
+        for b in self.bufs.iter_mut().take(count) {
+            b.clear();
+            b.resize(self.mtu, 0);
+        }
+    }
+
+    /// Recv one or more inside packets. Returns how packets it received and slice of populated
+    /// `BytesMut`s, each truncated to its packet's length.
+    ///
+    /// Caller must invoke [`reset`](Self::reset) after processing each batch
+    /// so the buffers are at MTU length on the next call. Initial state from
+    /// [`new`](Self::new) / [`new_batched`](Self::new_batched) already satisfies
+    /// the invariant.
+    pub async fn recv<ExtAppState, R>(
+        &mut self,
+        io: &R,
+    ) -> IOCallbackResult<(usize, &mut [BytesMut])>
+    where
+        ExtAppState: Send + Sync,
+        R: InsideIORecv<ExtAppState> + ?Sized,
+    {
+        #[cfg(linux)]
+        if let Some(buffers) = self.multi_buffers.as_mut() {
+            return match io.recv_multiple_buf(buffers, &mut self.bufs).await {
+                IOCallbackResult::Ok(n) => IOCallbackResult::Ok((n, &mut self.bufs[..n])),
+                IOCallbackResult::WouldBlock => IOCallbackResult::WouldBlock,
+                IOCallbackResult::Err(e) => IOCallbackResult::Err(e),
+            };
+        }
+        match io.recv_buf(&mut self.bufs[0]).await {
+            IOCallbackResult::Ok(_n) => IOCallbackResult::Ok((1, &mut self.bufs[..1])),
+            IOCallbackResult::WouldBlock => IOCallbackResult::WouldBlock,
+            IOCallbackResult::Err(e) => IOCallbackResult::Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const TEST_MTU: usize = 1500;
+
+    #[test]
+    fn new_allocates_one_mtu_sized_buffer() {
+        let buf = InsideRecvBuf::new(TEST_MTU);
+        assert_eq!(buf.bufs.len(), 1);
+        assert_eq!(buf.bufs[0].len(), TEST_MTU);
+        assert_eq!(buf.mtu, TEST_MTU);
+        #[cfg(linux)]
+        assert!(buf.multi_buffers.is_none());
+    }
+
+    #[cfg(linux)]
+    #[test]
+    fn new_batched_allocates_count_mtu_sized_buffers() {
+        let buf = InsideRecvBuf::new_batched(TEST_MTU, 8);
+        assert_eq!(buf.bufs.len(), 8);
+        for b in &buf.bufs {
+            assert_eq!(b.len(), TEST_MTU);
+        }
+        assert!(buf.multi_buffers.is_some());
+    }
+
+    #[test]
+    fn reset_restores_truncated_buffer_to_mtu() {
+        let mut buf = InsideRecvBuf::new(TEST_MTU);
+        buf.bufs[0].truncate(40);
+        buf.reset(1);
+        assert_eq!(buf.bufs[0].len(), TEST_MTU);
+    }
+
+    #[cfg(linux)]
+    #[test]
+    fn reset_only_touches_first_count_buffers() {
+        let mut buf = InsideRecvBuf::new_batched(TEST_MTU, 4);
+        for b in &mut buf.bufs {
+            b.truncate(10);
+        }
+        buf.reset(2);
+        assert_eq!(buf.bufs[0].len(), TEST_MTU);
+        assert_eq!(buf.bufs[1].len(), TEST_MTU);
+        assert_eq!(buf.bufs[2].len(), 10);
+        assert_eq!(buf.bufs[3].len(), 10);
+    }
+
+    #[tokio::test]
+    async fn recv_single_path_returns_one_truncated_buffer() {
+        let mut mock = MockInsideIORecv::<()>::new();
+        mock.expect_recv_buf().times(1).returning(|buf| {
+            buf.truncate(64);
+            IOCallbackResult::Ok(64)
+        });
+        let mut buf = InsideRecvBuf::new(TEST_MTU);
+        let IOCallbackResult::Ok((n, slice)) = buf.recv::<(), _>(&mock).await else {
+            panic!("expected Ok");
+        };
+        assert_eq!(n, 1);
+        assert_eq!(slice.len(), 1);
+        assert_eq!(slice[0].len(), 64);
+    }
+
+    #[tokio::test]
+    async fn recv_single_path_propagates_would_block() {
+        let mut mock = MockInsideIORecv::<()>::new();
+        mock.expect_recv_buf()
+            .times(1)
+            .returning(|_| IOCallbackResult::WouldBlock);
+        let mut buf = InsideRecvBuf::new(TEST_MTU);
+        assert!(matches!(
+            buf.recv::<(), _>(&mock).await,
+            IOCallbackResult::WouldBlock
+        ));
+    }
+
+    #[tokio::test]
+    async fn recv_single_path_propagates_err() {
+        let mut mock = MockInsideIORecv::<()>::new();
+        mock.expect_recv_buf()
+            .times(1)
+            .returning(|_| IOCallbackResult::Err(std::io::Error::other("boom")));
+        let mut buf = InsideRecvBuf::new(TEST_MTU);
+        assert!(matches!(
+            buf.recv::<(), _>(&mock).await,
+            IOCallbackResult::Err(_)
+        ));
+    }
+
+    #[cfg(linux)]
+    #[tokio::test]
+    async fn recv_batched_path_returns_first_n_populated_buffers() {
+        let mut mock = MockInsideIORecv::<()>::new();
+        mock.expect_recv_multiple_buf()
+            .times(1)
+            .returning(|_tun_buffer, bufs| {
+                bufs[0].truncate(40);
+                bufs[1].truncate(80);
+                bufs[2].truncate(120);
+                IOCallbackResult::Ok(3)
+            });
+        let mut buf = InsideRecvBuf::new_batched(TEST_MTU, 8);
+        let IOCallbackResult::Ok((n, slice)) = buf.recv::<(), _>(&mock).await else {
+            panic!("expected Ok");
+        };
+        assert_eq!(n, 3);
+        assert_eq!(slice.len(), 3);
+        assert_eq!(slice[0].len(), 40);
+        assert_eq!(slice[1].len(), 80);
+        assert_eq!(slice[2].len(), 120);
+    }
+
+    #[cfg(linux)]
+    #[tokio::test]
+    async fn recv_batched_path_does_not_call_recv_buf() {
+        let mut mock = MockInsideIORecv::<()>::new();
+        mock.expect_recv_buf().times(0);
+        mock.expect_recv_multiple_buf()
+            .times(1)
+            .returning(|_, bufs| {
+                bufs[0].truncate(10);
+                IOCallbackResult::Ok(1)
+            });
+        let mut buf = InsideRecvBuf::new_batched(TEST_MTU, 4);
+        let _ = buf.recv::<(), _>(&mock).await;
+    }
+
+    #[cfg(linux)]
+    #[tokio::test]
+    async fn recv_batched_path_propagates_would_block() {
+        let mut mock = MockInsideIORecv::<()>::new();
+        mock.expect_recv_multiple_buf()
+            .times(1)
+            .returning(|_, _| IOCallbackResult::WouldBlock);
+        let mut buf = InsideRecvBuf::new_batched(TEST_MTU, 8);
+        assert!(matches!(
+            buf.recv::<(), _>(&mock).await,
+            IOCallbackResult::WouldBlock
+        ));
+    }
+
+    #[cfg(linux)]
+    #[tokio::test]
+    async fn recv_batched_path_propagates_err() {
+        let mut mock = MockInsideIORecv::<()>::new();
+        mock.expect_recv_multiple_buf()
+            .times(1)
+            .returning(|_, _| IOCallbackResult::Err(std::io::Error::other("boom")));
+        let mut buf = InsideRecvBuf::new_batched(TEST_MTU, 8);
+        assert!(matches!(
+            buf.recv::<(), _>(&mock).await,
+            IOCallbackResult::Err(_)
+        ));
+    }
 }

--- a/lightway-client/src/io/inside.rs
+++ b/lightway-client/src/io/inside.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 pub use tun::Tun;
 
 use async_trait::async_trait;
+#[cfg(linux)]
+use lightway_app_utils::InsideRecvMultipleBuffers;
 use lightway_core::{
     IOCallbackResult, InsideIOSendCallback, InsideIOSendCallbackArg, InsideIpConfig,
 };
@@ -18,10 +20,29 @@ use crate::ConnectionState;
 pub trait InsideIORecv<ExtAppState: Send + Sync>: Send + Sync {
     async fn recv_buf(&self, buf: &mut BytesMut) -> IOCallbackResult<usize>;
 
+    /// Receive multiple packets into caller-owned buffers. `buffers` is
+    /// scratch reused across calls; each `Tun` impl uses only the part it
+    /// needs. `bufs` entries must be pre-sized to MTU; populated entries
+    /// are truncated to each packet's length on return.
+    ///
+    /// Returns the number of packets written.
+    ///
+    /// Linux and client only.
+    #[cfg(linux)]
+    async fn recv_multiple_buf(
+        &self,
+        tun_buffer: &mut InsideRecvMultipleBuffers,
+        bufs: &mut [BytesMut],
+    ) -> IOCallbackResult<usize>;
+
     fn try_send(&self, pkt: BytesMut, ip_config: Option<InsideIpConfig>) -> Result<usize>;
 
     /// MTU of the underlying interface.
     fn mtu(&self) -> usize;
+
+    /// Returns whether the underlying TUN reports UDP/TCP GSO support.
+    #[cfg(linux)]
+    fn gso(&self) -> (bool, bool);
 
     fn into_io_send_callback(
         self: Arc<Self>,

--- a/lightway-client/src/io/inside/tun.rs
+++ b/lightway-client/src/io/inside/tun.rs
@@ -5,13 +5,12 @@ use std::{net::Ipv4Addr, sync::Arc};
 use anyhow::Result;
 use async_trait::async_trait;
 use bytes::BytesMut;
-use pnet_packet::ipv4::Ipv4Packet;
-
 use lightway_app_utils::{Tun as AppUtilsTun, TunConfig};
 use lightway_core::{
     IOCallbackResult, InsideIOSendCallback, InsideIOSendCallbackArg, InsideIpConfig,
     ipv4_update_destination, ipv4_update_source,
 };
+use pnet_packet::ipv4::Ipv4Packet;
 
 use crate::{ConnectionState, io::inside::InsideIORecv};
 
@@ -105,6 +104,35 @@ impl<ExtAppState: Send + Sync> InsideIOSendCallback<ConnectionState<ExtAppState>
         }
 
         self.tun.try_send(buf)
+    }
+
+    #[cfg(linux)]
+    fn send_multiple(
+        &self,
+        bufs: &mut [BytesMut],
+        state: &mut ConnectionState<ExtAppState>,
+    ) -> IOCallbackResult<usize> {
+        for b in bufs.iter_mut() {
+            // Update destination IP from server provided inside ip to TUN device ip
+            ipv4_update_destination(b.as_mut(), self.ip);
+
+            // Update source IP from server DNS ip to TUN DNS ip
+            if let Some(ip_config) = state.ip_config {
+                let packet = Ipv4Packet::new(b.as_ref());
+                if let Some(packet) = packet
+                    && packet.get_source() == ip_config.dns_ip
+                {
+                    ipv4_update_source(b.as_mut(), self.dns_ip);
+                };
+            }
+        }
+
+        self.tun.try_send_multiple(bufs)
+    }
+
+    #[cfg(linux)]
+    fn gso(&self) -> (bool, bool) {
+        self.tun.gso()
     }
 
     fn mtu(&self) -> usize {

--- a/lightway-client/src/io/inside/tun.rs
+++ b/lightway-client/src/io/inside/tun.rs
@@ -5,6 +5,8 @@ use std::{net::Ipv4Addr, sync::Arc};
 use anyhow::Result;
 use async_trait::async_trait;
 use bytes::BytesMut;
+#[cfg(linux)]
+use lightway_app_utils::TunOffloadBuffers;
 use lightway_app_utils::{Tun as AppUtilsTun, TunConfig};
 use lightway_core::{
     IOCallbackResult, InsideIOSendCallback, InsideIOSendCallbackArg, InsideIpConfig,
@@ -53,6 +55,15 @@ impl<ExtAppState: Send + Sync> InsideIORecv<ExtAppState> for Tun {
         self.tun.recv_buf(buf).await
     }
 
+    #[cfg(linux)]
+    async fn recv_multiple_buf(
+        &self,
+        offload_buffer: &mut TunOffloadBuffers,
+        bufs: &mut [BytesMut],
+    ) -> IOCallbackResult<usize> {
+        self.tun.recv_multiple_buf(offload_buffer, bufs).await
+    }
+
     /// Api to send packet in the tunnel
     fn try_send(&self, mut pkt: BytesMut, ip_config: Option<InsideIpConfig>) -> Result<usize> {
         let pkt_len = pkt.len();
@@ -75,6 +86,11 @@ impl<ExtAppState: Send + Sync> InsideIORecv<ExtAppState> for Tun {
 
     fn mtu(&self) -> usize {
         self.tun.mtu()
+    }
+
+    #[cfg(linux)]
+    fn gso(&self) -> (bool, bool) {
+        self.tun.gso()
     }
 
     fn into_io_send_callback(

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -894,8 +894,10 @@ pub async fn connect<
     })
     .when(connection_type.is_datagram() && config.enable_pmtud, |b| {
         b.with_pmtud_timer(pmtud_timer)
-    })
-    .when(config.enable_batch_receive, |b| {
+    });
+
+    #[cfg(linux)]
+    let conn_builder = conn_builder.when(config.enable_batch_receive, |b| {
         b.with_inside_batch_enabled()
     });
 

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -894,6 +894,9 @@ pub async fn connect<
     })
     .when(connection_type.is_datagram() && config.enable_pmtud, |b| {
         b.with_pmtud_timer(pmtud_timer)
+    })
+    .when(config.enable_batch_receive, |b| {
+        b.with_inside_batch_enabled()
     });
 
     #[cfg(feature = "postquantum")]

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -510,69 +510,79 @@ pub async fn inside_io_task<ExtAppState: Send + Sync>(
     };
     let mut tracer_timeout_last_outside_data_rcvd: Option<Instant> = None;
     let mtu = inside_io.mtu();
-    let mut buf = BytesMut::with_capacity(mtu);
+    #[cfg(linux)]
+    let mut recv_buf = {
+        let (udp_gso, tcp_gso) = inside_io.gso();
+        if udp_gso || tcp_gso {
+            info!(
+                udp_gso,
+                tcp_gso, "TUN offloading is on, will use batched receiving"
+            );
+            io::inside::InsideRecvBuf::new_batched(
+                mtu,
+                lightway_app_utils::RECV_MULTIPLE_MAX_SEGMENTS,
+            )
+        } else {
+            io::inside::InsideRecvBuf::new(mtu)
+        }
+    };
+    #[cfg(not(linux))]
+    let mut recv_buf = io::inside::InsideRecvBuf::new(mtu);
+
     loop {
-        buf.clear();
-        buf.resize(mtu, 0);
-        match inside_io.recv_buf(&mut buf).await {
-            IOCallbackResult::Ok(_n) => {}
-            IOCallbackResult::WouldBlock => continue, // Spuriously failed to read, keep waiting
-            IOCallbackResult::Err(err) => {
-                // Fatal error
-                return Err(err.into());
-            }
+        let (count, bufs) = match recv_buf.recv(inside_io.as_ref()).await {
+            IOCallbackResult::Ok(b) => b,
+            IOCallbackResult::WouldBlock => continue,
+            IOCallbackResult::Err(err) => return Err(err.into()),
         };
 
         let last_outside_data_received = {
             let mut conn = conn.lock().unwrap();
 
-            // Update source IP address to server assigned IP address
             let ip_config = conn.app_state().ip_config;
-            if let Some(ip_config) = &ip_config {
-                ipv4_update_source(buf.as_mut(), ip_config.client_ip);
+            for buf in bufs.iter_mut() {
+                // Update source IP address to server-assigned IP address
+                if let Some(ip_config) = &ip_config {
+                    ipv4_update_source(buf.as_mut(), ip_config.client_ip);
 
-                // Update TUN device DNS IP address to server provided DNS address
-                let packet = Ipv4Packet::new(buf.as_ref());
-                if let Some(packet) = packet
-                    && packet.get_destination() == tun_dns_ip
-                {
-                    ipv4_update_destination(buf.as_mut(), ip_config.dns_ip);
-                };
-            }
+                    // Update TUN device DNS IP address to server-provided DNS address
+                    let packet = Ipv4Packet::new(buf.as_ref());
+                    if let Some(packet) = packet
+                        && packet.get_destination() == tun_dns_ip
+                    {
+                        ipv4_update_destination(buf.as_mut(), ip_config.dns_ip);
+                    };
+                }
 
-            match conn.inside_data_received(&mut buf) {
-                Ok(()) => conn.activity().last_outside_data_received,
-                Err(ConnectionError::PluginDropWithReply(reply)) => {
-                    // Send the reply packet to inside path
-                    let _ = inside_io.try_send(reply, ip_config);
-                    continue;
-                }
-                Err(ConnectionError::InvalidState) => {
-                    // Ignore the packet till the connection is online
-                    continue;
-                }
-                Err(ConnectionError::InvalidInsidePacket(_)) => {
-                    // Ignore invalid inside packet
-                    continue;
-                }
-                Err(err) => {
-                    // Fatal error
-                    return Err(err.into());
+                // TODO: Batch send packets out with sendmmsg
+                match conn.inside_data_received(buf) {
+                    Ok(()) => {}
+                    Err(ConnectionError::PluginDropWithReply(reply)) => {
+                        // Send the reply packet to inside path
+                        let _ = inside_io.try_send(reply, ip_config);
+                    }
+                    Err(ConnectionError::InvalidState) => {
+                        // Ignore the packet till the connection is online
+                    }
+                    Err(ConnectionError::InvalidInsidePacket(_)) => {
+                        // Ignore invalid inside packet
+                    }
+                    Err(err) => {
+                        // Fatal error
+                        return Err(err.into());
+                    }
                 }
             }
+            conn.activity().last_outside_data_received
         };
-
-        let now = Instant::now();
-        let duration_since_last_outside_data = now.duration_since(last_outside_data_received);
+        recv_buf.reset(count);
 
         if !tracer_trigger_timeout.is_zero()
-            && duration_since_last_outside_data > tracer_trigger_timeout
+            && last_outside_data_received.elapsed() > tracer_trigger_timeout
             && tracer_timeout_last_outside_data_rcvd.is_none_or(|x| x != last_outside_data_received)
         {
-            {
-                tracer_timeout_last_outside_data_rcvd = Some(last_outside_data_received);
-                keepalive.tracer_delta_exceeded().await;
-            }
+            tracer_timeout_last_outside_data_rcvd = Some(last_outside_data_received);
+            keepalive.tracer_delta_exceeded().await;
         }
     }
 }

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -4,16 +4,15 @@ use struct_patch::Patch;
 
 use anyhow::{Context, Result, anyhow};
 use futures::future::join_all;
-use lightway_core::{Event, EventCallback};
-use tokio::fs::read_to_string;
-use tokio::sync::mpsc;
-
 use lightway_app_utils::{
     TunConfig, Validate,
     args::{ConfigFormat, ConnectionType, LogFormat},
     validate_configuration_file_path,
 };
 use lightway_client::{io::inside::InsideIO, *};
+use lightway_core::{Event, EventCallback};
+use tokio::fs::read_to_string;
+use tokio::sync::mpsc;
 
 mod config;
 use config::{Config, ConfigPatch, ConnectionConfig};
@@ -175,6 +174,17 @@ async fn main() -> Result<()> {
         .address(config.tun_local_ip.into())
         .destination(config.tun_peer_ip)
         .up();
+
+    #[cfg(linux)]
+    if config.enable_offload {
+        if config.enable_tun_iouring {
+            tracing::warn!("TUN offloading is not available when using io-uring, ignoring");
+            tun_config.offload(false);
+        } else {
+            tun_config.offload(true);
+            config.enable_batch_receive = true;
+        }
+    }
 
     let (ctrlc_tx, mut ctrlc_rx) = tokio::sync::oneshot::channel();
 

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -5,7 +5,7 @@ use struct_patch::Patch;
 use anyhow::{Context, Result, anyhow};
 use futures::future::join_all;
 use lightway_app_utils::{
-    TunConfig, Validate,
+    DEFAULT_TUN_MTU, TunConfig, Validate,
     args::{ConfigFormat, ConnectionType, LogFormat},
     validate_configuration_file_path,
 };
@@ -170,7 +170,7 @@ async fn main() -> Result<()> {
 
     // TODO: Fix in future PR
     tun_config
-        .mtu(1350)
+        .mtu(DEFAULT_TUN_MTU)
         .address(config.tun_local_ip.into())
         .destination(config.tun_peer_ip)
         .up();

--- a/lightway-client/src/mobile/lightway.rs
+++ b/lightway-client/src/mobile/lightway.rs
@@ -11,7 +11,7 @@ use futures::StreamExt;
 use futures::future::{FutureExt, OptionFuture, select_all};
 use futures::stream::{FusedStream, FuturesUnordered};
 use lightway_app_utils::{
-    ConnectionTicker, DplpmtudTimer, EventStream, EventStreamCallback, TunConfig,
+    ConnectionTicker, DEFAULT_TUN_MTU, DplpmtudTimer, EventStream, EventStreamCallback, TunConfig,
     connection_ticker_cb,
 };
 use lightway_core::{
@@ -34,7 +34,7 @@ use tracing::{Instrument, debug, error, info, info_span, warn};
 use uniffi::deps::anyhow::{Context, anyhow, bail};
 use uniffi::deps::bytes::BytesMut;
 
-const INTERNAL_MTU: u16 = 1350;
+const INTERNAL_MTU: u16 = DEFAULT_TUN_MTU;
 #[cfg(apple)]
 const MAX_SOCKET_BUFFER_LEN: usize = 1024000;
 const ENABLE_PMTUD: bool = false;

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -441,6 +441,14 @@ pub struct Connection<AppState: Send = ()> {
 
     // Expresslane state, config exchange, health monitoring, wire crypto, and callbacks
     expresslane: expresslane::Expresslane<AppState>,
+
+    /// When true, [`Connection::send_to_inside`] pushes onto
+    /// `inside_send_batch` instead of sending immediately. Caller is
+    /// expected to call [`Connection::flush_to_inside`] (or use
+    /// [`Connection::outside_data_received_multiple`]) to deliver them.
+    ///
+    /// This is only supported on Linux client
+    inside_batch_enabled: bool,
 }
 
 /// Information about the new session being established with a new
@@ -466,6 +474,7 @@ struct NewConnectionArgs<AppState> {
     expresslane: bool,
     expresslane_cb: Option<expresslane::ExpresslaneCbType<AppState>>,
     expresslane_metrics: Option<expresslane::ExpresslaneMetricsType>,
+    inside_batch_enabled: bool,
 }
 
 impl<AppState: Send> Connection<AppState> {
@@ -482,6 +491,8 @@ impl<AppState: Send> Connection<AppState> {
             (ConnectionMode::Server { .. }, true) => ExpresslaneState::WaitingForClient,
             (_, false) => ExpresslaneState::Disabled,
         };
+
+        let client_mode = matches!(args.mode, ConnectionMode::Client { .. });
         let mut conn = Connection {
             connection_type: args.connection_type,
             tunnel_protocol_version: args.protocol_version,
@@ -530,6 +541,11 @@ impl<AppState: Send> Connection<AppState> {
                 args.expresslane_cb,
                 args.expresslane_metrics,
             ),
+            inside_batch_enabled: if cfg!(target_os = "linux") {
+                client_mode && args.inside_batch_enabled
+            } else {
+                false
+            },
         };
 
         // This will very likely fail since negotiation always needs

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -459,7 +459,8 @@ pub struct Connection<AppState: Send = ()> {
     /// expected to call [`Connection::flush_to_inside`] (or use
     /// [`Connection::multiple_outside_data_received`]) to deliver them.
     ///
-    /// This is only supported on Linux client
+    /// This is only supported on the Linux client
+    #[cfg_attr(not(target_os = "linux"), allow(unused))]
     inside_batch_enabled: bool,
 }
 
@@ -945,11 +946,14 @@ impl<AppState: Send> Connection<AppState> {
             }
         }
 
+        #[cfg(target_os = "linux")]
         if self.inside_batch_enabled {
             self.flush_to_inside().map(|_| total)
         } else {
             Ok(total)
         }
+        #[cfg(not(target_os = "linux"))]
+        Ok(total)
     }
 
     /// Consume data received from inside path and send it as

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -449,7 +449,7 @@ pub struct Connection<AppState: Send = ()> {
     expresslane: expresslane::Expresslane<AppState>,
 
     /// Inside packets queued for batched send via
-    /// [`InsideIOSendCallback::send_multiple`]. Drained by
+    /// `InsideIOSendCallback::send_multiple`. Drained by
     /// [`Connection::flush_to_inside`].
     #[cfg(target_os = "linux")]
     inside_send_batch: Vec<BytesMut>,
@@ -924,7 +924,7 @@ impl<AppState: Send> Connection<AppState> {
     }
 
     /// Process multiple outside packets. If `inside_batch_enabled` is true, it will batch
-    /// their inside-bound packets into a single [`InsideIOSendCallback::send_multiple`]
+    /// their inside-bound packets into a single [`InsideIOSendCallback::send_multiple`
     /// call at the end. If not, it will just process all the packets and send it to the TUN device
     /// one-by-one.
     ///
@@ -2138,7 +2138,7 @@ impl<AppState: Send> Connection<AppState> {
     }
 
     /// Flush any inside packets queued via [`Self::queue_to_inside`] in a
-    /// single [`InsideIOSendCallback::send_multiple`] call.
+    /// single [`InsideIOSendCallback::send_multiple` call.
     ///
     /// Returns how many bytes are actually sent
     /// Only Linux clients support this

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -13,6 +13,7 @@ use std::borrow::Cow;
 use std::net::AddrParseError;
 use std::num::{NonZeroU16, Wrapping};
 use std::{
+    io,
     net::SocketAddr,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
@@ -233,6 +234,10 @@ pub enum ConnectionError {
     /// Encoding Request Retransmit CB does not exist
     #[error("Schedule Encoding Request Retransmit Cb Does Not Exist")]
     EncodingReqRetransmitCbDoesNotExist,
+
+    /// TUN Offload Error
+    #[error("TUN offload error")]
+    TunOffloadError(io::Error),
 }
 
 impl ConnectionError {
@@ -271,6 +276,7 @@ impl ConnectionError {
                     WireError(wire::FromWireError::InvalidExpressData) => false,
                     WireError(wire::FromWireError::ReplayedExpressData) => false,
                     WireError(_) => true,
+                    TunOffloadError(_) => true,
 
                     InvalidState => false, // Can be due to out of order or repeated messages
                     InvalidInsideIo => false, // Can be used for test only test control plane
@@ -442,10 +448,16 @@ pub struct Connection<AppState: Send = ()> {
     // Expresslane state, config exchange, health monitoring, wire crypto, and callbacks
     expresslane: expresslane::Expresslane<AppState>,
 
+    /// Inside packets queued for batched send via
+    /// [`InsideIOSendCallback::send_multiple`]. Drained by
+    /// [`Connection::flush_to_inside`].
+    #[cfg(target_os = "linux")]
+    inside_send_batch: Vec<BytesMut>,
+
     /// When true, [`Connection::send_to_inside`] pushes onto
     /// `inside_send_batch` instead of sending immediately. Caller is
     /// expected to call [`Connection::flush_to_inside`] (or use
-    /// [`Connection::outside_data_received_multiple`]) to deliver them.
+    /// [`Connection::multiple_outside_data_received`]) to deliver them.
     ///
     /// This is only supported on Linux client
     inside_batch_enabled: bool,
@@ -541,6 +553,8 @@ impl<AppState: Send> Connection<AppState> {
                 args.expresslane_cb,
                 args.expresslane_metrics,
             ),
+            #[cfg(target_os = "linux")]
+            inside_send_batch: Vec::with_capacity(crate::MAX_IO_BATCH_SIZE),
             inside_batch_enabled: if cfg!(target_os = "linux") {
                 client_mode && args.inside_batch_enabled
             } else {
@@ -908,7 +922,10 @@ impl<AppState: Send> Connection<AppState> {
         result
     }
 
-    /// Process multiple outside packets.
+    /// Process multiple outside packets. If `inside_batch_enabled` is true, it will batch
+    /// their inside-bound packets into a single [`InsideIOSendCallback::send_multiple`]
+    /// call at the end. If not, it will just process all the packets and send it to the TUN device
+    /// one-by-one.
     ///
     /// `is_fatal` is invoked for every per-packet error encountered. If it
     /// returns `true`, processing stops and the error is returned immediately.
@@ -927,7 +944,12 @@ impl<AppState: Send> Connection<AppState> {
                 Err(e) => error!("Failed to process outside data: {e}"),
             }
         }
-        Ok(total)
+
+        if self.inside_batch_enabled {
+            self.flush_to_inside().map(|_| total)
+        } else {
+            Ok(total)
+        }
     }
 
     /// Consume data received from inside path and send it as
@@ -2033,8 +2055,13 @@ impl<AppState: Send> Connection<AppState> {
         }
     }
 
-    /// Send a packet to the inside
-    pub fn send_to_inside(&mut self, mut inside_pkt: BytesMut) -> ConnectionResult<()> {
+    /// Validate, run egress plugins, and update activity. Returns the
+    /// (possibly mutated) packet to send, or `None` if dropped silently
+    /// by a plugin.
+    fn prepare_inside_pkt(
+        &mut self,
+        mut inside_pkt: BytesMut,
+    ) -> ConnectionResult<Option<BytesMut>> {
         use ConnectionError::InvalidInsidePacket;
         use InvalidPacketError::InvalidIpv4Packet;
 
@@ -2046,33 +2073,94 @@ impl<AppState: Send> Connection<AppState> {
             return Err(InvalidInsidePacket(InvalidIpv4Packet));
         }
 
-        let Some(inside_io) = &self.inside_io else {
+        if self.inside_io.is_none() {
             return Err(InvalidInsidePacket(InvalidIpv4Packet));
-        };
+        }
 
         match self.inside_plugins.do_egress(&mut inside_pkt) {
             PluginResult::Accept => {}
-            PluginResult::Drop => {
-                return Ok(());
-            }
+            PluginResult::Drop => return Ok(None),
             PluginResult::DropWithReply(b) => {
                 return Err(ConnectionError::PluginDropWithReply(b));
             }
-            PluginResult::Error(e) => {
-                return Err(ConnectionError::PluginError(e));
-            }
+            PluginResult::Error(e) => return Err(ConnectionError::PluginError(e)),
         }
 
         self.activity.last_data_traffic_from_peer = Instant::now();
-        match inside_io.send(inside_pkt, &mut self.app_state) {
-            IOCallbackResult::Ok(_nr) => {}
-            IOCallbackResult::Err(err) => {
-                metrics::inside_io_send_failed(err);
+        Ok(Some(inside_pkt))
+    }
+
+    /// Send a packet to the inside.
+    ///
+    /// When inside-batch mode is enabled (set via the connection builder),
+    /// the packet is queued via [`Self::queue_to_inside`] instead of sent
+    /// immediately. Caller is expected to call [`Self::flush_to_inside`] at
+    /// the end of a packet burst.
+    pub fn send_to_inside(&mut self, inside_pkt: BytesMut) -> ConnectionResult<()> {
+        let Some(pkt) = self.prepare_inside_pkt(inside_pkt)? else {
+            return Ok(());
+        };
+        #[cfg(target_os = "linux")]
+        if self.inside_batch_enabled {
+            let queued_packets = self.queue_to_inside(pkt);
+            if queued_packets > crate::MAX_IO_BATCH_SIZE {
+                warn!(
+                    queued_packets,
+                    "Queued packets somehow exceeds max io batch size {}",
+                    crate::MAX_IO_BATCH_SIZE
+                );
             }
-            IOCallbackResult::WouldBlock => {}
+            return Ok(());
         }
 
+        let inside_io = self
+            .inside_io
+            .as_ref()
+            .expect("checked in prepare_inside_pkt");
+        match inside_io.send(pkt, &mut self.app_state) {
+            IOCallbackResult::Ok(_nr) => {}
+            IOCallbackResult::Err(err) => metrics::inside_io_send_failed(err),
+            IOCallbackResult::WouldBlock => {}
+        }
         Ok(())
+    }
+
+    /// Queue an inside packet to be sent in a later batch. Caller must call
+    /// [`Self::flush_to_inside`] to actually deliver the queued packets.
+    #[cfg(target_os = "linux")]
+    pub fn queue_to_inside(&mut self, inside_pkt: BytesMut) -> usize {
+        self.inside_send_batch.push(inside_pkt);
+        self.inside_send_batch.len()
+    }
+
+    /// Flush any inside packets queued via [`Self::queue_to_inside`] in a
+    /// single [`InsideIOSendCallback::send_multiple`] call.
+    ///
+    /// Returns how many bytes are actually sent
+    /// Only Linux clients support this
+    #[cfg(target_os = "linux")]
+    pub fn flush_to_inside(&mut self) -> ConnectionResult<usize> {
+        if matches!(self.mode, ConnectionMode::Server { .. }) {
+            return Err(ConnectionError::InvalidMode);
+        }
+        let batched = self.inside_send_batch.len();
+        if batched == 0 {
+            return Ok(batched);
+        }
+        let Some(inside_io) = self.inside_io.as_ref() else {
+            self.inside_send_batch.clear();
+            return Err(ConnectionError::InvalidInsideIo);
+        };
+        let result = inside_io.send_multiple(&mut self.inside_send_batch, &mut self.app_state);
+        self.inside_send_batch.clear();
+        match result {
+            IOCallbackResult::Ok(_bytes) => Ok(batched),
+            IOCallbackResult::Err(err) => {
+                // This is client-side only, no need to send metrics
+                Err(ConnectionError::TunOffloadError(err))
+            }
+            IOCallbackResult::WouldBlock => Ok(0),
+        }
     }
 
     fn handle_outside_data_packet(

--- a/lightway-core/src/connection/builders.rs
+++ b/lightway-core/src/connection/builders.rs
@@ -61,6 +61,8 @@ pub struct ClientConnectionBuilder<AppState> {
     pmtud_timer: Option<dplpmtud::TimerArg<AppState>>,
     outside_plugins: Arc<PluginList>,
     inside_pkt_codec: Option<(PacketEncoderType, PacketDecoderType)>,
+    #[cfg(target_os = "linux")]
+    inside_batch_enabled: bool,
 }
 
 impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
@@ -107,6 +109,8 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
             pmtud_base_mtu: None,
             outside_plugins,
             inside_pkt_codec: None,
+            #[cfg(target_os = "linux")]
+            inside_batch_enabled: false,
         })
     }
 
@@ -224,6 +228,20 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
         }
     }
 
+    /// Enable inside-batch mode. When set, [`Connection::send_to_inside`]
+    /// queues onto an internal batch and the caller is expected to call
+    /// [`Connection::flush_to_inside`] (or use
+    /// [`Connection::outside_data_received_multiple`]) to deliver them.
+    ///
+    /// Only available on Linux client for now.
+    #[cfg(target_os = "linux")]
+    pub fn with_inside_batch_enabled(self) -> Self {
+        Self {
+            inside_batch_enabled: true,
+            ..self
+        }
+    }
+
     /// Finalize the builder to create a [`Connection`] and begin the connection process.
     pub fn connect(self, app_state: AppState) -> ConnectionBuilderResult<Connection<AppState>> {
         let auth_method = self
@@ -260,6 +278,8 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
             expresslane: self.ctx.expresslane,
             expresslane_cb: self.ctx.expresslane_cb.clone(),
             expresslane_metrics: self.ctx.expresslane_metrics.clone(),
+            #[cfg(target_os = "linux")]
+            inside_batch_enabled: self.inside_batch_enabled,
         })?)
     }
 }
@@ -398,6 +418,8 @@ impl<'a, AppState: Send + 'static> ServerConnectionBuilder<'a, AppState> {
             expresslane: self.ctx.expresslane,
             expresslane_cb: self.ctx.expresslane_cb.clone(),
             expresslane_metrics: self.ctx.expresslane_metrics.clone(),
+            #[cfg(target_os = "linux")]
+            inside_batch_enabled: false,
         })?)
     }
 }

--- a/lightway-core/src/connection/builders.rs
+++ b/lightway-core/src/connection/builders.rs
@@ -61,7 +61,6 @@ pub struct ClientConnectionBuilder<AppState> {
     pmtud_timer: Option<dplpmtud::TimerArg<AppState>>,
     outside_plugins: Arc<PluginList>,
     inside_pkt_codec: Option<(PacketEncoderType, PacketDecoderType)>,
-    #[cfg(target_os = "linux")]
     inside_batch_enabled: bool,
 }
 
@@ -109,7 +108,6 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
             pmtud_base_mtu: None,
             outside_plugins,
             inside_pkt_codec: None,
-            #[cfg(target_os = "linux")]
             inside_batch_enabled: false,
         })
     }
@@ -278,7 +276,6 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
             expresslane: self.ctx.expresslane,
             expresslane_cb: self.ctx.expresslane_cb.clone(),
             expresslane_metrics: self.ctx.expresslane_metrics.clone(),
-            #[cfg(target_os = "linux")]
             inside_batch_enabled: self.inside_batch_enabled,
         })?)
     }
@@ -418,7 +415,6 @@ impl<'a, AppState: Send + 'static> ServerConnectionBuilder<'a, AppState> {
             expresslane: self.ctx.expresslane,
             expresslane_cb: self.ctx.expresslane_cb.clone(),
             expresslane_metrics: self.ctx.expresslane_metrics.clone(),
-            #[cfg(target_os = "linux")]
             inside_batch_enabled: false,
         })?)
     }

--- a/lightway-core/src/connection/builders.rs
+++ b/lightway-core/src/connection/builders.rs
@@ -231,7 +231,7 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
     /// Enable inside-batch mode. When set, [`Connection::send_to_inside`]
     /// queues onto an internal batch and the caller is expected to call
     /// [`Connection::flush_to_inside`] (or use
-    /// [`Connection::outside_data_received_multiple`]) to deliver them.
+    /// [`Connection::multiple_outside_data_received`]) to deliver them.
     ///
     /// Only available on Linux client for now.
     #[cfg(target_os = "linux")]

--- a/lightway-core/src/io.rs
+++ b/lightway-core/src/io.rs
@@ -17,6 +17,33 @@ pub trait InsideIOSendCallback<AppState> {
     /// [`IOCallbackResult::WouldBlock`].
     fn send(&self, buf: BytesMut, state: &mut AppState) -> IOCallbackResult<usize>;
 
+    /// Called when Lightway wishes to send multiple inside data packets at once.
+    ///
+    /// Each entry in `bufs` is a single packet. Returns total bytes sent.
+    /// Default impl falls back to calling [`Self::send`] per packet.
+    #[cfg(target_os = "linux")]
+    fn send_multiple(
+        &self,
+        bufs: &mut [BytesMut],
+        state: &mut AppState,
+    ) -> IOCallbackResult<usize> {
+        let mut total = 0;
+        for buf in bufs.iter_mut() {
+            match self.send(std::mem::take(buf), state) {
+                IOCallbackResult::Ok(n) => total += n,
+                IOCallbackResult::WouldBlock => return IOCallbackResult::Ok(total),
+                IOCallbackResult::Err(e) => return IOCallbackResult::Err(e),
+            }
+        }
+        IOCallbackResult::Ok(total)
+    }
+
+    #[cfg(target_os = "linux")]
+    /// Returns whether the TUN device supports UDP and TCP GSO respectively.
+    fn gso(&self) -> (bool, bool) {
+        (false, false)
+    }
+
     /// MTU supported by this inside I/O path
     fn mtu(&self) -> usize;
 

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -94,6 +94,10 @@ run-udp-iouring-test:
 run-udp-batch-receive-test:
     DO +TEST --MODE=udp --SERVER_PORT=27690 --CLIENT_EXTRA_ARGS="--enable-batch-receive"
 
+# run-udp-offload-batch-receive-test runs e2e test using UDP with TUN offloading and batch receive enabled
+run-udp-offload-batch-receive-test:
+    DO +TEST --MODE=udp --SERVER_PORT=27690 --CLIENT_EXTRA_ARGS="--enable-offload --enable-batch-receive"
+
 # run-udp-expresslane-test runs e2e test using UDP with expresslane enabled
 run-udp-expresslane-test:
     DO +TEST --MODE=udp --SERVER_PORT=27690 --SERVER_EXTRA_ARGS="--enable-expresslane" --CLIENT_EXTRA_ARGS="--enable-expresslane"
@@ -157,6 +161,7 @@ run-all-tests:
     BUILD +run-udp-pmtud-test
     BUILD +run-udp-iouring-test
     BUILD +run-udp-batch-receive-test
+    BUILD +run-udp-offload-batch-receive-test
     BUILD +run-udp-expresslane-test
     BUILD +run-udp-expresslane-compat-test
     BUILD +run-tcp-iouring-test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If offload config is on, enable TUN offload so that we can send/receive multiple packets at the same time. Both receive and sending side must use its `send/receive_multiple` function variants, as regular send/receive function from tun-rs is now sending raw packets.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Now that there's an option to batch receive packets, we can receive/send packets into TUN all at once.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passed e2e CI tests

Test reference, waiting for iPerf3 test
When tested with our regular testing server, speed mostly are quite similar, but upload speed got a nice speed bump of 1898 -> 2262 Mbps (with speedtest CLI)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
