### PR TITLE
CVPN-2528: client: Sighup reload config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,6 +2963,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3282,6 +3292,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ async-trait = "0.1.77"
 bytes = "1.5.0"
 bytesize = { version = "1.3.0", features = ["serde"] }
 clap = { version = "4.4.7", features = ["derive"] }
-ctrlc = { version = "3.4.6", features = ["termination"] }
+ctrlc = { version = "3.4.6" }
 delegate = "0.12.0"
 educe = { version = "0.6.0", default-features = false, features = ["Debug"] }
 ipnet = { version = "2.8.0", features = ["serde"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ socket2 = "0.6.0"
 struct-patch = "0.11.0"
 test-case = "3.1.0"
 thiserror = "2.0.3"
-tokio = { version = "1.33.0", features = ["rt-multi-thread", "macros", "net", "time", "sync", "io-util", "fs"] }
+tokio = { version = "1.33.0", features = ["rt-multi-thread", "macros", "net", "time", "sync", "io-util", "fs", "signal"] }
 tokio-stream = "0.1.14"
 tokio-util = "0.7.10"
 tracing = "0.1.37"

--- a/lightway-app-utils/src/args/cipher.rs
+++ b/lightway-app-utils/src/args/cipher.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use lightway_core::Cipher as LWCipher;
 
-#[derive(Copy, Clone, Debug, JsonSchema, ValueEnum, Serialize, Deserialize, Default, PartialEq)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Debug, JsonSchema, ValueEnum, Serialize, Deserialize, Default,
+)]
 #[serde(rename_all = "lowercase")]
 #[value(rename_all = "lowercase")]
 /// [`LWCipher`] wrapper compatible with clap

--- a/lightway-app-utils/src/args/connection_type.rs
+++ b/lightway-app-utils/src/args/connection_type.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use lightway_core::ConnectionType as LWConnectionType;
 
-#[derive(Copy, Clone, ValueEnum, Debug, JsonSchema, Serialize, Deserialize, Default, PartialEq)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, ValueEnum, Debug, JsonSchema, Serialize, Deserialize, Default,
+)]
 #[serde(rename_all = "lowercase")]
 #[value(rename_all = "lowercase")]
 /// [`lightway_core::ConnectionType`] wrapper compatible with clap

--- a/lightway-app-utils/src/args/duration.rs
+++ b/lightway-app-utils/src/args/duration.rs
@@ -7,7 +7,7 @@ use serde_with::{DisplayFromStr, serde_as};
 
 /// Wrapper for compatibility with clap
 #[serde_as]
-#[derive(Copy, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Duration(#[serde_as(as = "DisplayFromStr")] humantime::Duration);
 
 impl std::fmt::Display for Duration {

--- a/lightway-app-utils/src/args/keyshare.rs
+++ b/lightway-app-utils/src/args/keyshare.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use lightway_core::KeyShare as LWKeyShare;
 
-#[derive(Copy, Clone, Debug, JsonSchema, ValueEnum, Serialize, Deserialize, Default, PartialEq)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Debug, JsonSchema, ValueEnum, Serialize, Deserialize, Default,
+)]
 #[serde(rename_all = "lowercase")]
 #[value(rename_all = "lowercase")]
 /// [`LWKeyShare`] wrapper compatible with clap and twelf

--- a/lightway-app-utils/src/args/logging.rs
+++ b/lightway-app-utils/src/args/logging.rs
@@ -7,7 +7,7 @@ use tracing_subscriber::{
     fmt::{SubscriberBuilder, format},
 };
 
-#[derive(Copy, Clone, ValueEnum, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq, ValueEnum, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 #[value(rename_all = "lowercase")]
 /// Tracing log format type compatible with clap
@@ -52,7 +52,7 @@ impl LogFormat {
     }
 }
 
-#[derive(Copy, Clone, ValueEnum, Debug, JsonSchema, Serialize, Deserialize, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq, ValueEnum, Debug, JsonSchema, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 #[value(rename_all = "lowercase")]
 /// Tracing log level type compatible with clap

--- a/lightway-app-utils/src/args/nonzero_duration.rs
+++ b/lightway-app-utils/src/args/nonzero_duration.rs
@@ -7,7 +7,7 @@ use serde_with::{DisplayFromStr, serde_as};
 
 /// Wrapper for compatibility with both clap
 #[serde_as]
-#[derive(Copy, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NonZeroDuration(#[serde_as(as = "DisplayFromStr")] humantime::Duration);
 
 impl std::fmt::Display for NonZeroDuration {

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -32,7 +32,6 @@ async-trait.workspace = true
 bytes.workspace = true
 bytesize.workspace = true
 clap.workspace = true
-ctrlc.workspace = true
 educe.workspace = true
 futures = "0.3.30"
 libc.workspace = true
@@ -83,6 +82,7 @@ objc2-core-foundation = "0.3.1"
 objc2-system-configuration = "0.3.1"
 
 [target.'cfg(windows)'.dependencies]
+ctrlc.workspace = true
 uuid = "1"
 windows-dpapi = "0.2.0"
 windows-sys = { workspace = true, features = [

--- a/lightway-client/src/config.rs
+++ b/lightway-client/src/config.rs
@@ -25,8 +25,8 @@ use std::net::IpAddr;
 // values follow the Rust convention in Default trait, such that we are able
 // to serialized out any kind of configure from the Config::default(), such
 // that our library will be nice and easy to further do integrations.
-#[derive(Debug, Deserialize, JsonSchema, Serialize, Patch)]
-#[patch(attribute(derive(Deserialize, Parser)))]
+#[derive(Clone, Debug, PartialEq, Deserialize, JsonSchema, Serialize, Patch)]
+#[patch(attribute(derive(Clone, Deserialize, Parser)))]
 #[patch(attribute(command(about = "A lightway client")))]
 pub struct Config {
     #[patch(attribute(clap(short, long)))]

--- a/lightway-client/src/config.rs
+++ b/lightway-client/src/config.rs
@@ -238,7 +238,8 @@ pub struct Config {
         attribute(doc = r#"Enable inside packet encoding once lightway connects
     Only used if a codec is set"#)
     )]
-    pub enable_inside_pkt_encoding_at_connect: bool,
+    #[serde(alias = "enable_inside_pkt_encoding_at_connect")]
+    pub enable_inside_pkt_encoding: bool,
 
     #[cfg(feature = "debug")]
     #[patch(attribute(clap(long)))]
@@ -393,7 +394,7 @@ impl Default for Config {
             enable_tun_iouring: false,
             iouring_entry_count: 1024,
             iouring_sqpoll_idle_time: Duration::from_std_duration(StdDuration::from_millis(100)),
-            enable_inside_pkt_encoding_at_connect: false,
+            enable_inside_pkt_encoding: false,
             #[cfg(feature = "debug")]
             keylog: None,
             #[cfg(feature = "debug")]

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -308,7 +308,7 @@ pub struct ClientConnectionConfig<EventHandler: 'static + Send + EventCallback> 
 #[educe(Debug)]
 pub struct ClientInsidePacketCodecConfig {
     /// Enables inside packet encoding when connection is established.
-    pub enable_encoding_at_connect: bool,
+    pub enable_inside_pkt_encoding: bool,
 
     /// Signal for send inside packet encoding request to the server.
     #[educe(Debug(ignore))]
@@ -319,7 +319,7 @@ pub struct ClientInsidePacketCodecConfig {
 /// Sent via `config_reload_signal` when the process receives a reload trigger (e.g. SIGHUP).
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct ReloadableClientConfig {
-    pub encoding_enabled: Option<bool>,
+    pub enable_inside_pkt_encoding: Option<bool>,
 }
 
 impl ReloadableClientConfig {
@@ -327,8 +327,9 @@ impl ReloadableClientConfig {
     /// Unchanged fields are set to `None`.
     pub fn delta(&self, prev: &Self) -> Self {
         Self {
-            encoding_enabled: (self.encoding_enabled != prev.encoding_enabled)
-                .then_some(self.encoding_enabled)
+            enable_inside_pkt_encoding: (self.enable_inside_pkt_encoding
+                != prev.enable_inside_pkt_encoding)
+                .then_some(self.enable_inside_pkt_encoding)
                 .flatten(),
         }
     }
@@ -699,7 +700,7 @@ async fn config_reload_task(
     while let Some(new_config) = signal.recv().await {
         tracing::info!("Applying reloaded config: {new_config:?}");
 
-        if let Some(enabled) = new_config.enable_encoding_at_connect
+        if let Some(enabled) = new_config.enable_inside_pkt_encoding
             && let Err(e) = encoding_request.send(enabled).await
         {
             tracing::error!("Failed to send encoding request from config reload: {e}");
@@ -927,7 +928,7 @@ pub async fn connect<
         config
             .inside_pkt_codec_config
             .as_ref()
-            .is_some_and(|x| x.enable_encoding_at_connect),
+            .is_some_and(|x| x.enable_inside_pkt_encoding),
         event_handler,
         connected_tx,
         disconnected_tx,

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -254,6 +254,11 @@ pub struct ClientConfig<'cert, ExtAppState: Send + Sync> {
     #[educe(Debug(ignore))]
     pub network_change_signal: Option<mpsc::Receiver<()>>,
 
+    /// Signal for triggering a runtime config reload.
+    /// Each received value is applied to the running connection.
+    #[educe(Debug(ignore))]
+    pub config_reload_signal: Option<mpsc::Receiver<ReloadableClientConfig>>,
+
     /// Signal for Lightway to notify about the best connection when it is selected
     #[educe(Debug(ignore))]
     pub best_connection_selected_signal: Option<oneshot::Sender<BestConnectionInfo>>,
@@ -308,6 +313,25 @@ pub struct ClientInsidePacketCodecConfig {
     /// Signal for send inside packet encoding request to the server.
     #[educe(Debug(ignore))]
     pub encoding_request_signal: tokio::sync::mpsc::Receiver<bool>,
+}
+
+/// Config fields that can be updated at runtime without tearing down the connection.
+/// Sent via `config_reload_signal` when the process receives a reload trigger (e.g. SIGHUP).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ReloadableClientConfig {
+    pub encoding_enabled: Option<bool>,
+}
+
+impl ReloadableClientConfig {
+    /// Returns a new config containing only the fields that differ from `prev`.
+    /// Unchanged fields are set to `None`.
+    pub fn delta(&self, prev: &Self) -> Self {
+        Self {
+            encoding_enabled: (self.encoding_enabled != prev.encoding_enabled)
+                .then_some(self.encoding_enabled)
+                .flatten(),
+        }
+    }
 }
 
 fn debug_fmt_plugin_list(
@@ -666,6 +690,23 @@ pub async fn encoding_request_task<ExtAppState: Send + Sync>(
     }
 
     tracing::info!("toggle encode task has finished");
+}
+
+async fn config_reload_task(
+    mut signal: mpsc::Receiver<ReloadableClientConfig>,
+    encoding_request: mpsc::Sender<bool>,
+) {
+    while let Some(new_config) = signal.recv().await {
+        tracing::info!("Applying reloaded config: {new_config:?}");
+
+        if let Some(enabled) = new_config.enable_encoding_at_connect
+            && let Err(e) = encoding_request.send(enabled).await
+        {
+            tracing::error!("Failed to send encoding request from config reload: {e}");
+        }
+    }
+
+    tracing::info!("config reload task has finished");
 }
 
 /// Represents a connection to a server. When dropped, the route table will be removed.
@@ -1282,6 +1323,11 @@ pub async fn client<
         });
     }
 
+    if let Some(reload_signal) = config.config_reload_signal.take() {
+        let encoding_request = connection.encoding_request_signal.clone();
+        tokio::spawn(config_reload_task(reload_signal, encoding_request));
+    }
+
     let connection_stop_signal = connection.stop_signal.take().unwrap();
     tokio::spawn(async move {
         let _ = stop_signal.await;
@@ -1639,5 +1685,22 @@ mod tests {
             result.unwrap_err().to_string(),
             "All connections disconnected"
         );
+    }
+
+    #[test_case(Some(true),  Some(true)  => None       ; "unchanged")]
+    #[test_case(Some(false), Some(true)  => Some(true) ; "changed")]
+    #[test_case(None,        Some(true)  => Some(true) ; "none to some")]
+    #[test_case(Some(true),  None        => None       ; "some to none")]
+    fn reloadable_config_delta(
+        prev_encoding: Option<bool>,
+        current_encoding: Option<bool>,
+    ) -> Option<bool> {
+        let prev = ReloadableClientConfig {
+            enable_inside_pkt_encoding: prev_encoding,
+        };
+        let current = ReloadableClientConfig {
+            enable_inside_pkt_encoding: current_encoding,
+        };
+        current.delta(&prev).enable_inside_pkt_encoding
     }
 }

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result, anyhow};
 use futures::future::join_all;
 use lightway_core::{Event, EventCallback};
 use tokio::fs::read_to_string;
+use tokio::sync::mpsc;
 
 use lightway_app_utils::{
     TunConfig, Validate,
@@ -127,7 +128,7 @@ async fn main() -> Result<()> {
     config.apply(load_patch(&options, &config_file).await?);
     #[cfg(not(windows))]
     config.apply(serde_saphyr::from_str::<ConfigPatch>(
-        &read_to_string(config_file).await?,
+        &read_to_string(&config_file).await?,
     )?);
     config.apply(serde_env::from_env_with_prefix("LW_CLIENT")?);
     config.apply(options);
@@ -180,6 +181,8 @@ async fn main() -> Result<()> {
             tracing::warn!("Failed to send Ctrl-C signal: {err:?}");
         }
     })?;
+
+    let config_reload_signal = spawn_sighup_reload_handler(&config, config_file.clone());
 
     let inside_io: Option<Arc<dyn InsideIO<()>>> = None;
 
@@ -251,6 +254,7 @@ async fn main() -> Result<()> {
         #[cfg(feature = "io-uring")]
         iouring_sqpoll_idle_time: config.iouring_sqpoll_idle_time.into(),
         inside_pkt_codec_config: None,
+        config_reload_signal,
         network_change_signal: None,
         best_connection_selected_signal: None,
         #[cfg(feature = "debug")]
@@ -260,4 +264,104 @@ async fn main() -> Result<()> {
     };
 
     client(config, ctrlc_rx, conn_confs).await.map(|_| ())
+}
+
+#[cfg(unix)]
+fn reload_config_from_yaml(path: &PathBuf) -> Option<Config> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| tracing::error!("Failed to read config: {e}"))
+        .ok()?;
+    let patch = serde_saphyr::from_str::<ConfigPatch>(&content)
+        .map_err(|e| tracing::error!("Failed to parse config on reload: {e}"))
+        .ok()?;
+    let mut config = Config::default();
+    config.apply(patch);
+    Some(config)
+}
+
+#[cfg(unix)]
+fn warn_non_reloadable_changes(old: &Config, new: &Config) {
+    /// Mask reloadable fields so only non-reloadable differences remain.
+    /// Clone old, overwrite listed fields with new's values, then compare to new.
+    /// Any remaining difference means a non-reloadable field changed.
+    macro_rules! mask_reloadable {
+        ($old:expr, $new:expr, $($field:ident),+ $(,)?) => {{
+            let mut masked = $old.clone();
+            $(masked.$field = $new.$field.clone();)+
+            masked
+        }};
+    }
+
+    if old == new {
+        return;
+    }
+
+    // List ONLY the fields that CAN be reloaded at runtime.
+    // Everything else is automatically caught by the PartialEq check.
+    let masked = mask_reloadable!(old, new, log_level, enable_inside_pkt_encoding_at_connect);
+
+    if masked != *new {
+        tracing::warn!("Non-reloadable config fields changed (requires restart to take effect)");
+    }
+}
+
+impl From<&Config> for ReloadableClientConfig {
+    fn from(config: &Config) -> Self {
+        Self {
+            encoding_enabled: Some(config.enable_inside_pkt_encoding_at_connect),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn spawn_sighup_reload_handler(
+    config: &Config,
+    config_file: PathBuf,
+) -> Option<mpsc::Receiver<ReloadableClientConfig>> {
+    let initial = ReloadableClientConfig::from(config);
+
+    let (tx, rx) = mpsc::channel(1);
+    tokio::spawn(async move {
+        let mut sighup = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup())
+            .expect("Failed to register SIGHUP handler");
+
+        let mut prev = initial;
+        let mut prev_config: Option<Config> = None;
+
+        while sighup.recv().await.is_some() {
+            tracing::info!("SIGHUP received, reloading config");
+
+            let Some(new_config) = reload_config_from_yaml(&config_file) else {
+                continue;
+            };
+
+            if let Some(old) = &prev_config {
+                warn_non_reloadable_changes(old, &new_config);
+            }
+
+            let current = ReloadableClientConfig::from(&new_config);
+            prev_config = Some(new_config);
+
+            if current == prev {
+                tracing::info!("Config unchanged, skipping reload");
+                continue;
+            }
+
+            let delta = current.delta(&prev);
+            prev = current;
+
+            if tx.send(delta).await.is_err() {
+                break;
+            }
+        }
+    });
+    Some(rx)
+}
+
+#[cfg(not(unix))]
+fn spawn_sighup_reload_handler(
+    _config: &Config,
+    _config_file: PathBuf,
+) -> Option<mpsc::Receiver<ReloadableClientConfig>> {
+    None
 }

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -130,7 +130,9 @@ async fn main() -> Result<()> {
     config.apply(serde_saphyr::from_str::<ConfigPatch>(
         &read_to_string(&config_file).await?,
     )?);
-    config.apply(serde_env::from_env_with_prefix("LW_CLIENT")?);
+    let env_patch: ConfigPatch = serde_env::from_env_with_prefix("LW_CLIENT")?;
+    config.apply(env_patch.clone());
+    let cli_patch = options.clone();
     config.apply(options);
 
     let level: tracing::level_filters::LevelFilter = config.log_level.into();
@@ -204,7 +206,7 @@ async fn main() -> Result<()> {
     }
 
     let config_reload_signal =
-        spawn_sighup_reload_handler(&config, config_file.clone());
+        spawn_sighup_reload_handler(&config, config_file.clone(), env_patch, cli_patch);
 
     let inside_io: Option<Arc<dyn InsideIO<()>>> = None;
 
@@ -289,15 +291,23 @@ async fn main() -> Result<()> {
 }
 
 #[cfg(unix)]
-fn reload_config_from_yaml(path: &PathBuf) -> Option<Config> {
-    let content = std::fs::read_to_string(path)
+async fn reload_config(
+    path: &PathBuf,
+    env_patch: &ConfigPatch,
+    cli_patch: &ConfigPatch,
+) -> Option<Config> {
+    let content = tokio::fs::read_to_string(path)
+        .await
         .map_err(|e| tracing::error!("Failed to read config: {e}"))
         .ok()?;
-    let patch = serde_saphyr::from_str::<ConfigPatch>(&content)
+    let file_patch = serde_saphyr::from_str::<ConfigPatch>(&content)
         .map_err(|e| tracing::error!("Failed to parse config on reload: {e}"))
         .ok()?;
+
     let mut config = Config::default();
-    config.apply(patch);
+    config.apply(file_patch);
+    config.apply(env_patch.clone());
+    config.apply(cli_patch.clone());
     Some(config)
 }
 
@@ -339,30 +349,30 @@ impl From<&Config> for ReloadableClientConfig {
 fn spawn_sighup_reload_handler(
     config: &Config,
     config_file: PathBuf,
+    env_patch: ConfigPatch,
+    cli_patch: ConfigPatch,
 ) -> Option<mpsc::Receiver<ReloadableClientConfig>> {
     let mut sighup = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup())
         .expect("Failed to register SIGHUP handler");
 
-    let initial = ReloadableClientConfig::from(config);
+    let initial = config.clone();
 
     let (tx, rx) = mpsc::channel(1);
     tokio::spawn(async move {
-        let mut prev = initial;
-        let mut prev_config: Option<Config> = None;
+        let mut prev = ReloadableClientConfig::from(&initial);
+        let mut prev_config = initial;
 
         while sighup.recv().await.is_some() {
             tracing::info!("SIGHUP received, reloading config");
 
-            let Some(new_config) = reload_config_from_yaml(&config_file) else {
+            let Some(new_config) = reload_config(&config_file, &env_patch, &cli_patch).await else {
                 continue;
             };
 
-            if let Some(old) = &prev_config {
-                warn_non_reloadable_changes(old, &new_config);
-            }
+            warn_non_reloadable_changes(&prev_config, &new_config);
 
             let current = ReloadableClientConfig::from(&new_config);
-            prev_config = Some(new_config);
+            prev_config = new_config;
 
             if current == prev {
                 tracing::info!("Config unchanged, skipping reload");
@@ -384,6 +394,8 @@ fn spawn_sighup_reload_handler(
 fn spawn_sighup_reload_handler(
     _config: &Config,
     _config_file: PathBuf,
+    _env_patch: ConfigPatch,
+    _cli_patch: ConfigPatch,
 ) -> Option<mpsc::Receiver<ReloadableClientConfig>> {
     None
 }

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -175,14 +175,36 @@ async fn main() -> Result<()> {
         .up();
 
     let (ctrlc_tx, mut ctrlc_rx) = tokio::sync::oneshot::channel();
-    let mut ctrlc_tx = Some(ctrlc_tx);
-    ctrlc::set_handler(move || {
-        if let Some(Err(err)) = ctrlc_tx.take().map(|tx| tx.send(())) {
-            tracing::warn!("Failed to send Ctrl-C signal: {err:?}");
-        }
-    })?;
 
-    let config_reload_signal = spawn_sighup_reload_handler(&config, config_file.clone());
+    #[cfg(unix)]
+    {
+        tokio::spawn(async move {
+            let mut sigint =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
+                    .expect("Failed to register SIGINT handler");
+            let mut sigterm =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                    .expect("Failed to register SIGTERM handler");
+            tokio::select! {
+                _ = sigint.recv() => {}
+                _ = sigterm.recv() => {}
+            }
+            let _ = ctrlc_tx.send(());
+        });
+    }
+
+    #[cfg(windows)]
+    {
+        let ctrlc_tx = std::sync::Mutex::new(Some(ctrlc_tx));
+        ctrlc::set_handler(move || {
+            if let Some(tx) = ctrlc_tx.lock().unwrap().take() {
+                let _ = tx.send(());
+            }
+        })?;
+    }
+
+    let config_reload_signal =
+        spawn_sighup_reload_handler(&config, config_file.clone());
 
     let inside_io: Option<Arc<dyn InsideIO<()>>> = None;
 
@@ -318,13 +340,13 @@ fn spawn_sighup_reload_handler(
     config: &Config,
     config_file: PathBuf,
 ) -> Option<mpsc::Receiver<ReloadableClientConfig>> {
+    let mut sighup = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup())
+        .expect("Failed to register SIGHUP handler");
+
     let initial = ReloadableClientConfig::from(config);
 
     let (tx, rx) = mpsc::channel(1);
     tokio::spawn(async move {
-        let mut sighup = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup())
-            .expect("Failed to register SIGHUP handler");
-
         let mut prev = initial;
         let mut prev_config: Option<Config> = None;
 

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -298,7 +298,7 @@ fn warn_non_reloadable_changes(old: &Config, new: &Config) {
 
     // List ONLY the fields that CAN be reloaded at runtime.
     // Everything else is automatically caught by the PartialEq check.
-    let masked = mask_reloadable!(old, new, log_level, enable_inside_pkt_encoding_at_connect);
+    let masked = mask_reloadable!(old, new, log_level, enable_inside_pkt_encoding);
 
     if masked != *new {
         tracing::warn!("Non-reloadable config fields changed (requires restart to take effect)");
@@ -308,7 +308,7 @@ fn warn_non_reloadable_changes(old: &Config, new: &Config) {
 impl From<&Config> for ReloadableClientConfig {
     fn from(config: &Config) -> Self {
         Self {
-            encoding_enabled: Some(config.enable_inside_pkt_encoding_at_connect),
+            enable_inside_pkt_encoding: Some(config.enable_inside_pkt_encoding),
         }
     }
 }

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -149,8 +149,8 @@ async fn main() -> Result<()> {
 
     let mut tun_config = TunConfig::default();
 
-    if let Some(tun_name) = config.tun_name.take() {
-        tun_config.tun_name(tun_name);
+    if let Some(ref tun_name) = config.tun_name {
+        tun_config.tun_name(tun_name.clone());
     }
 
     #[cfg(windows)]

--- a/lightway-server/Cargo.toml
+++ b/lightway-server/Cargo.toml
@@ -23,7 +23,6 @@ average = "0.17.0"
 bytes.workspace = true
 bytesize.workspace = true
 clap.workspace = true
-ctrlc.workspace = true
 delegate.workspace = true
 educe.workspace = true
 ipnet.workspace = true
@@ -52,6 +51,9 @@ tokio-stream = { workspace = true, features = ["time"] }
 tracing.workspace = true
 tracing-log = "0.2.0"
 tracing-subscriber = { workspace = true, features = ["json", "env-filter"] }
+
+[target.'cfg(windows)'.dependencies]
+ctrlc.workspace = true
 
 [dev-dependencies]
 more-asserts.workspace = true

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -38,7 +38,7 @@ use tokio::{
     net::{TcpListener, UdpSocket},
     task::JoinHandle,
 };
-use tracing::{info, warn};
+use tracing::info;
 
 pub use crate::connection::ConnectionState;
 pub use crate::io::inside::{InsideIO, InsideIORecv};
@@ -399,12 +399,33 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
     });
 
     let (ctrlc_tx, ctrlc_rx) = tokio::sync::oneshot::channel();
-    let mut ctrlc_tx = Some(ctrlc_tx);
-    ctrlc::set_handler(move || {
-        if let Some(Err(err)) = ctrlc_tx.take().map(|tx| tx.send(())) {
-            warn!("Failed to send Ctrl-C signal: {err:?}");
-        }
-    })?;
+
+    #[cfg(unix)]
+    {
+        tokio::spawn(async move {
+            let mut sigint =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
+                    .expect("Failed to register SIGINT handler");
+            let mut sigterm =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                    .expect("Failed to register SIGTERM handler");
+            tokio::select! {
+                _ = sigint.recv() => {}
+                _ = sigterm.recv() => {}
+            }
+            let _ = ctrlc_tx.send(());
+        });
+    }
+
+    #[cfg(windows)]
+    {
+        let mut ctrlc_tx = Some(ctrlc_tx);
+        ctrlc::set_handler(move || {
+            if let Some(Err(err)) = ctrlc_tx.take().map(|tx| tx.send(())) {
+                tracing::warn!("Failed to send Ctrl-C signal: {err:?}");
+            }
+        })?;
+    }
 
     tokio::select! {
         err = server.run() => err.context("Outside IO loop exited"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
BREAKING: `enable_inside_pkt_encoding_at_connect` arg is renamed to `enable_inside_pkt_encoding`

Add runtime reloadable config infrastructure for lightway-client. For now, only `enable_inside_pkt_encoding` is reloadable. The existing `enable_inside_pkt_encoding_at_connect` is renamed to `enable_inside_pkt_encoding` to be more accurate.

When a SIGHUP is received, lightway-client reloads the config from YAML and diffs it with the previous state. If any fields that are not reloadable are changed, it gives a warning.

CLI args and env variables will still take priority over the YAML config. (i.e. they will cause any config changes to fail if specified)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows lightway configuration to be updated at runtime. For now, toggling inside pkt codec can be done by updating the config and sending a SIGHUP.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested that SIGHUP is properly handled, `enable_inside_pkt_encoding` field is properly parsed, and warn if other fields changed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
