### PR TITLE
CVPN-2519: Expresslane and InsidePktCodec mutually exclusive

### DIFF
--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -421,6 +421,9 @@ async fn handle_events<A: 'static + Send + EventCallback, ExtAppState: Send + Sy
             Event::EncodingStateChanged { enabled } => {
                 info!("Encoding state changed to {enabled}");
             }
+            Event::DataPathModeChanged(mode) => {
+                info!(?mode, "Data path mode changed");
+            }
 
             // Server only events
             Event::SessionIdRotationStarted { .. }

--- a/lightway-client/src/mobile/lightway.rs
+++ b/lightway-client/src/mobile/lightway.rs
@@ -809,7 +809,9 @@ async fn handle_events<A: 'static + Send + EventCallback>(
                 }
                 continue;
             }
-            Event::FirstPacketReceived | Event::EncodingStateChanged { .. } => (), // will be handled by handle_global_events
+            Event::FirstPacketReceived
+            | Event::EncodingStateChanged { .. }
+            | Event::DataPathModeChanged(_) => (), // will be handled by handle_global_events
 
             // Server-only events
             Event::SessionIdRotationAcknowledged { .. }

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -78,6 +78,24 @@ const MAX_RETRANSMISSION_ATTEMPTS: u8 = 5;
 /// Maximum number of retransmissions attempts for each encoding request packet.
 const ENCODING_REQUEST_PKT_MAX_RETRANSMISSION_ATTEMPTS: u8 = 5;
 
+/// Which mutually exclusive data path optimization is active.
+///
+/// ExpressLane and InsidePktCodec cannot be active simultaneously.
+/// This enum is the single source of truth for which mode governs
+/// the data path.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum DataPathMode {
+    /// Standard data path (i.e. non-ExpressLane, non-InsidePktCodec)
+    #[default]
+    Standard,
+
+    /// ExpressLane
+    ExpressLane,
+
+    /// InsidePktCodec
+    InsidePktCodec,
+}
+
 /// Connection state
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(u8)]
@@ -436,6 +454,9 @@ pub struct Connection<AppState: Send = ()> {
 
     // Expresslane state, config exchange, health monitoring, wire crypto, and callbacks
     expresslane: expresslane::Expresslane<AppState>,
+
+    /// Which mutually exclusive data path optimization is active
+    data_path_mode: DataPathMode,
 }
 
 /// Information about the new session being established with a new
@@ -527,6 +548,7 @@ impl<AppState: Send> Connection<AppState> {
                 args.expresslane_metrics,
                 args.expresslane_keys_rotation_interval,
             ),
+            data_path_mode: DataPathMode::Standard,
         };
 
         // This will very likely fail since negotiation always needs
@@ -1674,6 +1696,14 @@ impl<AppState: Send> Connection<AppState> {
         self.event(Event::ExpresslaneStateChanged(new_state));
     }
 
+    fn set_data_path_mode(&mut self, new_mode: DataPathMode) {
+        if self.data_path_mode == new_mode {
+            return;
+        }
+        self.data_path_mode = new_mode;
+        self.event(Event::DataPathModeChanged(new_mode));
+    }
+
     /// Encode expresslane metrics as a binary payload.
     ///
     /// Encodes absolute cumulative counters: [packets_sent: u64, packets_received: u64].
@@ -2235,6 +2265,11 @@ impl<AppState: Send> Connection<AppState> {
         self.encoding_request_states.pending_request_pkt = None;
 
         Ok(())
+    }
+
+    /// Get the current data path mode
+    pub fn data_path_mode(&self) -> DataPathMode {
+        self.data_path_mode
     }
 
     /// Get the current encoding state from the encoder

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -1850,6 +1850,25 @@ impl<AppState: Send> Connection<AppState> {
         // If updating key failed, send disabled to peer
         let enabled = self.expresslane.data.update_next_self_key(key).is_ok();
 
+        self.send_expresslane_config(enabled, key);
+
+        self.expresslane.last_key_rotation = Some(Instant::now());
+
+        Ok(())
+    }
+
+    /// Mark expresslane as [Degraded](ExpresslaneState::Degraded) and notify the peer to also disable
+    fn set_expresslane_degraded(&mut self) {
+        self.set_expresslane_state(ExpresslaneState::Degraded);
+
+        let key = ExpresslaneKey::INVALID;
+        let _ = self.expresslane.data.update_next_self_key(key);
+
+        self.send_expresslane_config(false, key);
+    }
+
+    /// Build an ExpresslaneConfig, send it to the peer, and schedule retransmission.
+    fn send_expresslane_config(&mut self, enabled: bool, key: ExpresslaneKey) {
         // Outgoing version: if we have already negotiated a version
         // with the peer, use that. Otherwise advertise our local max
         let version = match self.expresslane.data.version {
@@ -1869,43 +1888,6 @@ impl<AppState: Send> Connection<AppState> {
         let msg = wire::Frame::ExpresslaneConfig(config);
         let _ = self.send_frame_or_drop(msg);
 
-        self.expresslane.last_key_rotation = Some(Instant::now());
-
-        // Callback to schedule re-transmission if required
-        (self.schedule_tick_cb)(
-            self.expresslane.retransmit_wait_time(),
-            &mut self.app_state,
-            TickType::ExpresslaneKeyShareTick(ExpresslaneTickData(config)),
-        );
-        Ok(())
-    }
-
-    /// Mark expresslane as [Degraded](ExpresslaneState::Degraded) and notify the peer to also disable
-    fn set_expresslane_degraded(&mut self) {
-        self.set_expresslane_state(ExpresslaneState::Degraded);
-
-        let key = ExpresslaneKey::INVALID;
-        let _ = self.expresslane.data.update_next_self_key(key);
-
-        let version = match self.expresslane.data.version {
-            ExpresslaneVersion::Unknown => ExpresslaneVersion::MAX,
-            v => v,
-        };
-
-        self.expresslane.config_counter += 1;
-        let config = wire::ExpresslaneConfig {
-            enabled: false,
-            key,
-            version,
-            ack: false,
-            counter: self.expresslane.config_counter,
-        };
-
-        let msg = wire::Frame::ExpresslaneConfig(config);
-        let _ = self.send_frame_or_drop(msg);
-
-        // Callback to schedule re-transmission if required
-        // reuses same retry logic as key rotation
         (self.schedule_tick_cb)(
             self.expresslane.retransmit_wait_time(),
             &mut self.app_state,

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -1688,12 +1688,36 @@ impl<AppState: Send> Connection<AppState> {
     }
 
     /// Set the expresslane state and emit the event if the state has changed.
+    ///
+    /// Activation is blocked while data path mode is [`DataPathMode::InsidePktCodec`].
+    /// Transitions to/from [`ExpresslaneState::Active`] automatically update
+    /// the [`DataPathMode`].
     fn set_expresslane_state(&mut self, new_state: ExpresslaneState) {
         if self.expresslane.state == new_state {
             return;
         }
+        if new_state == ExpresslaneState::Active
+            && self.data_path_mode == DataPathMode::InsidePktCodec
+        {
+            warn!("Blocking expresslane activation: InsidePktCodec is active");
+            return;
+        }
+
         self.expresslane.state = new_state;
         self.event(Event::ExpresslaneStateChanged(new_state));
+
+        match (new_state, self.data_path_mode) {
+            (ExpresslaneState::Active, _) => {
+                self.set_data_path_mode(DataPathMode::ExpressLane);
+            }
+            (_, DataPathMode::ExpressLane) => {
+                self.set_data_path_mode(DataPathMode::Standard);
+            }
+            (ExpresslaneState::Disabled, _)
+            | (ExpresslaneState::WaitingForClient, _)
+            | (ExpresslaneState::Inactive, _)
+            | (ExpresslaneState::Degraded, _) => {}
+        }
     }
 
     fn set_data_path_mode(&mut self, new_mode: DataPathMode) {

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -1794,6 +1794,11 @@ impl<AppState: Send> Connection<AppState> {
             return Ok(());
         }
 
+        if self.data_path_mode == DataPathMode::InsidePktCodec {
+            debug!("Ignoring expresslane config from peer (InsidePktCodec active)");
+            return Ok(());
+        }
+
         // Server starts in WaitingForClient. The client's first config
         // transitions the server to Pending, which enables
         // expresslane_supported() and allows the server to send its own key.
@@ -1858,8 +1863,20 @@ impl<AppState: Send> Connection<AppState> {
     }
 
     /// Mark expresslane as [Degraded](ExpresslaneState::Degraded) and notify the peer to also disable
+    /// Expresslane will not be re-enabled after being degraded
     fn set_expresslane_degraded(&mut self) {
         self.set_expresslane_state(ExpresslaneState::Degraded);
+
+        let key = ExpresslaneKey::INVALID;
+        let _ = self.expresslane.data.update_next_self_key(key);
+
+        self.send_expresslane_config(false, key);
+    }
+
+    /// Mark expresslane as [Inactive](ExpresslaneState::Inactive) and notify the peer to also disable
+    /// Unlike [`Self::set_expresslane_degraded`], this allows re-activation when InsidePktCodec is later disabled
+    fn set_expresslane_inactive(&mut self) {
+        self.set_expresslane_state(ExpresslaneState::Inactive);
 
         let key = ExpresslaneKey::INVALID;
         let _ = self.expresslane.data.update_next_self_key(key);
@@ -2197,6 +2214,15 @@ impl<AppState: Send> Connection<AppState> {
         // Update the latest acknowledged packet's id
         self.encoding_request_states.id_counter = er.id;
 
+        if er.enable {
+            if self.data_path_mode == DataPathMode::ExpressLane {
+                self.set_expresslane_inactive();
+            }
+            self.set_data_path_mode(DataPathMode::InsidePktCodec);
+        } else {
+            self.set_data_path_mode(DataPathMode::Standard);
+        }
+
         encoder.set_encoding_state(er.enable);
         debug!(
             "Client {:?}: EncodingRequest {} received. encoding state now: {}.",
@@ -2206,6 +2232,12 @@ impl<AppState: Send> Connection<AppState> {
         );
 
         self.event(Event::EncodingStateChanged { enabled: er.enable });
+
+        if !er.enable && self.expresslane_supported() {
+            // Re-enable ExpressLane
+            self.expresslane.last_key_rotation = None;
+            let _ = self.rotate_expresslane_key();
+        }
 
         // Reply to the client.
         let msg = wire::Frame::EncodingResponse(wire::EncodingResponse {
@@ -2220,13 +2252,10 @@ impl<AppState: Send> Connection<AppState> {
         &mut self,
         te: wire::EncodingResponse,
     ) -> ConnectionResult<()> {
-        let encoder = match &mut self.inside_pkt_encoder {
-            Some(encoder) => encoder,
-            None => {
-                error!("Received EncodingResponse packet even without an encoder.");
-                return Err(ConnectionError::PacketCodecDoesNotExist);
-            }
-        };
+        if self.inside_pkt_encoder.is_none() {
+            error!("Received EncodingResponse packet even without an encoder.");
+            return Err(ConnectionError::PacketCodecDoesNotExist);
+        }
 
         if !matches!(self.state, State::Online) {
             warn!("Received encoding request packet before state is Online");
@@ -2260,7 +2289,19 @@ impl<AppState: Send> Connection<AppState> {
 
         let new_setting = te.enable;
 
-        encoder.set_encoding_state(new_setting);
+        if new_setting {
+            if self.data_path_mode == DataPathMode::ExpressLane {
+                self.set_expresslane_inactive();
+            }
+            self.set_data_path_mode(DataPathMode::InsidePktCodec);
+        } else {
+            self.set_data_path_mode(DataPathMode::Standard);
+        }
+
+        self.inside_pkt_encoder
+            .as_mut()
+            .unwrap()
+            .set_encoding_state(new_setting);
         info!("inside packet encoding state is now set to {}", new_setting);
 
         self.event(Event::EncodingStateChanged {
@@ -2269,6 +2310,11 @@ impl<AppState: Send> Connection<AppState> {
 
         // Removes from pending pkt store such that it is no longer retransmitted
         self.encoding_request_states.pending_request_pkt = None;
+
+        if !new_setting && self.expresslane_supported() {
+            self.expresslane.last_key_rotation = None;
+            let _ = self.rotate_expresslane_key();
+        }
 
         Ok(())
     }

--- a/lightway-core/src/connection/event.rs
+++ b/lightway-core/src/connection/event.rs
@@ -1,4 +1,4 @@
-use crate::connection::ExpresslaneState;
+use crate::connection::{DataPathMode, ExpresslaneState};
 use crate::{SessionId, State};
 
 /// A lightway event
@@ -52,4 +52,6 @@ pub enum Event {
     },
     /// Expresslane state changed
     ExpresslaneStateChanged(ExpresslaneState),
+    /// Data path mode changed
+    DataPathModeChanged(DataPathMode),
 }

--- a/lightway-core/src/lib.rs
+++ b/lightway-core/src/lib.rs
@@ -29,8 +29,9 @@ pub use builder_predicates::BuilderPredicates;
 pub use cipher::Cipher;
 pub use connection::{
     ClientConnectionBuilder, Connection, ConnectionActivity, ConnectionBuilderError,
-    ConnectionError, ConnectionResult, Event, EventCallback, EventCallbackArg, ExpresslaneState,
-    ServerConnectionBuilder, State, dplpmtud::Timer as DplpmtudTimer, expresslane::*,
+    ConnectionError, ConnectionResult, DataPathMode, Event, EventCallback, EventCallbackArg,
+    ExpresslaneState, ServerConnectionBuilder, State, dplpmtud::Timer as DplpmtudTimer,
+    expresslane::*,
 };
 pub use context::{
     ClientContext, ClientContextBuilder, ConnectionType, ContextError, ScheduleTickCb, ServerAuth,

--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -480,6 +480,9 @@ async fn client<S: TestSock>(
                 Event::EncodingStateChanged { enabled } => {
                     println!("Encoding state change to {enabled}")
                 }
+                Event::DataPathModeChanged(mode) => {
+                    println!("Data path mode change to {mode:?}")
+                }
             }
         }
     });

--- a/lightway-server/src/connection_manager.rs
+++ b/lightway-server/src/connection_manager.rs
@@ -198,6 +198,9 @@ async fn handle_events(
             Event::ExpresslaneStateChanged(s) => {
                 info!("Setting expresslane state to {:?}", s);
             }
+            Event::DataPathModeChanged(mode) => {
+                info!("Setting data path mode to {:?}", mode);
+            }
             Event::FirstPacketReceived => {
                 unreachable!("client only event received");
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a `DataPathMode` enum that enforces that ExpressLane and InsidePktCodec are never both enabled.

ExpressLane cannot be enabled if `DataPathMode` is `InsidePktCodec`.

If ExpressLane is enabled when an encoding request is sent or received, ExpressLane is set to `Inactive` and is only re-enabled when encoding is then disabled.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
They are mutually exclusive. Previously, this was not enforced by code and relies on correct user configuration.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
