### PR TITLE
client: update systemd-resolved detection to require /etc/resolv.conf…

### DIFF
--- a/lightway-client/src/platform/linux/dns_manager.rs
+++ b/lightway-client/src/platform/linux/dns_manager.rs
@@ -47,14 +47,38 @@ fn ifname_from_index(ifindex: u32) -> Option<String> {
     None
 }
 
-/// Returns `true` when systemd-resolved is actively running.
+/// Returns `true` when systemd-resolved is actively running and wired up as the
+/// system resolver.
 ///
-/// `/run/systemd/resolve/stub-resolv.conf` is written by systemd-resolved only
-/// while it is running. Because `/run` is tmpfs it is never stale across reboots,
-/// making it a reliable liveness indicator without spawning a process or requiring
-/// a D-Bus connection.
+/// Two checks:
+/// 1. `/run/systemd/resolve/stub-resolv.conf` exists. systemd-resolved writes
+///    this file only while running, and `/run` is tmpfs so it is never stale
+///    across reboots - a reliable liveness indicator without spawning a process
+///    or requiring a D-Bus connection.
+/// 2. `/etc/resolv.conf` is a symlink pointing at that stub file. If a user has
+///    deleted the symlink (or replaced it with an unrelated file), libc-based
+///    resolvers bypass systemd-resolved entirely; configuring DNS via
+///    `resolvectl` would silently have no effect on application DNS lookups.
+///    Fall back to the direct-file backend in that case.
 fn systemd_resolved_running() -> bool {
-    std::path::Path::new("/run/systemd/resolve/stub-resolv.conf").exists()
+    let stub = std::path::Path::new("/run/systemd/resolve/stub-resolv.conf");
+    if !stub.exists() {
+        return false;
+    }
+    match std::fs::read_link("/etc/resolv.conf") {
+        Ok(target) => {
+            let abs = if target.is_absolute() {
+                target
+            } else {
+                // ArchLinux recommends creating symlink with relative path:
+                // ln -sf ../run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
+                // Ref: https://wiki.archlinux.org/title/Systemd-resolved
+                std::path::Path::new("/etc").join(target)
+            };
+            std::fs::canonicalize(&abs).ok() == std::fs::canonicalize(stub).ok()
+        }
+        Err(_) => false,
+    }
 }
 
 /// Returns `true` when openresolv is actively managing DNS.


### PR DESCRIPTION

## Description

update systemd-resolved detection to require /etc/resolv.conf symlink

It is possible that user has configured systemd-resolved and then removed the resolv.conf symlink to use a static one.

Handle those cases, by checking valid symlink, before using resolved handler.

## Motivation and Context

In testing, found dns resolver was not working properly in one of the machines with deleted symlink.

## How Has This Been Tested?

Verified DNS resolver uses static file if symlink is deleted

<details>
<summary>Testing logs</summary>

```

root@vpn-client /etc# ls -l resolv.conf
lrwxrwxrwx 1 root root 39 Mar 18 11:22 resolv.conf -> ../run/systemd/resolve/stub-resolv.conf
root@vpn-client /etc# rm resolv.conf
root@vpn-client /etc# vim resolv.conf
root@vpn-client /etc# dig google.com

; <<>> DiG 9.20.18-1~deb13u1-Debian <<>> google.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 40009
;; flags: qr rd ra; QUERY: 1, ANSWER: 6, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;google.com.                    IN      A

;; ANSWER SECTION:
google.com.             300     IN      A       172.217.194.102
google.com.             300     IN      A       172.217.194.139
google.com.             300     IN      A       172.217.194.100
google.com.             300     IN      A       172.217.194.138
google.com.             300     IN      A       172.217.194.101
google.com.             300     IN      A       172.217.194.113

;; Query time: 4 msec
;; SERVER: 8.8.8.8#53(8.8.8.8) (UDP)
;; WHEN: Wed Apr 29 17:34:01 +08 2026
;; MSG SIZE  rcvd: 135

root@vpn-client /etc# ls -l resolv.conf*
-rw-r--r-- 1 root root 62 Apr 29 17:34 resolv.conf
-rw-r--r-- 1 root root 19 Apr 29 17:33 resolv.conf.lightway-orig
root@vpn-client /etc# cat resolv.conf
# Generated by lightway
search lightway
nameserver 10.126.0.1
root@vpn-client /etc# cat resolv.conf
nameserver 8.8.8.8
root@vpn-client /etc# ls -l resolv.conf*
-rw-r--r-- 1 root root 19 Apr 29 17:33 resolv.conf
root@vpn-client /etc# rm resolv.conf
root@vpn-client /etc# ln -sf ../run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
root@vpn-client /etc# ls -l resolv.conf*
lrwxrwxrwx 1 root root 39 Apr 29 17:34 resolv.conf -> ../run/systemd/resolve/stub-resolv.conf
root@vpn-client /etc# dig google.com

; <<>> DiG 9.20.18-1~deb13u1-Debian <<>> google.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 9065
;; flags: qr rd ra; QUERY: 1, ANSWER: 6, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 65494
;; QUESTION SECTION:
;google.com.                    IN      A

;; ANSWER SECTION:
google.com.             300     IN      A       74.125.200.102
google.com.             300     IN      A       74.125.200.100
google.com.             300     IN      A       74.125.200.113
google.com.             300     IN      A       74.125.200.138
google.com.             300     IN      A       74.125.200.101
google.com.             300     IN      A       74.125.200.139

;; Query time: 4 msec
;; SERVER: 127.0.0.53#53(127.0.0.53) (UDP)
;; WHEN: Wed Apr 29 17:35:02 +08 2026
;; MSG SIZE  rcvd: 135

root@vpn-client /etc#

```

</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
