### PR TITLE
CVPN-2346 Implement GSO offload on lightway-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "1.0.0"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -94,9 +94,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "1.0.0"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
@@ -156,7 +156,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -200,7 +200,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -303,7 +303,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -314,7 +314,7 @@ checksum = "3ca6739863c590881f038d033a146c51ddae239186a4327014839fd864f44ed5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -409,22 +409,23 @@ dependencies = [
 
 [[package]]
 name = "c2rust-bitfields"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcee50917f9de1a018e3f4f9a8f2ff3d030a288cffa4b18d9b391e97c12e4cfb"
+checksum = "e91b9a85391b09c224053f3c45344f0639822e641f9d2b4f351bb3152600742d"
 dependencies = [
  "c2rust-bitfields-derive",
 ]
 
 [[package]]
 name = "c2rust-bitfields-derive"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b457277798202ccd365b9c112ebee08ddd57f1033916c8b8ea52f222e5b715d"
+checksum = "153187c06ed005d5cb75ed9f0a2f274836f54f6b2efdc1f45136e728764875f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -537,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -547,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -559,14 +560,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -728,7 +729,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -750,7 +751,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -761,7 +762,7 @@ checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -798,7 +799,7 @@ dependencies = [
  "quote",
  "sha3",
  "strum",
- "syn 2.0.117",
+ "syn 2.0.106",
  "unicode-ident",
  "void",
 ]
@@ -892,7 +893,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -942,7 +943,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1139,7 +1140,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1879,7 +1880,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1896,7 +1897,7 @@ checksum = "4e3d8fc9e04620b75d822dfaf2ae73ff7aa806916f9641c984fa12c51ef15603"
 dependencies = [
  "lenient_semver",
  "serde_json",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2083,7 +2084,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2289,7 +2290,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2376,7 +2377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2390,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -2441,9 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -2561,7 +2562,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2690,7 +2691,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2716,7 +2717,7 @@ checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2756,7 +2757,7 @@ checksum = "2bf03b7a5281cfd4013bc788d057b0f09fc634397d83bc8973c955bd4f32727a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2796,7 +2797,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2807,7 +2808,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2852,7 +2853,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2890,7 +2891,7 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3072,7 +3073,7 @@ checksum = "970378c47245454d5899f4aae1ed2ad9698f756ebbfc8589bd63b54f56af86ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
  "syn-serde",
 ]
 
@@ -3094,7 +3095,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3116,9 +3117,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3135,7 +3136,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3185,7 +3186,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3196,7 +3197,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
  "test-case-core",
 ]
 
@@ -3237,7 +3238,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3248,7 +3249,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3341,7 +3342,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3437,7 +3438,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3525,9 +3526,9 @@ dependencies = [
 
 [[package]]
 name = "tun-rs"
-version = "2.8.1"
+version = "2.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88c6aea62111e48fb67b733d6bbdc2019272e6d6f7108c9b0f4cd25d715d38a"
+checksum = "63271eef24ceec4e06b121a757ace951681196950825e6f29d955a151363eb6b"
 dependencies = [
  "blocking",
  "byteorder",
@@ -3546,7 +3547,7 @@ dependencies = [
  "tokio",
  "widestring",
  "windows-sys 0.61.2",
- "winreg",
+ "winreg 0.56.0",
 ]
 
 [[package]]
@@ -3563,9 +3564,9 @@ checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.24"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-linebreak"
@@ -3649,7 +3650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72775b3afa6adb30e0c92b3107858d2fcb0ff1a417ac242db1f648b0e2dd0ef2"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3681,7 +3682,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
+ "syn 2.0.106",
  "toml",
  "uniffi_build",
  "uniffi_meta",
@@ -3827,7 +3828,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -3999,7 +4000,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4010,7 +4011,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4182,6 +4183,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4217,7 +4228,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.14.0",
  "prettyplease",
- "syn 2.0.117",
+ "syn 2.0.106",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4233,7 +4244,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4316,7 +4327,7 @@ checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4336,7 +4347,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,6 @@ tokio-stream = "0.1.14"
 tokio-util = "0.7.10"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
-tun-rs = { version = "2.5.1", features = ["async"] }
+tun-rs = { version = "2.8.5", features = ["async"] }
 windows-sys = "0.61.0"
 uniffi = "0.26.1"

--- a/lightway-app-utils/src/lib.rs
+++ b/lightway-app-utils/src/lib.rs
@@ -37,7 +37,7 @@ pub use network_change_monitor::NetworkChangeMonitor;
 pub use tun::TunIoUring;
 pub use tun::{Tun, TunConfig, TunDirect};
 
-#[cfg(feature = "io-uring")]
+#[cfg(any(feature = "io-uring", target_os = "linux"))]
 mod metrics;
 mod utils;
 pub use utils::{Validate, validate_configuration_file_path};

--- a/lightway-app-utils/src/metrics.rs
+++ b/lightway-app-utils/src/metrics.rs
@@ -1,10 +1,23 @@
 use metrics::{Counter, counter};
 use std::sync::LazyLock;
 
+#[cfg(feature = "io-uring")]
 static METRIC_TUN_IOURING_RX_ERR: LazyLock<Counter> =
     LazyLock::new(|| counter!("tun_iouring_rx_err"));
 
+#[cfg(target_os = "linux")]
+static METRIC_TUN_RECV_GSO_SHORT_READ: LazyLock<Counter> =
+    LazyLock::new(|| counter!("tun_recv_gso_short_read"));
+
 /// Count iouring RX entries which complete with an error
+#[cfg(feature = "io-uring")]
 pub(crate) fn tun_iouring_rx_err() {
     METRIC_TUN_IOURING_RX_ERR.increment(1)
+}
+
+/// `Tun::recv_gso` returned a read shorter than a virtio header.
+/// Treated as a no-op for the iteration; the kernel likely truncated.
+#[cfg(target_os = "linux")]
+pub(crate) fn tun_recv_gso_short_read() {
+    METRIC_TUN_RECV_GSO_SHORT_READ.increment(1)
 }

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -316,9 +316,18 @@ impl Tun {
         }
     }
 
-    /// Raw read from `Tun`, returning the full virtio frame (header + payload).
+    /// Recv a GSO frame from `Tun` into `buf`, stripping and decoding the
+    /// leading `virtio_net_hdr`.
+    ///
+    /// On success `buf` holds the IP payload (header already advanced past)
+    /// and the returned tuple is `(buf.len(), hdr)`. Short reads and headers
+    /// that fail to decode are reported as [`IOCallbackResult::WouldBlock`] so
+    /// the caller's recv loop retries instead of treating them as hard errors.
     #[cfg(target_os = "linux")]
-    pub async fn recv_gso(&self, buf: &mut [u8]) -> IOCallbackResult<usize> {
+    pub async fn recv_gso(
+        &self,
+        buf: &mut BytesMut,
+    ) -> IOCallbackResult<(usize, lightway_core::VirtioNetHdr)> {
         match self {
             Tun::Direct(t) => t.recv_gso(buf).await,
             #[cfg(feature = "io-uring")]
@@ -433,18 +442,73 @@ impl TunDirect {
         }
     }
 
-    /// Raw read from Tun, returning the full virtio frame (header + payload).
+    /// Recv a GSO frame into `buf`. See [`Tun::recv_gso`] for the
+    /// buffer/result contract.
     #[cfg(target_os = "linux")]
-    pub async fn recv_gso(&self, buf: &mut [u8]) -> IOCallbackResult<usize> {
+    pub async fn recv_gso(
+        &self,
+        buf: &mut BytesMut,
+    ) -> IOCallbackResult<(usize, lightway_core::VirtioNetHdr)> {
+        use bytes::Buf;
+        use lightway_core::gso::VIRTIO_NET_HDR_LEN;
+
         let tun = self.tun.as_ref().unwrap();
-        match tun.recv(buf).await {
-            Ok(0) => IOCallbackResult::WouldBlock,
-            Ok(n) => IOCallbackResult::Ok(n),
+
+        // Read directly into the spare capacity. BytesMut's
+        // spare_capacity_mut returns &mut [MaybeUninit<u8>] so there's
+        // no zero-init pass on the hot path.
+        let spare = buf.spare_capacity_mut();
+        // SAFETY: `tun_rs::AsyncDevice::recv` takes `&mut [u8]` and forwards
+        // to `libc::read(2)`. The kernel only writes — it never dereferences
+        // userspace memory for reading — so handing it our uninitialized slab
+        // is sound at the syscall boundary. The unsoundness lives in *Rust*:
+        // constructing a `&mut [u8]` over uninitialized bytes is UB per strict
+        // aliasing rules, even if no one reads them. This cast is the only
+        // place we paper over that gap. Delete it once `tun-rs` exposes a
+        // `MaybeUninit`-aware recv.
+        #[allow(unsafe_code)]
+        let raw =
+            unsafe { std::slice::from_raw_parts_mut(spare.as_mut_ptr().cast::<u8>(), spare.len()) };
+
+        let n = match tun.recv(raw).await {
+            Ok(0) => return IOCallbackResult::WouldBlock,
+            Ok(n) => n,
             Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
-                IOCallbackResult::WouldBlock
+                return IOCallbackResult::WouldBlock;
             }
-            Err(err) => IOCallbackResult::Err(err),
+            Err(err) => return IOCallbackResult::Err(err),
+        };
+
+        if n <= VIRTIO_NET_HDR_LEN {
+            tracing::warn!(n, "tun recv_gso: read shorter than virtio header");
+            crate::metrics::tun_recv_gso_short_read();
+            // Discard the partial read (buf is untouched — no set_len)
+            // and return WouldBlock so the caller's recv loop retries
+            // immediately instead of treating this as a hard error.
+            return IOCallbackResult::WouldBlock;
         }
+
+        // SAFETY: the kernel wrote exactly `n` bytes into the spare
+        // slab; `n <= buf.capacity()` because the kernel wrote into a
+        // slice of that length.
+        #[allow(unsafe_code)]
+        unsafe {
+            buf.set_len(n);
+        }
+
+        // SAFETY for VirtioNetHdr::from_bytes: BytesMut is heap-backed
+        // and 8-byte aligned; `n > VIRTIO_NET_HDR_LEN` was just checked.
+        let hdr = match lightway_core::VirtioNetHdr::from_bytes(&buf[..VIRTIO_NET_HDR_LEN]) {
+            Ok(h) => *h,
+            Err(e) => {
+                tracing::warn!(?e, "tun recv_gso: virtio header decode failed");
+                buf.clear();
+                return IOCallbackResult::WouldBlock;
+            }
+        };
+        buf.advance(VIRTIO_NET_HDR_LEN);
+
+        IOCallbackResult::Ok((buf.len(), hdr))
     }
 
     /// Try write from Tun

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -49,6 +49,11 @@ pub struct TunConfig {
     #[cfg(unix)]
     #[educe(Default = true)]
     pub close_fd_on_drop: bool,
+    /// Enable TUN offload (`IFF_VNET_HDR`) so reads/writes carry a
+    /// `virtio_net_hdr` and the kernel performs GRO/GSO across the
+    /// device. Required for the GSO inside-IO path.
+    #[cfg(target_os = "linux")]
+    pub offload: bool,
     #[cfg(windows)]
     /// Optional wintun file path for Windows TUN interfaces
     pub wintun_file: Option<String>,
@@ -224,6 +229,10 @@ impl TunConfig {
             {
                 builder = builder.associate_route(false);
             }
+            #[cfg(target_os = "linux")]
+            if self.offload {
+                builder = builder.offload(true);
+            }
             let device = builder.build_async()?;
 
             if let Some(mtu) = self.mtu {
@@ -307,6 +316,18 @@ impl Tun {
         }
     }
 
+    /// Raw read from `Tun`, returning the full virtio frame (header + payload).
+    #[cfg(target_os = "linux")]
+    pub async fn recv_gso(&self, buf: &mut [u8]) -> IOCallbackResult<usize> {
+        match self {
+            Tun::Direct(t) => t.recv_gso(buf).await,
+            #[cfg(feature = "io-uring")]
+            Tun::IoUring(_) => {
+                IOCallbackResult::Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+            }
+        }
+    }
+
     /// Send a packet to `Tun`
     pub fn try_send(&self, buf: BytesMut) -> IOCallbackResult<usize> {
         match self {
@@ -363,6 +384,10 @@ pub struct TunDirect {
     fd: RawFd,
     #[cfg(unix)]
     close_fd_on_drop: bool,
+    /// `IFF_VNET_HDR` enabled — sends must be prefixed with a 12-byte
+    /// `virtio_net_hdr`, reads include it.
+    #[cfg(target_os = "linux")]
+    vnet_hdr: bool,
 }
 
 impl TunDirect {
@@ -385,6 +410,8 @@ impl TunDirect {
             fd,
             #[cfg(unix)]
             close_fd_on_drop: config.close_fd_on_drop,
+            #[cfg(target_os = "linux")]
+            vnet_hdr: config.offload,
         })
     }
 
@@ -406,10 +433,38 @@ impl TunDirect {
         }
     }
 
+    /// Raw read from Tun, returning the full virtio frame (header + payload).
+    #[cfg(target_os = "linux")]
+    pub async fn recv_gso(&self, buf: &mut [u8]) -> IOCallbackResult<usize> {
+        let tun = self.tun.as_ref().unwrap();
+        match tun.recv(buf).await {
+            Ok(0) => IOCallbackResult::WouldBlock,
+            Ok(n) => IOCallbackResult::Ok(n),
+            Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
+                IOCallbackResult::WouldBlock
+            }
+            Err(err) => IOCallbackResult::Err(err),
+        }
+    }
+
     /// Try write from Tun
     pub fn try_send(&self, buf: BytesMut) -> IOCallbackResult<usize> {
         let tun = self.tun.as_ref().unwrap();
-        match tun.try_send(&buf[..]) {
+        #[cfg(target_os = "linux")]
+        let res = if self.vnet_hdr {
+            // IFF_VNET_HDR requires a zeroed `virtio_net_hdr` prefix
+            // on every write (NEEDS_CSUM=0, GSO_NONE).
+            let hdr_len = tun_rs::VIRTIO_NET_HDR_LEN;
+            let mut prefixed = bytes::BytesMut::zeroed(hdr_len);
+            prefixed.extend_from_slice(&buf[..]);
+            tun.try_send(&prefixed[..])
+                .map(|n| n.saturating_sub(hdr_len))
+        } else {
+            tun.try_send(&buf[..])
+        };
+        #[cfg(not(target_os = "linux"))]
+        let res = tun.try_send(&buf[..]);
+        match res {
             Ok(nr) => IOCallbackResult::Ok(nr),
             Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
                 IOCallbackResult::WouldBlock

--- a/lightway-client/src/io/outside/tcp.rs
+++ b/lightway-client/src/io/outside/tcp.rs
@@ -92,6 +92,10 @@ impl OutsideIOSendCallback for Tcp {
         }
     }
 
+    fn send_gso(&self, _bufs: &[std::io::IoSlice<'_>], _gso_size: u16) -> IOCallbackResult<usize> {
+        IOCallbackResult::Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+    }
+
     fn peer_addr(&self) -> SocketAddr {
         self.peer_addr()
     }

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -207,6 +207,10 @@ impl OutsideIOSendCallback for Udp {
         }
     }
 
+    fn send_gso(&self, _bufs: &[std::io::IoSlice<'_>], _gso_size: u16) -> IOCallbackResult<usize> {
+        IOCallbackResult::Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+    }
+
     fn peer_addr(&self) -> SocketAddr {
         self.peer_addr()
     }

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -110,6 +110,13 @@ pub enum InvalidPacketError {
     /// Packet size greater than MAX_MTU
     #[error("Packet size greater than MAX_MTU")]
     InvalidPacketSize,
+
+    /// GSO superpacket failed validation (bad virtio_net_hdr,
+    /// per-segment build failure, etc.). The specific cause is
+    /// reflected in the `gso_dropped_*` and `gso_build_segment_failed`
+    /// metrics.
+    #[error("Invalid GSO superpacket")]
+    InvalidGsoPacket,
 }
 
 /// An error from an operation on a [`Connection`]
@@ -983,6 +990,215 @@ impl<AppState: Send> Connection<AppState> {
             // If no packet encoder presents, directly send to outside
             self.send_to_outside(pkt, false)
         }
+    }
+
+    /// Process a GSO superpacket as a single packet through the pipeline.
+    ///
+    /// Unlike `inside_data_received`, this skips the MTU check (the
+    /// superpacket is intentionally oversized) and `tcp_clamp_mss`
+    /// (GSO packets are never SYN). Plugins and encoder see the whole
+    /// superpacket as one packet.
+    #[cfg(target_os = "linux")]
+    pub fn inside_data_received_gso(
+        &mut self,
+        pkt: &mut BytesMut,
+        hdr: &crate::gso::VirtioNetHdr,
+    ) -> ConnectionResult<()> {
+        use ConnectionError::InvalidInsidePacket;
+        use InvalidPacketError::InvalidIpv4Packet;
+
+        if matches!(self.state, State::Disconnected) {
+            return Err(ConnectionError::Disconnected);
+        }
+
+        if !matches!(self.state, State::Online) {
+            return Err(ConnectionError::InvalidState);
+        }
+
+        let Some(inside_io) = &self.inside_io else {
+            return Err(ConnectionError::InvalidState);
+        };
+        let mtu = inside_io.mtu();
+
+        // No MTU check — GSO superpacket is intentionally oversized
+        if !ipv4_is_valid_packet(pkt.as_ref()) {
+            return Err(InvalidInsidePacket(InvalidIpv4Packet));
+        }
+
+        let _ = self.rotate_expresslane_key();
+
+        // No tcp_clamp_mss — GSO packets are never SYN
+
+        // Plugins see the whole superpacket as one packet
+        match self.inside_plugins.do_ingress(pkt) {
+            PluginResult::Accept => {}
+            PluginResult::Drop => {
+                return Ok(());
+            }
+            PluginResult::DropWithReply(b) => {
+                return Err(ConnectionError::PluginDropWithReply(b));
+            }
+            PluginResult::Error(e) => {
+                return Err(ConnectionError::PluginError(e));
+            }
+        }
+
+        // Encoder sees the whole superpacket
+        if let Some(encoder) = &mut self.inside_pkt_encoder {
+            let codec_state = encoder.store(pkt);
+            match codec_state {
+                Ok(CodecStatus::PacketAccepted) => return Ok(()),
+                Ok(CodecStatus::SkipPacket) => {}
+                Err(e) => return Err(ConnectionError::PacketCodecError(e)),
+            }
+        }
+
+        self.send_to_outside_gso(pkt, hdr, mtu)
+    }
+
+    /// Split a GSO superpacket into segments, encrypt each, and send
+    /// the entire wire buffer as one `sendmsg` with `UDP_SEGMENT`.
+    ///
+    /// For expresslane: encrypts with AES-GCM, frames via `udp_frame`,
+    /// collects into wire buffer.
+    ///
+    /// For DTLS: `send_frame_or_drop` triggers wolfssl `try_write` which
+    /// calls the IO callback `send()`. The IO callback detects the
+    /// open `GsoBuffer` batch and coalesces framed wire packets there
+    /// instead of sending.
+    #[cfg(target_os = "linux")]
+    fn send_to_outside_gso(
+        &mut self,
+        pkt: &mut BytesMut,
+        hdr: &crate::gso::VirtioNetHdr,
+        mtu: usize,
+    ) -> ConnectionResult<()> {
+        use crate::gso;
+
+        // Parse the protocol header length from the packet itself. We
+        // can't trust `hdr.hdr_len` — Linux's TUN puts `skb_headlen`
+        // (~MTU for multi-segment aggregates) there, not the protocol
+        // header length the virtio-net spec calls for.
+        let hdr_len = match gso::calc_hdr_len(pkt.as_ref()) {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(
+                    ?e,
+                    pkt_len = pkt.len(),
+                    "cannot parse hdr_len in superpacket, dropping"
+                );
+                crate::metrics::gso_dropped_invalid_hdr_len(e.metric_reason());
+                return Err(ConnectionError::InvalidInsidePacket(
+                    InvalidPacketError::InvalidGsoPacket,
+                ));
+            }
+        };
+
+        // Kernel-supplied gso_size of 0 would div-by-zero in
+        // calc_gso_segs and produce a degenerate single segment in
+        // build_segment. Treat as an invalid aggregate.
+        if hdr.gso_size == 0 {
+            tracing::warn!("invalid gso_size = 0 in superpacket, dropping");
+            crate::metrics::gso_dropped_zero_gso_size();
+            return Err(ConnectionError::InvalidInsidePacket(
+                InvalidPacketError::InvalidGsoPacket,
+            ));
+        }
+
+        let gso_segs = gso::calc_gso_segs(pkt.len(), hdr_len, hdr.gso_size as usize);
+        if gso_segs == 0 {
+            return Ok(());
+        }
+
+        if gso_segs > gso::MAX_GSO_SEGS {
+            tracing::warn!(
+                gso_segs,
+                MAX_GSO_SEGS = gso::MAX_GSO_SEGS,
+                "too many segments in superpacket, dropping"
+            );
+            crate::metrics::gso_dropped_iov_overflow();
+            return Err(ConnectionError::InvalidInsidePacket(
+                InvalidPacketError::InvalidGsoPacket,
+            ));
+        }
+
+        // Per-segment MTU guard: when TUN_F_TSO4 is enabled the kernel
+        // hands us GSO aggregates without enforcing per-segment MTU.
+        // If anything upstream (TS-unaware MSS, missing MSS clamp, a
+        // forwarding fastpath that skipped ip_finish_output_gso) put a
+        // segment in here larger than the tunnel can carry, drop the
+        // aggregate to avoid the build_segment slice overflow.
+        let seg_size = hdr_len + hdr.gso_size as usize;
+        if seg_size > mtu {
+            tracing::warn!(
+                hdr_len,
+                gso_size = hdr.gso_size,
+                mtu,
+                "header-wrapped segment exceeds tunnel MTU, dropping"
+            );
+            crate::metrics::gso_dropped_oversized_segment();
+            return Err(ConnectionError::InvalidInsidePacket(
+                InvalidPacketError::InvalidGsoPacket,
+            ));
+        }
+
+        let expresslane = self.expresslane_ready();
+
+        // One reusable segment buffer. `build_segment` calls `clear()`
+        // and then `extend_from_slice` to materialize the segment, so
+        // we only need capacity here — no zero-init.
+        let mut segment = BytesMut::with_capacity(mtu);
+
+        // Open the GSO coalescing buffer — IO callback will coalesce
+        // here. Both DTLS and expresslane paths detect this and
+        // append encrypted segments instead of sending immediately.
+        self.session.io_cb_mut().gso_buf.open();
+
+        let mut result = Ok(());
+
+        for i in 0..gso_segs {
+            if let Err(e) = gso::build_segment(hdr, hdr_len, pkt.as_ref(), i, &mut segment) {
+                tracing::warn!(
+                    ?e,
+                    gso_idx = i,
+                    csum_start = hdr.csum_start,
+                    hdr_len,
+                    "GSO build_segment header parse failed"
+                );
+                crate::metrics::gso_build_segment_failed(e.metric_reason());
+                // Abort the whole batch — UDP_SEGMENT requires
+                // uniform-stride segments, so we can't ship a partial
+                // aggregate.
+                result = Err(ConnectionError::InvalidInsidePacket(
+                    InvalidPacketError::InvalidGsoPacket,
+                ));
+                break;
+            }
+
+            if let Err(e) = self.send_outside_data(&mut segment, false) {
+                result = Err(e);
+                break;
+            }
+        }
+
+        if result.is_ok() {
+            self.activity.last_data_traffic_from_peer = Instant::now();
+            match self.session.io_cb_mut().udp_send_gso(gso_segs, expresslane) {
+                IOCallbackResult::Ok(_) | IOCallbackResult::WouldBlock => {}
+                IOCallbackResult::Err(e) => {
+                    tracing::warn!(error = %e, gso_segs, "udp_send_gso failed");
+                    crate::metrics::gso_send_failed();
+                }
+            }
+        }
+
+        // Always reset the GSO coalescing buffer on exit. udp_send_gso
+        // borrows it; this returns to Passthrough and clears the
+        // bytes in place so the underlying allocation is reused on
+        // the next batch.
+        self.session.io_cb_mut().gso_buf.reset();
+
+        result
     }
 
     /// Send a packet to the outside

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -1891,9 +1891,13 @@ impl<AppState: Send> Connection<AppState> {
             .append_to_wire(&mut buf, session_id, data.as_ref(), iv, is_encoded);
         self.activity.last_data_traffic_from_peer = Instant::now();
 
-        match self.session.io_cb().udp_send(buf.as_ref(), true) {
-            IOCallbackResult::Ok(_) => ConnectionResult::Ok(()),
-            IOCallbackResult::WouldBlock => ConnectionResult::Ok(()),
+        // `udp_send` coalesces into the per-connection `GsoBuffer`
+        // when a batch has been opened by an upstream `gso_buf.open()`
+        // (currently only `send_to_outside_gso`), or wraps + sends
+        // immediately otherwise. Both branches hand the same shape
+        // of bytes to `udp_send_gso` at flush time.
+        match self.session.io_cb_mut().udp_send(buf.as_ref(), true) {
+            IOCallbackResult::Ok(_) | IOCallbackResult::WouldBlock => ConnectionResult::Ok(()),
             IOCallbackResult::Err(_e) => ConnectionResult::Err(ConnectionError::AccessDenied),
         }
     }

--- a/lightway-core/src/connection/builders.rs
+++ b/lightway-core/src/connection/builders.rs
@@ -88,6 +88,8 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
             io: outside_io,
             session_id: SessionId::EMPTY,
             outside_plugins: outside_plugins.clone(),
+            #[cfg(target_os = "linux")]
+            gso_buf: super::io_adapter::GsoBuffer::default(),
         };
         let session_config =
             crate::tls::SessionConfig::new(io).when(connection_type.is_datagram(), |s| {
@@ -323,6 +325,8 @@ impl<'a, AppState: Send + 'static> ServerConnectionBuilder<'a, AppState> {
             io: outside_io,
             session_id,
             outside_plugins: outside_plugins.clone(),
+            #[cfg(target_os = "linux")]
+            gso_buf: super::io_adapter::GsoBuffer::default(),
         };
         let session_config =
             crate::tls::SessionConfig::new(io).when(connection_type.is_datagram(), |s| {

--- a/lightway-core/src/connection/io_adapter.rs
+++ b/lightway-core/src/connection/io_adapter.rs
@@ -355,6 +355,14 @@ mod tests {
             }
         }
 
+        fn send_gso(
+            &self,
+            _bufs: &[std::io::IoSlice<'_>],
+            _gso_size: u16,
+        ) -> IOCallbackResult<usize> {
+            IOCallbackResult::Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+        }
+
         fn peer_addr(&self) -> std::net::SocketAddr {
             std::unreachable!("Should not be testing peer_addr");
         }

--- a/lightway-core/src/connection/io_adapter.rs
+++ b/lightway-core/src/connection/io_adapter.rs
@@ -1,3 +1,5 @@
+#[cfg(any(target_os = "linux", test))]
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use bytes::{Buf, BytesMut};
@@ -9,6 +11,91 @@ use crate::tls::IOCallbackResult;
 use crate::{
     ConnectionType, OutsideIOSendCallbackArg, PluginResult, Version, plugin::PluginList, wire,
 };
+
+/// Per-connection UDP GSO coalescing buffer + batch state.
+#[cfg(any(target_os = "linux", test))]
+#[derive(Default)]
+pub(crate) struct GsoBuffer {
+    /// Coalescing buffer for the current GSO frame. Retained across
+    /// batches — `clear()`ed on reset, never dropped — so the
+    /// allocation is reused for the connection's lifetime. Starts
+    /// (and stays, on connections that never coalesce) zero-capacity,
+    /// costing only the `BytesMut` struct.
+    buf: BytesMut,
+    state: GsoBufferState,
+}
+
+/// State of the in-progress GSO batch.
+#[cfg(any(target_os = "linux", test))]
+#[derive(Default)]
+enum GsoBufferState {
+    /// Not coalescing — `udp_send` passes a single datagram straight
+    /// to the socket (cf. a non-GSO skb, `gso_size == 0`).
+    #[default]
+    Passthrough,
+    /// Batch open, awaiting the first segment; `gso_size` not yet
+    /// established.
+    Pending,
+    /// First segment fixed `gso_size`; later segments coalesce at
+    /// this stride for `UDP_SEGMENT`.
+    Coalescing(NonZeroUsize),
+}
+
+#[cfg(any(target_os = "linux", test))]
+impl GsoBuffer {
+    /// Open a GSO batch. Reserves worst-case capacity on first call;
+    /// subsequent calls are a no-op on the underlying allocation.
+    pub(crate) fn open(&mut self) {
+        debug_assert!(matches!(self.state, GsoBufferState::Passthrough));
+        self.buf.reserve(crate::gso::MAX_GSO_FRAME_BYTES);
+        self.state = GsoBufferState::Pending;
+    }
+
+    /// True iff a batch is open (state ≠ Passthrough). `udp_send`
+    /// uses this to dispatch between coalescing and pass-through.
+    pub(crate) fn is_batching(&self) -> bool {
+        !matches!(self.state, GsoBufferState::Passthrough)
+    }
+
+    /// Append one encrypted segment to the frame — echoes `skb_put`.
+    ///
+    /// The first segment fixes `gso_size`; every later segment must
+    /// be `<= gso_size`, a shorter one being the final datagram. A
+    /// non-final segment shorter than `gso_size` would misalign the
+    /// kernel's slicing.
+    pub(crate) fn put(&mut self, seg: &[u8]) {
+        match self.state {
+            GsoBufferState::Passthrough => unreachable!("put before open"),
+            GsoBufferState::Pending => {
+                let Some(gso_size) = NonZeroUsize::new(seg.len()) else {
+                    unreachable!("zero-length first GSO segment")
+                };
+                self.state = GsoBufferState::Coalescing(gso_size);
+            }
+            GsoBufferState::Coalescing(gso_size) => {
+                debug_assert!(seg.len() <= gso_size.get())
+            }
+        }
+        self.buf.extend_from_slice(seg);
+    }
+
+    /// The assembled frame and its `gso_size` for the `UDP_SEGMENT`
+    /// sendmsg, or `None` if nothing was coalesced (Passthrough or
+    /// Pending). Does not reset — call `reset` after the send.
+    pub(crate) fn frame(&self) -> Option<(&[u8], NonZeroUsize)> {
+        match self.state {
+            GsoBufferState::Coalescing(gso_size) => Some((&self.buf[..], gso_size)),
+            _ => None,
+        }
+    }
+
+    /// Clear the frame and return to `Passthrough`, keeping `buf`'s
+    /// capacity.
+    pub(crate) fn reset(&mut self) {
+        self.buf.clear();
+        self.state = GsoBufferState::Passthrough;
+    }
+}
 
 pub(crate) struct SendBuffer {
     data: BytesMut,
@@ -100,6 +187,12 @@ pub(crate) struct TlsIOAdapter {
     /// This buffer will be used to save the remaining data, to be sent in next call.
     pub(crate) send_buf: SendBuffer,
 
+    /// Per-connection UDP GSO coalescing buffer + batch state. On
+    /// connections that never see GSO, this stays zero-capacity and
+    /// costs only the `GsoBuffer` struct (no heap).
+    #[cfg(target_os = "linux")]
+    pub(crate) gso_buf: GsoBuffer,
+
     /// Application provided object used to send data.
     pub(crate) io: OutsideIOSendCallbackArg,
 
@@ -136,7 +229,23 @@ impl TlsIOAdapter {
         }
     }
 
-    pub(crate) fn udp_send(&self, buf: &[u8], expresslane_data: bool) -> IOCallbackResult<usize> {
+    pub(crate) fn udp_send(
+        &mut self,
+        buf: &[u8],
+        expresslane_data: bool,
+    ) -> IOCallbackResult<usize> {
+        // GSO buffering: when a batch is open, coalesce the raw
+        // post-encrypt, pre-`wire::Header` bytes; `udp_send_gso` will
+        // later wrap each segment with `wire::Header` and flush via
+        // `sendmsg(UDP_SEGMENT)`. Both DTLS and expresslane callers
+        // hand us bytes in the same shape (post-encrypt, no header),
+        // so this branch covers both.
+        #[cfg(target_os = "linux")]
+        if self.gso_buf.is_batching() {
+            self.gso_buf.put(buf);
+            return IOCallbackResult::Ok(buf.len());
+        }
+
         // Prepend our `wire::Header` to the data we've been asked to
         // send.
         let h = wire::Header {
@@ -203,6 +312,115 @@ impl TlsIOAdapter {
             wb @ IOCallbackResult::WouldBlock => wb,
             err @ IOCallbackResult::Err(_) => err,
         }
+    }
+
+    /// Take the raw encrypted segments coalesced in `self.gso_buf`,
+    /// wrap each with `wire::Header` (+ plugins), and send as one
+    /// `sendmsg` with `UDP_SEGMENT`. The caller is responsible for
+    /// calling `gso_buf.reset()` after this returns.
+    ///
+    /// When no outside plugins are configured, the encrypted payload
+    /// is sent zero-copy: the kernel gathers a shared header buffer
+    /// and slices of `tun_buf` via `iovec`, with no intermediate copy
+    /// of the segment bytes.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn udp_send_gso(
+        &mut self,
+        gso_segs: usize,
+        expresslane_data: bool,
+    ) -> IOCallbackResult<usize> {
+        use std::io::{Error, IoSlice};
+
+        // No coalesced frame yet — caller's `gso.reset()` cleanup
+        // path runs unconditionally, so this is also the safe exit
+        // when nothing was buffered.
+        let Some((tun_buf, tun_gso_size)) = self.gso_buf.frame() else {
+            return IOCallbackResult::Ok(0);
+        };
+        let tun_gso_size = tun_gso_size.get();
+
+        if gso_segs == 0 {
+            return IOCallbackResult::Ok(0);
+        }
+
+        // Same Lightway header for every segment.
+        let hdr = wire::Header {
+            version: self.protocol_version,
+            aggressive_mode: false,
+            expresslane_data,
+            session: self.session_id,
+        };
+        let mut hdr_buf = BytesMut::with_capacity(wire::Header::WIRE_SIZE);
+        hdr.append_to_wire(&mut hdr_buf);
+
+        // Fast path: no outside plugins. Segments are not mutated, so
+        // we scatter-gather via iovec — shared header buffer plus
+        // borrowed slices of `tun_buf`, zero payload copies.
+        if self.outside_plugins.is_empty() {
+            let stride = (wire::Header::WIRE_SIZE + tun_gso_size) as u16;
+            let mut iovs: Vec<IoSlice<'_>> = Vec::with_capacity(gso_segs * 2);
+            for i in 0..gso_segs {
+                let start = i * tun_gso_size;
+                let end = ((i + 1) * tun_gso_size).min(tun_buf.len());
+                iovs.push(IoSlice::new(&hdr_buf[..]));
+                iovs.push(IoSlice::new(&tun_buf[start..end]));
+            }
+            return self.io.send_gso(&iovs, stride);
+        }
+
+        // Plugin path: each segment is built into its own BytesMut so
+        // plugins can freely mutate it. The Vec<BytesMut> outlives the
+        // Vec<IoSlice> built from it, so the borrows are sound.
+        let mut segs: Vec<BytesMut> = Vec::with_capacity(gso_segs);
+        let mut wire_gso_size: Option<usize> = None;
+
+        for i in 0..gso_segs {
+            let start = i * tun_gso_size;
+            let end = ((i + 1) * tun_gso_size).min(tun_buf.len());
+            debug_assert_le!(start, end);
+
+            let mut seg = BytesMut::with_capacity(self.outside_mtu);
+            seg.extend_from_slice(&hdr_buf[..]);
+            seg.extend_from_slice(&tun_buf[start..end]);
+
+            match self.outside_plugins.do_egress(&mut seg) {
+                PluginResult::Accept => {}
+                PluginResult::Drop | PluginResult::DropWithReply(_) => continue,
+                PluginResult::Error(e) => {
+                    return IOCallbackResult::Err(Error::other(e));
+                }
+            }
+
+            // UDP_SEGMENT requires every segment except the last to
+            // have identical stride.
+            let is_last = i == gso_segs - 1;
+            match wire_gso_size {
+                None => wire_gso_size = Some(seg.len()),
+                Some(s) if !is_last && seg.len() != s => {
+                    return IOCallbackResult::Err(Error::other(
+                        "outside plugins produced non-uniform GSO segment size",
+                    ));
+                }
+                Some(s) if is_last && seg.len() > s => {
+                    return IOCallbackResult::Err(Error::other(
+                        "outside plugins produced oversized trailing GSO segment",
+                    ));
+                }
+                _ => {}
+            }
+
+            segs.push(seg);
+        }
+
+        // All segments dropped by plugins — nothing to put on the wire,
+        // but report success for the inside bytes the caller handed us.
+        if segs.is_empty() {
+            return IOCallbackResult::Ok(tun_buf.len());
+        }
+
+        let stride = wire_gso_size.unwrap_or(0) as u16;
+        let iovs: Vec<IoSlice<'_>> = segs.iter().map(|s| IoSlice::new(&s[..])).collect();
+        self.io.send_gso(&iovs, stride)
     }
 
     // In general, TCP send can succeed even for partial data and the caller
@@ -383,6 +601,8 @@ mod tests {
             io,
             session_id: SessionId::from_const(*b"\xde\xad\xbe\xef\xde\xad\xbe\xef"),
             outside_plugins: outside_plugins.into(),
+            #[cfg(target_os = "linux")]
+            gso_buf: GsoBuffer::default(),
         }
     }
 
@@ -392,7 +612,7 @@ mod tests {
     fn udp_send_plugin(r: PluginResult) -> IOCallbackResult<usize> {
         let plugins: Vec<crate::PluginType> = vec![OneshotFakePlugin::new(r)];
         let plugins = PluginList::from(plugins);
-        let a = make_adapter(ConnectionType::Datagram, FakeOutsideIOSend::new(), plugins);
+        let mut a = make_adapter(ConnectionType::Datagram, FakeOutsideIOSend::new(), plugins);
         a.udp_send(b"abc", false)
     }
 
@@ -403,7 +623,7 @@ mod tests {
     #[test_case(vec![IOCallbackResult::Err(Error::other("ERR"))] => matches(IOCallbackResult::Err(e), v) if e.to_string() == "ERR" && v.is_empty(); "error")]
     fn udp_send_io(fakes: Vec<IOCallbackResult<usize>>) -> (IOCallbackResult<usize>, Vec<u8>) {
         let io = FakeOutsideIOSend::with_fakes(fakes.into());
-        let a = make_adapter(ConnectionType::Datagram, io.clone(), Default::default());
+        let mut a = make_adapter(ConnectionType::Datagram, io.clone(), Default::default());
         let r = a.udp_send(b"abcdefghi", false);
 
         let (fakes, sent) = &*io.0.lock().unwrap();
@@ -569,5 +789,113 @@ mod tests {
         assert_eq!(buf.original_len(), 0);
         assert_eq!(buf.actual_len(), 0);
         assert_eq!(buf.data.capacity(), buf.total_capacity);
+    }
+
+    #[test]
+    fn gso_default_is_passthrough() {
+        let g = GsoBuffer::default();
+        assert!(!g.is_batching());
+        assert!(g.frame().is_none());
+        assert_eq!(g.buf.capacity(), 0);
+    }
+
+    #[test]
+    fn gso_open_transitions_to_pending() {
+        let mut g = GsoBuffer::default();
+        g.open();
+        assert!(g.is_batching());
+        assert!(g.frame().is_none());
+        assert!(g.buf.capacity() >= crate::gso::MAX_GSO_FRAME_BYTES);
+    }
+
+    #[test]
+    fn gso_put_fixes_stride() {
+        let mut g = GsoBuffer::default();
+        g.open();
+        g.put(&[0xAB; 1280]);
+
+        let (bytes, stride) = g.frame().expect("Coalescing");
+        assert_eq!(bytes.len(), 1280);
+        assert_eq!(stride.get(), 1280);
+        assert!(bytes.iter().all(|&b| b == 0xAB));
+    }
+
+    #[test]
+    fn gso_put_appends_subsequent_segments() {
+        let mut g = GsoBuffer::default();
+        g.open();
+        g.put(&[0xAA; 1280]);
+        g.put(&[0xBB; 1280]);
+
+        let (bytes, stride) = g.frame().expect("Coalescing");
+        assert_eq!(bytes.len(), 2560);
+        assert_eq!(stride.get(), 1280);
+        assert!(bytes[..1280].iter().all(|&b| b == 0xAA));
+        assert!(bytes[1280..].iter().all(|&b| b == 0xBB));
+    }
+
+    #[test]
+    fn gso_put_allows_shorter_trailing() {
+        let mut g = GsoBuffer::default();
+        g.open();
+        g.put(&[0xAA; 1280]);
+        g.put(&[0xBB; 800]);
+
+        let (bytes, stride) = g.frame().expect("Coalescing");
+        assert_eq!(bytes.len(), 1280 + 800);
+        assert_eq!(stride.get(), 1280);
+    }
+
+    #[test]
+    fn gso_reset_clears_state_keeps_capacity() {
+        let mut g = GsoBuffer::default();
+        g.open();
+        g.put(&[0xAA; 1280]);
+        let cap_before = g.buf.capacity();
+        g.reset();
+
+        assert!(!g.is_batching());
+        assert!(g.frame().is_none());
+        assert_eq!(g.buf.len(), 0);
+        assert_eq!(g.buf.capacity(), cap_before);
+        assert!(g.buf.capacity() >= crate::gso::MAX_GSO_FRAME_BYTES);
+    }
+
+    #[test]
+    fn gso_open_then_reset_then_open_reuses_buf() {
+        let mut g = GsoBuffer::default();
+        g.open();
+        let cap_after_first_open = g.buf.capacity();
+        g.put(&[0xAA; 1280]);
+        g.reset();
+
+        g.open();
+        assert_eq!(g.buf.capacity(), cap_after_first_open);
+        assert!(g.is_batching());
+    }
+
+    #[test]
+    #[should_panic(expected = "put before open")]
+    fn gso_put_without_open_panics() {
+        let mut g = GsoBuffer::default();
+        g.put(&[0xAA; 1280]);
+    }
+
+    #[test]
+    #[should_panic(expected = "zero-length first GSO segment")]
+    fn gso_put_zero_length_first_segment_panics() {
+        let mut g = GsoBuffer::default();
+        g.open();
+        g.put(&[]);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic]
+    fn gso_put_oversized_segment_debug_asserts() {
+        let mut g = GsoBuffer::default();
+        g.open();
+        g.put(&[0xAA; 1280]);
+        g.put(&[0xBB; 1281]);
     }
 }

--- a/lightway-core/src/gso.rs
+++ b/lightway-core/src/gso.rs
@@ -173,6 +173,24 @@ pub(crate) enum GsoHdrError {
     UnsupportedL4Proto(u8),
 }
 
+impl GsoHdrError {
+    /// Stable, low-cardinality label used as the `reason` field of the
+    /// `gso_dropped_invalid_hdr_len` counter. Production has no
+    /// datapath logs, so this label is the only way to distinguish
+    /// failure modes.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn metric_reason(&self) -> &'static str {
+        match self {
+            Self::Empty => "empty",
+            Self::Truncated { stage } => stage,
+            Self::UnsupportedIpVersion(_) => "unsupported_ip_version",
+            Self::BadIpv4Ihl => "bad_ipv4_ihl",
+            Self::BadTcpDataOffset => "bad_tcp_data_offset",
+            Self::UnsupportedL4Proto(_) => "unsupported_l4_proto",
+        }
+    }
+}
+
 /// Why `build_segment` could not produce one wire-format segment.
 ///
 /// Each variant corresponds to a `pnet_packet` constructor returning

--- a/lightway-core/src/gso.rs
+++ b/lightway-core/src/gso.rs
@@ -1,0 +1,753 @@
+//! GSO (Generic Segmentation Offload) segment fixup functions.
+//!
+//! When a GSO superpacket is processed as a single packet through
+//! plugins/encoder, the individual segments need per-segment header
+//! fixups (IP ID, TCP seq, checksums) before encryption and wire send.
+//!
+//! All functions take `&VirtioNetHdr` directly for metadata.
+
+/// Virtio network header for GSO/checksum offload.
+///
+/// This is a local copy of the kernel `virtio_net_hdr` structure, since
+/// tun-rs defines this type internally but does not re-export it.
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct VirtioNetHdr {
+    /// Flags (e.g. VIRTIO_NET_HDR_F_NEEDS_CSUM).
+    pub flags: u8,
+    /// GSO type (e.g. GSO_NONE, GSO_TCPV4, GSO_TCPV6, GSO_UDP_L4).
+    pub gso_type: u8,
+    /// Ethernet + IP + transport header length in bytes.
+    pub hdr_len: u16,
+    /// Bytes per GSO segment (payload only).
+    pub gso_size: u16,
+    /// Offset from packet start where checksum computation begins.
+    pub csum_start: u16,
+    /// Offset from csum_start to the checksum field.
+    pub csum_offset: u16,
+}
+
+/// Size of the VirtioNetHdr in bytes.
+pub const VIRTIO_NET_HDR_LEN: usize = std::mem::size_of::<VirtioNetHdr>();
+
+/// GSO type: not a GSO frame.
+pub const VIRTIO_NET_HDR_GSO_NONE: u8 = 0;
+/// Flag: checksum needs to be computed.
+pub const VIRTIO_NET_HDR_F_NEEDS_CSUM: u8 = 1;
+
+/// Maximum number of segments in a single UDP GSO superpacket —
+/// matches the kernel's `UDP_MAX_SEGMENTS` (`1 << 6`); a `sendmsg`
+/// with `UDP_SEGMENT` and more than this is rejected with `EINVAL`.
+pub(crate) const MAX_GSO_SEGS: usize = 64;
+
+/// Upper bound on the bytes a single GSO coalescing buffer can hold:
+/// `MAX_GSO_SEGS` segments, each at most `MAX_OUTSIDE_MTU`.
+pub(crate) const MAX_GSO_FRAME_BYTES: usize = MAX_GSO_SEGS * crate::MAX_OUTSIDE_MTU;
+
+impl VirtioNetHdr {
+    /// Interpret the first [`VIRTIO_NET_HDR_LEN`] bytes of `buf` as a
+    /// `&VirtioNetHdr` without copying.
+    ///
+    /// Returns `Err(InvalidInput)` if `buf` is shorter than
+    /// `VIRTIO_NET_HDR_LEN` or not 2-byte aligned.
+    #[allow(unsafe_code)]
+    pub fn from_bytes(buf: &[u8]) -> std::io::Result<&Self> {
+        if buf.len() < VIRTIO_NET_HDR_LEN {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "buffer too short for VirtioNetHdr",
+            ));
+        }
+        let ptr = buf.as_ptr();
+        if ptr.align_offset(std::mem::align_of::<VirtioNetHdr>()) != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "buffer not aligned for VirtioNetHdr",
+            ));
+        }
+        // SAFETY: We verified length and alignment. VirtioNetHdr is repr(C)
+        // with no padding, and the returned lifetime is tied to `buf`.
+        unsafe { Ok(&*(ptr as *const VirtioNetHdr)) }
+    }
+
+    /// True if `gso_type` indicates a TCP segmentation aggregate (v4 or v6).
+    ///
+    /// Linux ORs `VIRTIO_NET_HDR_GSO_ECN` (0x80) into `gso_type` for
+    /// ECN-marked flows, so a TCPv4 ECN aggregate has `gso_type =
+    /// 0x81`. Mask the ECN bit before comparing.
+    pub fn is_tcp(&self) -> bool {
+        let base = self.gso_type & !VIRTIO_NET_HDR_GSO_ECN;
+        base == VIRTIO_NET_HDR_GSO_TCPV4 || base == VIRTIO_NET_HDR_GSO_TCPV6
+    }
+}
+
+/// Compute and fill the transport-layer checksum for a non-GSO packet
+/// that has `VIRTIO_NET_HDR_F_NEEDS_CSUM` set.
+///
+/// The kernel deposits the pseudo-header partial sum (src + dst + proto + len)
+/// at `[csum_start + csum_offset]` before delivering the packet.
+/// We seed our sum with that value, then sum from `csum_start` and complement.
+pub fn gso_none_checksum(buf: &mut [u8], csum_start: u16, csum_offset: u16) {
+    let start = csum_start as usize;
+    let offset = csum_offset as usize;
+    let at = start + offset;
+    if at + 2 > buf.len() || start > buf.len() {
+        tracing::warn!(
+            buf_len = buf.len(),
+            csum_start,
+            csum_offset,
+            "csum_start/offset outside buffer, cannot write checksum"
+        );
+        crate::metrics::gso_none_checksum_skipped();
+        return;
+    }
+
+    // Read the kernel-deposited pseudo-header partial, then zero the
+    // field so it doesn't double-count when we sum the segment.
+    let initial = read_u16(&buf[at..at + 2]) as u64;
+    buf[at] = 0;
+    buf[at + 1] = 0;
+
+    let csum = !checksum(&buf[start..], initial);
+    buf[at] = (csum >> 8) as u8;
+    buf[at + 1] = csum as u8;
+}
+
+// Internet checksum used only by `gso_none_checksum` below — the
+// build_segment path uses pnet_packet's protocol-aware helpers.
+#[inline]
+fn read_u16(b: &[u8]) -> u16 {
+    u16::from_be_bytes(b[..2].try_into().unwrap())
+}
+
+// One's-complement folded checksum with a kernel-seeded initial value.
+// The inner loop unrolls to read 8 bytes per iteration; on x86_64
+// release LLVM auto-vectorizes the resulting straight-line code.
+#[inline]
+fn checksum(mut b: &[u8], initial: u64) -> u16 {
+    let mut acc = initial;
+    while b.len() >= 8 {
+        acc += u32::from_be_bytes(b[..4].try_into().unwrap()) as u64;
+        acc += u32::from_be_bytes(b[4..8].try_into().unwrap()) as u64;
+        b = &b[8..];
+    }
+    if b.len() >= 4 {
+        acc += u32::from_be_bytes(b[..4].try_into().unwrap()) as u64;
+        b = &b[4..];
+    }
+    if b.len() >= 2 {
+        acc += read_u16(&b[..2]) as u64;
+        b = &b[2..];
+    }
+    if let Some(&byte) = b.first() {
+        acc += (byte as u64) << 8;
+    }
+    while acc > 0xFFFF {
+        acc = (acc >> 16) + (acc & 0xFFFF);
+    }
+    acc as u16
+}
+
+/// GSO type: TCP segmentation aggregate over IPv4.
+const VIRTIO_NET_HDR_GSO_TCPV4: u8 = 1;
+/// GSO type: TCP segmentation aggregate over IPv6.
+const VIRTIO_NET_HDR_GSO_TCPV6: u8 = 4;
+/// ECN flag OR'd into `gso_type` for ECN-marked aggregates.
+const VIRTIO_NET_HDR_GSO_ECN: u8 = 0x80;
+
+/// Why `calc_hdr_len` could not decode the protocol header length.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GsoHdrError {
+    /// Buffer was empty.
+    Empty,
+    /// Buffer was shorter than the named header (e.g. `"ipv4_hdr"`,
+    /// `"ipv6_hdr"`, `"tcp_hdr"`).
+    Truncated { stage: &'static str },
+    /// IP version is neither 4 nor 6.
+    UnsupportedIpVersion(u8),
+    /// IPv4 IHL field encoded a header length smaller than the minimum.
+    BadIpv4Ihl,
+    /// TCP Data Offset field encoded a header length smaller than the minimum.
+    BadTcpDataOffset,
+    /// Layer-4 protocol is neither TCP nor UDP.
+    UnsupportedL4Proto(u8),
+}
+
+/// Why `build_segment` could not produce one wire-format segment.
+///
+/// Each variant corresponds to a `pnet_packet` constructor returning
+/// `None` (or, for [`Self::Tcp`], the TCP sequence-number slice in
+/// `gso_pkt` falling out of bounds). The kernel violated the
+/// invariant that `virtio_net_hdr.csum_start` and `hdr_len` match
+/// the actual packet bytes — typically a truncated header in the
+/// GSO aggregate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GsoSegError {
+    /// Superpacket buffer was empty.
+    Empty,
+    /// IPv4 header parse failed.
+    Ipv4,
+    /// IPv6 header parse failed.
+    Ipv6,
+    /// TCP header parse failed (or `gso_pkt` shorter than
+    /// `csum_start + 8` when reading the first sequence number).
+    Tcp,
+    /// UDP header parse failed.
+    Udp,
+}
+
+impl GsoSegError {
+    /// Stable, low-cardinality label for the `reason` field of the
+    /// `gso_build_segment_failed` counter.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn metric_reason(&self) -> &'static str {
+        match self {
+            Self::Empty => "empty",
+            Self::Ipv4 => "ipv4_parse",
+            Self::Ipv6 => "ipv6_parse",
+            Self::Tcp => "tcp_parse",
+            Self::Udp => "udp_parse",
+        }
+    }
+}
+
+/// Compute the protocol-header length (IP + transport) from an IPv4/IPv6 packet.
+///
+/// Linux's TUN driver writes `skb_headlen` (a hint about linearity) into
+/// `virtio_net_hdr.hdr_len` — NOT the protocol header length the virtio-net
+/// spec calls for. For multi-segment GSO aggregates the linearity hint is
+/// roughly the size of the first segment (≈ MTU), not the headers, so any
+/// code that copies a per-segment header template based on `vhdr.hdr_len`
+/// will get a wildly wrong value. Parse the real length from the packet.
+pub(crate) fn calc_hdr_len(pkt: &[u8]) -> Result<usize, GsoHdrError> {
+    use pnet_packet::ip::IpNextHeaderProtocols;
+    use pnet_packet::ipv4::Ipv4Packet;
+    use pnet_packet::tcp::TcpPacket;
+
+    if pkt.is_empty() {
+        return Err(GsoHdrError::Empty);
+    }
+    // The server's inside-IO loop is IPv4-only today, and a correct
+    // IPv6 header length requires walking the extension-header chain.
+    // Add IPv6 handling here when we have an end-to-end IPv6 path.
+    let (ip_hdr_len, proto) = match pkt[0] >> 4 {
+        4 => {
+            let ip = Ipv4Packet::new(pkt).ok_or(GsoHdrError::Truncated { stage: "ipv4_hdr" })?;
+            let ihl = ip.get_header_length() as usize * 4;
+            if ihl < 20 {
+                return Err(GsoHdrError::BadIpv4Ihl);
+            }
+            if pkt.len() < ihl {
+                return Err(GsoHdrError::Truncated { stage: "ipv4_hdr" });
+            }
+            (ihl, ip.get_next_level_protocol())
+        }
+        v => return Err(GsoHdrError::UnsupportedIpVersion(v)),
+    };
+    let l4_hdr_len = if proto == IpNextHeaderProtocols::Tcp {
+        let tcp = TcpPacket::new(&pkt[ip_hdr_len..])
+            .ok_or(GsoHdrError::Truncated { stage: "tcp_hdr" })?;
+        let doff = tcp.get_data_offset() as usize * 4;
+        if doff < 20 {
+            return Err(GsoHdrError::BadTcpDataOffset);
+        }
+        doff
+    } else if proto == IpNextHeaderProtocols::Udp {
+        8
+    } else {
+        return Err(GsoHdrError::UnsupportedL4Proto(proto.0));
+    };
+    Ok(ip_hdr_len + l4_hdr_len)
+}
+
+/// Number of segments in a GSO superpacket.
+pub(crate) fn calc_gso_segs(pkt_len: usize, hdr_len: usize, gso_size: usize) -> usize {
+    if gso_size == 0 {
+        return 0;
+    }
+    let payload_len = pkt_len.saturating_sub(hdr_len);
+    payload_len.div_ceil(gso_size)
+}
+
+/// Build segment `gso_idx` from the superpacket into `out`.
+///
+/// Resets `out` and writes header template + payload slice into its
+/// spare capacity, applies all per-segment fixups (IP ID, TCP seq,
+/// checksums), then commits the segment via `set_len`. On return,
+/// `out` holds exactly the one segment's wire bytes.
+///
+/// `hdr_len` is the real header length the caller derived once via
+/// [`calc_hdr_len`] for the whole superpacket.
+///
+/// `out.capacity()` must be ≥ one segment's maximum wire length.
+pub(crate) fn build_segment(
+    hdr: &VirtioNetHdr,
+    hdr_len: usize,
+    gso_pkt: &[u8],
+    gso_idx: usize,
+    out: &mut bytes::BytesMut,
+) -> Result<(), GsoSegError> {
+    use pnet_packet::ipv4::{Ipv4Packet, MutableIpv4Packet};
+    use pnet_packet::ipv6::{Ipv6Packet, MutableIpv6Packet};
+    use pnet_packet::tcp::{MutableTcpPacket, TcpFlags};
+    use pnet_packet::udp::MutableUdpPacket;
+
+    if gso_pkt.is_empty() {
+        return Err(GsoSegError::Empty);
+    }
+    let gso_size = hdr.gso_size as usize;
+    let csum_start = hdr.csum_start as usize;
+    let v6 = (gso_pkt[0] >> 4) == 6;
+
+    // This segment's payload range within the superpacket.
+    let seg_start = hdr_len + gso_idx * gso_size;
+    let seg_end = std::cmp::min(seg_start + gso_size, gso_pkt.len());
+    let seg_len = seg_end - seg_start;
+    let out_len = hdr_len + seg_len;
+    let is_last = seg_end == gso_pkt.len();
+
+    // Materialize the segment: header template + payload.
+    // BytesMut::extend_from_slice memcpys without zero-init.
+    out.clear();
+    out.extend_from_slice(&gso_pkt[..hdr_len]);
+    out.extend_from_slice(&gso_pkt[seg_start..seg_end]);
+    debug_assert_eq!(out.len(), out_len);
+
+    // Read IP source/destination addresses once before taking any
+    // mutable borrow on `out`. Used downstream for the L4 checksum
+    // pseudo-header.
+    let (v4_addrs, v6_addrs) = if v6 {
+        let ip = Ipv6Packet::new(&out[..csum_start]).ok_or(GsoSegError::Ipv6)?;
+        (None, Some((ip.get_source(), ip.get_destination())))
+    } else {
+        let ip = Ipv4Packet::new(&out[..csum_start]).ok_or(GsoSegError::Ipv4)?;
+        (Some((ip.get_source(), ip.get_destination())), None)
+    };
+
+    // IP-layer fixups.
+    if v6 {
+        let mut ip = MutableIpv6Packet::new(&mut out[..csum_start]).ok_or(GsoSegError::Ipv6)?;
+        // payload_length excludes the 40-byte fixed IPv6 header.
+        ip.set_payload_length((out_len - 40) as u16);
+    } else {
+        let mut ip = MutableIpv4Packet::new(&mut out[..csum_start]).ok_or(GsoSegError::Ipv4)?;
+        if gso_idx > 0 {
+            ip.set_identification(ip.get_identification().wrapping_add(gso_idx as u16));
+        }
+        ip.set_total_length(out_len as u16);
+        ip.set_checksum(0);
+        let csum = pnet_packet::ipv4::checksum(&ip.to_immutable());
+        ip.set_checksum(csum);
+    }
+
+    // Transport-layer fixups.
+    if hdr.is_tcp() {
+        let mut tcp =
+            MutableTcpPacket::new(&mut out[csum_start..out_len]).ok_or(GsoSegError::Tcp)?;
+        // Bounds-safe read of 4 bytes at csum_start+4 in gso_pkt.
+        let seq_bytes = gso_pkt
+            .get(csum_start + 4..csum_start + 8)
+            .ok_or(GsoSegError::Tcp)?;
+        let first_seq =
+            u32::from_be_bytes([seq_bytes[0], seq_bytes[1], seq_bytes[2], seq_bytes[3]]);
+        tcp.set_sequence(first_seq.wrapping_add(gso_size as u32 * gso_idx as u32));
+        if !is_last {
+            tcp.set_flags(tcp.get_flags() & !(TcpFlags::FIN | TcpFlags::PSH));
+        }
+        tcp.set_checksum(0);
+        let csum = match (v4_addrs, v6_addrs) {
+            (Some((src, dst)), None) => {
+                pnet_packet::tcp::ipv4_checksum(&tcp.to_immutable(), &src, &dst)
+            }
+            (None, Some((src, dst))) => {
+                pnet_packet::tcp::ipv6_checksum(&tcp.to_immutable(), &src, &dst)
+            }
+            _ => unreachable!(),
+        };
+        tcp.set_checksum(csum);
+    } else {
+        let mut udp =
+            MutableUdpPacket::new(&mut out[csum_start..out_len]).ok_or(GsoSegError::Udp)?;
+        udp.set_length((out_len - csum_start) as u16);
+        udp.set_checksum(0);
+        let csum = match (v4_addrs, v6_addrs) {
+            (Some((src, dst)), None) => {
+                pnet_packet::udp::ipv4_checksum(&udp.to_immutable(), &src, &dst)
+            }
+            (None, Some((src, dst))) => {
+                pnet_packet::udp::ipv6_checksum(&udp.to_immutable(), &src, &dst)
+            }
+            _ => unreachable!(),
+        };
+        udp.set_checksum(csum);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::BytesMut;
+    use pnet_packet::ipv4::{Ipv4Packet, MutableIpv4Packet};
+    use pnet_packet::tcp::{MutableTcpPacket, TcpFlags, TcpPacket};
+    use pnet_packet::udp::{MutableUdpPacket, UdpPacket};
+
+    const TCP_FLAG_ACK: u8 = TcpFlags::ACK;
+    const TCP_FLAG_FIN: u8 = TcpFlags::FIN;
+    const TCP_FLAG_PSH: u8 = TcpFlags::PSH;
+    const IPPROTO_TCP: u8 = 6;
+    const IPPROTO_UDP: u8 = 17;
+    const VIRTIO_NET_HDR_GSO_UDP_L4: u8 = 5;
+    const IPV4_HDR_LEN: usize = 20;
+    const TCP_HDR_LEN: usize = 20;
+    const UDP_HDR_LEN: usize = 8;
+    const SRC: [u8; 4] = [10, 0, 0, 1];
+    const DST: [u8; 4] = [10, 0, 0, 2];
+
+    // ---- builders ----
+
+    fn ipv4_hdr(total_len: u16, id: u16, proto: u8) -> [u8; 20] {
+        let mut h = [0u8; 20];
+        h[0] = 0x45; // version=4, IHL=5
+        h[2..4].copy_from_slice(&total_len.to_be_bytes());
+        h[4..6].copy_from_slice(&id.to_be_bytes());
+        h[8] = 64; // TTL
+        h[9] = proto;
+        h[12..16].copy_from_slice(&SRC);
+        h[16..20].copy_from_slice(&DST);
+        h
+    }
+
+    fn tcp_hdr(seq: u32, flags: u8) -> [u8; 20] {
+        let mut h = [0u8; 20];
+        h[0..2].copy_from_slice(&1234u16.to_be_bytes());
+        h[2..4].copy_from_slice(&5678u16.to_be_bytes());
+        h[4..8].copy_from_slice(&seq.to_be_bytes());
+        h[12] = 0x50; // data offset = 5 32-bit words (20 bytes)
+        h[13] = flags;
+        h[14..16].copy_from_slice(&0xFFFFu16.to_be_bytes());
+        h
+    }
+
+    fn udp_hdr(length: u16) -> [u8; 8] {
+        let mut h = [0u8; 8];
+        h[0..2].copy_from_slice(&1234u16.to_be_bytes());
+        h[2..4].copy_from_slice(&5678u16.to_be_bytes());
+        h[4..6].copy_from_slice(&length.to_be_bytes());
+        h
+    }
+
+    fn payload(len: usize) -> Vec<u8> {
+        (0..len).map(|i| (i % 251) as u8).collect()
+    }
+
+    fn tcpv4_super(
+        gso_size: u16,
+        payload_len: usize,
+        seq: u32,
+        id: u16,
+        flags: u8,
+    ) -> (VirtioNetHdr, Vec<u8>) {
+        let hdr_len = (IPV4_HDR_LEN + TCP_HDR_LEN) as u16;
+        let total = hdr_len as usize + payload_len;
+        let mut pkt = Vec::with_capacity(total);
+        pkt.extend_from_slice(&ipv4_hdr(total as u16, id, IPPROTO_TCP));
+        pkt.extend_from_slice(&tcp_hdr(seq, flags));
+        pkt.extend(payload(payload_len));
+        let vhdr = VirtioNetHdr {
+            flags: VIRTIO_NET_HDR_F_NEEDS_CSUM,
+            gso_type: VIRTIO_NET_HDR_GSO_TCPV4,
+            hdr_len,
+            gso_size,
+            csum_start: IPV4_HDR_LEN as u16,
+            csum_offset: 16,
+        };
+        (vhdr, pkt)
+    }
+
+    fn udpv4_super(gso_size: u16, payload_len: usize) -> (VirtioNetHdr, Vec<u8>) {
+        let hdr_len = (IPV4_HDR_LEN + UDP_HDR_LEN) as u16;
+        let total = hdr_len as usize + payload_len;
+        let mut pkt = Vec::with_capacity(total);
+        pkt.extend_from_slice(&ipv4_hdr(total as u16, 0x1234, IPPROTO_UDP));
+        pkt.extend_from_slice(&udp_hdr((UDP_HDR_LEN + payload_len) as u16));
+        pkt.extend(payload(payload_len));
+        let vhdr = VirtioNetHdr {
+            flags: VIRTIO_NET_HDR_F_NEEDS_CSUM,
+            gso_type: VIRTIO_NET_HDR_GSO_UDP_L4,
+            hdr_len,
+            gso_size,
+            csum_start: IPV4_HDR_LEN as u16,
+            csum_offset: 6,
+        };
+        (vhdr, pkt)
+    }
+
+    // ---- verifiers ----
+
+    fn check_ipv4(out: &[u8], total_len: usize, expected_id: u16) {
+        let ip = Ipv4Packet::new(&out[..total_len]).expect("v4 hdr fits");
+        assert_eq!(ip.get_total_length() as usize, total_len, "IP total_len");
+        assert_eq!(ip.get_identification(), expected_id, "IP id");
+        // Verify stored checksum equals a re-computed one over the
+        // header with the checksum field zeroed.
+        let mut copy = out[..IPV4_HDR_LEN].to_vec();
+        let mut ip_mut = MutableIpv4Packet::new(&mut copy).unwrap();
+        let stored = ip_mut.get_checksum();
+        ip_mut.set_checksum(0);
+        assert_eq!(
+            stored,
+            pnet_packet::ipv4::checksum(&ip_mut.to_immutable()),
+            "IPv4 header csum"
+        );
+    }
+
+    fn check_transport_v4(hdr: &VirtioNetHdr, out: &[u8], total_len: usize, proto: u8) {
+        let ip = Ipv4Packet::new(&out[..hdr.csum_start as usize]).expect("v4 hdr fits");
+        let (src, dst) = (ip.get_source(), ip.get_destination());
+        let mut l4 = out[hdr.csum_start as usize..total_len].to_vec();
+        if proto == IPPROTO_TCP {
+            let mut tcp = MutableTcpPacket::new(&mut l4).unwrap();
+            let stored = tcp.get_checksum();
+            tcp.set_checksum(0);
+            assert_eq!(
+                stored,
+                pnet_packet::tcp::ipv4_checksum(&tcp.to_immutable(), &src, &dst),
+                "TCP csum"
+            );
+        } else {
+            let mut udp = MutableUdpPacket::new(&mut l4).unwrap();
+            let stored = udp.get_checksum();
+            udp.set_checksum(0);
+            assert_eq!(
+                stored,
+                pnet_packet::udp::ipv4_checksum(&udp.to_immutable(), &src, &dst),
+                "UDP csum"
+            );
+        }
+    }
+
+    // ---- tests ----
+
+    /// PSH/FIN must only stick on the final segment of a TCPv4 superpacket.
+    /// gso=100, payload=250 → segs (100, 100, 50). Asserts flags cleared
+    /// to ACK-only on segs 0–1, restored to PSH|FIN|ACK on seg 2, plus
+    /// per-seg seq (orig + 100·i), IP id (orig + i), and both checksums.
+    #[test]
+    fn tcpv4_psh_fin_cleared_until_last_segment() {
+        let psh_fin_ack = TCP_FLAG_PSH | TCP_FLAG_FIN | TCP_FLAG_ACK;
+        let (vhdr, pkt) = tcpv4_super(100, 250, 0x1000_0000, 0x0001, psh_fin_ack);
+        let hdr_len = calc_hdr_len(&pkt).unwrap();
+        let mut out = BytesMut::with_capacity(2048);
+
+        // seg 0 — full, not last
+        build_segment(&vhdr, hdr_len, &pkt, 0, &mut out).unwrap();
+        let t0 = out.len();
+        assert_eq!(t0, 40 + 100);
+        let tcp = TcpPacket::new(&out[IPV4_HDR_LEN..t0]).unwrap();
+        assert_eq!(tcp.get_flags(), TCP_FLAG_ACK);
+        assert_eq!(tcp.get_sequence(), 0x1000_0000);
+        check_ipv4(&out, t0, 0x0001);
+        check_transport_v4(&vhdr, &out, t0, IPPROTO_TCP);
+
+        // seg 1 — full, not last
+        build_segment(&vhdr, hdr_len, &pkt, 1, &mut out).unwrap();
+        let t1 = out.len();
+        assert_eq!(t1, 40 + 100);
+        let tcp = TcpPacket::new(&out[IPV4_HDR_LEN..t1]).unwrap();
+        assert_eq!(tcp.get_flags(), TCP_FLAG_ACK);
+        assert_eq!(tcp.get_sequence(), 0x1000_0064);
+        check_ipv4(&out, t1, 0x0002);
+        check_transport_v4(&vhdr, &out, t1, IPPROTO_TCP);
+
+        // seg 2 — short, last: PSH+FIN restored
+        build_segment(&vhdr, hdr_len, &pkt, 2, &mut out).unwrap();
+        let t2 = out.len();
+        assert_eq!(t2, 40 + 50);
+        let tcp = TcpPacket::new(&out[IPV4_HDR_LEN..t2]).unwrap();
+        assert_eq!(tcp.get_flags(), psh_fin_ack);
+        assert_eq!(tcp.get_sequence(), 0x1000_00C8);
+        check_ipv4(&out, t2, 0x0003);
+        check_transport_v4(&vhdr, &out, t2, IPPROTO_TCP);
+    }
+
+    /// Odd gso_size + odd-length last segment: every checksum still folds
+    /// correctly. gso=1001, payload=2003 → segs (1001, 1001, 1) — the 1-byte
+    /// trailing seg drives the lone-byte branch in checksum_no_fold, and
+    /// 1001-byte segs make the total odd so the trailing path runs there too.
+    #[test]
+    fn tcpv4_odd_mss_checksum_valid() {
+        let (vhdr, pkt) = tcpv4_super(1001, 2003, 0, 0x0010, TCP_FLAG_ACK);
+        let hdr_len = calc_hdr_len(&pkt).unwrap();
+        let mut out = BytesMut::with_capacity(4096);
+        let expected_sizes = [1001, 1001, 1];
+        for (i, &want) in expected_sizes.iter().enumerate() {
+            build_segment(&vhdr, hdr_len, &pkt, i, &mut out).unwrap();
+            let t = out.len();
+            assert_eq!(t, 40 + want, "seg {i} size");
+            check_ipv4(&out, t, 0x0010 + i as u16);
+            check_transport_v4(&vhdr, &out, t, IPPROTO_TCP);
+        }
+    }
+
+    /// UDPv4 GSO (UDP_L4) takes the non-TCP branch: the UDP length field
+    /// must be rewritten per segment (not just the IP total_len), and the
+    /// UDP checksum recomputed with the pseudo header reflecting the
+    /// per-segment length. gso=1000, payload=2500 → segs (1000, 1000, 500).
+    #[test]
+    fn udpv4_superframe_per_segment_length_and_csum() {
+        let (vhdr, pkt) = udpv4_super(1000, 2500);
+        let hdr_len = calc_hdr_len(&pkt).unwrap();
+        let mut out = BytesMut::with_capacity(2048);
+        let expected_sizes = [1000usize, 1000, 500];
+        for (i, &want) in expected_sizes.iter().enumerate() {
+            build_segment(&vhdr, hdr_len, &pkt, i, &mut out).unwrap();
+            let t = out.len();
+            assert_eq!(t, 28 + want);
+            // UDP length field = UDP hdr + segment payload
+            let udp = UdpPacket::new(&out[IPV4_HDR_LEN..t]).unwrap();
+            assert_eq!(
+                udp.get_length() as usize,
+                UDP_HDR_LEN + want,
+                "seg {i} UDP length"
+            );
+            check_ipv4(&out, t, 0x1234 + i as u16);
+            check_transport_v4(&vhdr, &out, t, IPPROTO_UDP);
+        }
+    }
+
+    /// N=1: with a single segment, all per-index fixups must be no-ops.
+    /// index=0 skips the IP-ID bump and adds 0 to seq; is_last=true keeps
+    /// PSH. Output payload bytes must equal input payload bytes verbatim.
+    #[test]
+    fn tcpv4_n_equals_one_is_noop_fixup() {
+        let psh_ack = TCP_FLAG_PSH | TCP_FLAG_ACK;
+        let (vhdr, pkt) = tcpv4_super(100, 50, 0xDEAD_BEEF, 0x4242, psh_ack);
+        let hdr_len = calc_hdr_len(&pkt).unwrap();
+        let mut out = BytesMut::with_capacity(2048);
+
+        build_segment(&vhdr, hdr_len, &pkt, 0, &mut out).unwrap();
+        let t = out.len();
+        assert_eq!(t, 40 + 50);
+        let ip = Ipv4Packet::new(&out[..IPV4_HDR_LEN]).unwrap();
+        assert_eq!(ip.get_identification(), 0x4242, "IP ID unchanged");
+        let tcp = TcpPacket::new(&out[IPV4_HDR_LEN..t]).unwrap();
+        assert_eq!(tcp.get_sequence(), 0xDEAD_BEEF, "seq unchanged");
+        assert_eq!(tcp.get_flags(), psh_ack, "flags preserved");
+        // Payload identical to source.
+        assert_eq!(&out[40..t], &pkt[40..], "payload");
+        check_ipv4(&out, t, 0x4242);
+        check_transport_v4(&vhdr, &out, t, IPPROTO_TCP);
+    }
+
+    /// Boundary cases for `calc_gso_segs`: 0 payload → 0 segs, exact-multiple
+    /// of gso_size → integer count, leftover bytes spill to next seg.
+    #[test]
+    fn calc_gso_segs_counts_segments() {
+        // (pkt_len, want_segs) — hdr_len=40 (IPv4+TCP), gso_size=100
+        let cases = [(40, 0), (41, 1), (140, 1), (141, 2), (340, 3)];
+        for (pkt_len, want_segs) in cases {
+            assert_eq!(
+                calc_gso_segs(pkt_len, 40, 100),
+                want_segs,
+                "pkt_len={pkt_len} should yield {want_segs} segs"
+            );
+        }
+    }
+
+    /// IPv4 ID is u16 and uses wrapping_add — bumps past 0xFFFF must roll
+    /// over cleanly, not panic in debug. Initial id 0xFFFE with 3 segs
+    /// yields {0xFFFE, 0xFFFF, 0x0000}. Also verifies the IP header
+    /// checksum still validates around the wrap.
+    #[test]
+    fn tcpv4_ip_id_wraps_at_0xffff() {
+        let (vhdr, pkt) = tcpv4_super(100, 250, 0, 0xFFFE, TCP_FLAG_ACK);
+        let hdr_len = calc_hdr_len(&pkt).unwrap();
+        let mut out = BytesMut::with_capacity(2048);
+        let expected_ids = [0xFFFEu16, 0xFFFF, 0x0000];
+        for (i, &want_id) in expected_ids.iter().enumerate() {
+            build_segment(&vhdr, hdr_len, &pkt, i, &mut out).unwrap();
+            let t = out.len();
+            let ip = Ipv4Packet::new(&out[..IPV4_HDR_LEN]).unwrap();
+            assert_eq!(ip.get_identification(), want_id, "seg {i} IP id");
+            check_ipv4(&out, t, want_id);
+            check_transport_v4(&vhdr, &out, t, IPPROTO_TCP);
+        }
+    }
+
+    /// When payload is exactly N·gso_size, the last segment is full-sized
+    /// (not short) — is_last is computed by `seg_end == pkt.len()`, not
+    /// by short length. Asserts PSH is still preserved on the full-sized
+    /// final seg and stripped from the identical-sized prior segs.
+    #[test]
+    fn tcpv4_exact_mtu_boundary_last_segment_is_full() {
+        let psh_ack = TCP_FLAG_PSH | TCP_FLAG_ACK;
+        let (vhdr, pkt) = tcpv4_super(100, 300, 0x4000_0000, 0x0007, psh_ack);
+        let hdr_len = calc_hdr_len(&pkt).unwrap();
+        let mut out = BytesMut::with_capacity(2048);
+
+        // Segs 0 and 1: full + not last → PSH cleared
+        for i in 0..2 {
+            build_segment(&vhdr, hdr_len, &pkt, i, &mut out).unwrap();
+            let t = out.len();
+            assert_eq!(t, 40 + 100);
+            let tcp = TcpPacket::new(&out[IPV4_HDR_LEN..t]).unwrap();
+            assert_eq!(tcp.get_flags(), TCP_FLAG_ACK, "seg {i} PSH cleared");
+            check_ipv4(&out, t, 0x0007 + i as u16);
+            check_transport_v4(&vhdr, &out, t, IPPROTO_TCP);
+        }
+
+        // Seg 2: full-sized, but is_last → PSH preserved
+        build_segment(&vhdr, hdr_len, &pkt, 2, &mut out).unwrap();
+        let t = out.len();
+        assert_eq!(t, 40 + 100, "last seg same size as others");
+        let tcp = TcpPacket::new(&out[IPV4_HDR_LEN..t]).unwrap();
+        assert_eq!(tcp.get_flags(), psh_ack, "last seg PSH preserved");
+        check_ipv4(&out, t, 0x0009);
+        check_transport_v4(&vhdr, &out, t, IPPROTO_TCP);
+    }
+
+    /// IPv6 is rejected at the calc_hdr_len boundary. The fixed
+    /// `(40, next_header)` returned previously was wrong for any
+    /// packet carrying extension headers; until v6 is wired end-to-
+    /// end we surface this as `UnsupportedIpVersion(6)`.
+    #[test]
+    fn calc_hdr_len_rejects_ipv6() {
+        // Minimal IPv6 header: version=6 in the first nibble; payload
+        // doesn't matter, we never reach parsing.
+        let mut pkt = vec![0u8; 40];
+        pkt[0] = 0x60;
+        match calc_hdr_len(&pkt) {
+            Err(GsoHdrError::UnsupportedIpVersion(6)) => {}
+            other => panic!("expected UnsupportedIpVersion(6), got {other:?}"),
+        }
+    }
+
+    /// `build_segment` must not panic on an empty superpacket — it
+    /// reads `gso_pkt[0]` to dispatch v4/v6. Empty input goes through
+    /// the explicit guard.
+    #[test]
+    fn build_segment_rejects_empty_input() {
+        let vhdr = VirtioNetHdr {
+            flags: 0,
+            gso_type: VIRTIO_NET_HDR_GSO_TCPV4,
+            hdr_len: 40,
+            gso_size: 100,
+            csum_start: 20,
+            csum_offset: 16,
+        };
+        let mut out = BytesMut::with_capacity(2048);
+        assert_eq!(
+            build_segment(&vhdr, 40, &[], 0, &mut out),
+            Err(GsoSegError::Empty)
+        );
+    }
+
+    /// `calc_gso_segs(_, _, 0)` must not panic from `div_ceil(0)` —
+    /// callers should gate, but the function guards regardless.
+    #[test]
+    fn calc_gso_segs_zero_gso_size_returns_zero() {
+        assert_eq!(calc_gso_segs(1000, 40, 0), 0);
+        assert_eq!(calc_gso_segs(0, 0, 0), 0);
+    }
+}

--- a/lightway-core/src/io.rs
+++ b/lightway-core/src/io.rs
@@ -1,6 +1,6 @@
 use crate::tls::IOCallbackResult;
 use bytes::BytesMut;
-use std::{net::SocketAddr, sync::Arc};
+use std::{io::IoSlice, net::SocketAddr, sync::Arc};
 
 /// Maximum number of packets handled in a single batched IO call —
 /// covers both inbound (recvmmsg-style) reads and outbound
@@ -60,6 +60,12 @@ pub trait OutsideIOSendCallback {
     fn disable_pmtud_probe(&self) -> std::io::Result<()> {
         Err(std::io::Error::other("pmtud probe not supported"))
     }
+
+    /// Send concatenated wire packets via kernel GSO (`UDP_SEGMENT`).
+    /// The implementation gathers `bufs` into one payload via
+    /// `sendmsg`, which the kernel splits into `gso_size`-byte
+    /// segments. The trailing segment may be shorter than `gso_size`.
+    fn send_gso(&self, bufs: &[IoSlice<'_>], gso_size: u16) -> IOCallbackResult<usize>;
 }
 
 /// Convenience type to use as function arguments

--- a/lightway-core/src/lib.rs
+++ b/lightway-core/src/lib.rs
@@ -41,6 +41,8 @@ pub use context::{
     ip_pool::{ClientIpConfig, ClientIpConfigArg, InsideIpConfig, ServerIpPool, ServerIpPoolArg},
 };
 pub use features::LightwayFeature;
+#[cfg(any(target_os = "linux", test))]
+pub use gso::VirtioNetHdr;
 pub use io::{
     InsideIOSendCallback, InsideIOSendCallbackArg, MAX_IO_BATCH_SIZE, OutsideIOSendCallback,
     OutsideIOSendCallbackArg,

--- a/lightway-core/src/lib.rs
+++ b/lightway-core/src/lib.rs
@@ -9,6 +9,8 @@ mod connection;
 mod context;
 mod encoding_request_states;
 mod features;
+#[cfg(any(target_os = "linux", test))]
+pub mod gso;
 mod io;
 #[cfg(feature = "postquantum")]
 mod keyshare;

--- a/lightway-core/src/metrics.rs
+++ b/lightway-core/src/metrics.rs
@@ -47,6 +47,9 @@ const GSO_BUILD_REASON_LABEL: &str = "reason";
 #[cfg(any(target_os = "linux", test))]
 static METRIC_GSO_NONE_CHECKSUM_SKIPPED: LazyLock<Counter> =
     LazyLock::new(|| counter!("gso_none_checksum_skipped"));
+#[cfg(target_os = "linux")]
+static METRIC_GSO_DROPPED_IOV_OVERFLOW: LazyLock<Counter> =
+    LazyLock::new(|| counter!("gso_dropped_iov_overflow"));
 
 /// [`crate::Connection`] has allocated its [`crate::Connection::fragment_map`]
 pub(crate) fn connection_alloc_frag_map() {
@@ -156,4 +159,13 @@ pub(crate) fn gso_build_segment_failed(reason: &'static str) {
 #[cfg(any(target_os = "linux", test))]
 pub(crate) fn gso_none_checksum_skipped() {
     METRIC_GSO_NONE_CHECKSUM_SKIPPED.increment(1);
+}
+
+/// Server dropped a GSO superpacket whose segment count exceeds the
+/// `IOV_MAX`-derived cap. Each segment contributes 2 iovecs to the
+/// outbound `sendmsg`, so the cap protects against `EMSGSIZE` /
+/// `EINVAL` from the kernel under malformed virtio_net_hdr input.
+#[cfg(target_os = "linux")]
+pub(crate) fn gso_dropped_iov_overflow() {
+    METRIC_GSO_DROPPED_IOV_OVERFLOW.increment(1);
 }

--- a/lightway-core/src/metrics.rs
+++ b/lightway-core/src/metrics.rs
@@ -28,6 +28,26 @@ static METRIC_EXPRESSLANE_DECRYPT_NO_KEY: LazyLock<Counter> =
 static METRIC_EXPRESSLANE_DECRYPT_FAILED: LazyLock<Counter> =
     LazyLock::new(|| counter!("expresslane_decrypt_failed"));
 
+#[cfg(target_os = "linux")]
+const METRIC_GSO_DROPPED_INVALID_HDR_LEN: &str = "gso_dropped_invalid_hdr_len";
+#[cfg(target_os = "linux")]
+const GSO_HDR_REASON_LABEL: &str = "reason";
+#[cfg(target_os = "linux")]
+static METRIC_GSO_DROPPED_ZERO_GSO_SIZE: LazyLock<Counter> =
+    LazyLock::new(|| counter!("gso_dropped_zero_gso_size"));
+#[cfg(target_os = "linux")]
+static METRIC_GSO_DROPPED_OVERSIZED_SEGMENT: LazyLock<Counter> =
+    LazyLock::new(|| counter!("gso_dropped_oversized_segment"));
+#[cfg(target_os = "linux")]
+static METRIC_GSO_SEND_FAILED: LazyLock<Counter> = LazyLock::new(|| counter!("gso_send_failed"));
+#[cfg(target_os = "linux")]
+const METRIC_GSO_BUILD_SEGMENT_FAILED: &str = "gso_build_segment_failed";
+#[cfg(target_os = "linux")]
+const GSO_BUILD_REASON_LABEL: &str = "reason";
+#[cfg(any(target_os = "linux", test))]
+static METRIC_GSO_NONE_CHECKSUM_SKIPPED: LazyLock<Counter> =
+    LazyLock::new(|| counter!("gso_none_checksum_skipped"));
+
 /// [`crate::Connection`] has allocated its [`crate::Connection::fragment_map`]
 pub(crate) fn connection_alloc_frag_map() {
     METRIC_CONNECTION_ALLOC_FRAG_MAP.increment(1);
@@ -89,4 +109,51 @@ pub(crate) fn expresslane_decrypt_no_key() {
 pub(crate) fn expresslane_decrypt_failed(err: &Aes256GcmError) {
     warn!("Prev key failed: {err:?}");
     METRIC_EXPRESSLANE_DECRYPT_FAILED.increment(1);
+}
+
+/// Server dropped a GSO superpacket because the protocol header
+/// length could not be parsed. `reason` is one of the
+/// [`crate::gso::GsoHdrError::metric_reason`] labels.
+#[cfg(target_os = "linux")]
+pub(crate) fn gso_dropped_invalid_hdr_len(reason: &'static str) {
+    counter!(METRIC_GSO_DROPPED_INVALID_HDR_LEN, GSO_HDR_REASON_LABEL => reason).increment(1);
+}
+
+/// Server dropped a GSO superpacket whose kernel-reported `gso_size`
+/// was zero.
+#[cfg(target_os = "linux")]
+pub(crate) fn gso_dropped_zero_gso_size() {
+    METRIC_GSO_DROPPED_ZERO_GSO_SIZE.increment(1);
+}
+
+/// Server dropped a GSO superpacket because a header-wrapped segment
+/// would exceed the tunnel MTU.
+#[cfg(target_os = "linux")]
+pub(crate) fn gso_dropped_oversized_segment() {
+    METRIC_GSO_DROPPED_OVERSIZED_SEGMENT.increment(1);
+}
+
+/// `sendmsg(UDP_SEGMENT)` of the GSO batch failed.
+#[cfg(target_os = "linux")]
+pub(crate) fn gso_send_failed() {
+    METRIC_GSO_SEND_FAILED.increment(1);
+}
+
+/// `build_segment` could not parse the per-segment header (kernel
+/// supplied a virtio_net_hdr with csum_start/hdr_len that disagree
+/// with the actual packet bytes, or the packet was truncated mid-
+/// header). `reason` is one of:
+/// `empty` | `ipv4_parse` | `ipv6_parse` | `tcp_parse` | `udp_parse`.
+#[cfg(target_os = "linux")]
+pub(crate) fn gso_build_segment_failed(reason: &'static str) {
+    counter!(METRIC_GSO_BUILD_SEGMENT_FAILED, GSO_BUILD_REASON_LABEL => reason).increment(1);
+}
+
+/// `gso_none_checksum` was called with `csum_start`/`csum_offset`
+/// pointing outside the packet buffer — no checksum is written and
+/// the packet is forwarded with whatever value the kernel left in
+/// place. Indicates a malformed virtio_net_hdr from the TUN.
+#[cfg(any(target_os = "linux", test))]
+pub(crate) fn gso_none_checksum_skipped() {
+    METRIC_GSO_NONE_CHECKSUM_SKIPPED.increment(1);
 }

--- a/lightway-core/src/plugin.rs
+++ b/lightway-core/src/plugin.rs
@@ -53,6 +53,11 @@ pub enum PluginResult {
 }
 
 impl PluginList {
+    #[allow(dead_code)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.plugins.is_empty()
+    }
+
     pub(crate) fn do_ingress(&self, data: &mut BytesMut) -> PluginResult {
         for plugin in self.plugins.iter() {
             let res = plugin.ingress(data);

--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -169,6 +169,10 @@ impl OutsideIOSendCallback for TestDatagramSock {
         }
     }
 
+    fn send_gso(&self, _bufs: &[std::io::IoSlice<'_>], _gso_size: u16) -> IOCallbackResult<usize> {
+        IOCallbackResult::Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+    }
+
     fn peer_addr(&self) -> SocketAddr {
         todo!()
     }
@@ -216,6 +220,10 @@ impl OutsideIOSendCallback for TestStreamSock {
             }
             Err(err) => IOCallbackResult::Err(err),
         }
+    }
+
+    fn send_gso(&self, _bufs: &[std::io::IoSlice<'_>], _gso_size: u16) -> IOCallbackResult<usize> {
+        IOCallbackResult::Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
     }
 
     fn peer_addr(&self) -> SocketAddr {

--- a/lightway-server/src/config.rs
+++ b/lightway-server/src/config.rs
@@ -103,6 +103,12 @@ pub struct Config {
     #[patch(attribute(clap(long)))]
     #[patch(empty_value = false)]
     #[patch(attribute(serde(default)))]
+    #[patch(attribute(doc = "Enable TUN offload (GRO/GSO) for batch packet processing"))]
+    pub enable_tun_offload: bool,
+
+    #[patch(attribute(clap(long)))]
+    #[patch(empty_value = false)]
+    #[patch(attribute(serde(default)))]
     #[patch(attribute(doc = "Enable IO-uring interface for Tunnel"))]
     pub enable_tun_iouring: bool,
 
@@ -198,6 +204,7 @@ impl Default for Config {
                 crate::DEFAULT_STATISTICS_REPORTING_INTERVAL,
             ),
             enable_pqc: false,
+            enable_tun_offload: false,
             enable_tun_iouring: false,
             iouring_entry_count: 1024,
             iouring_sqpoll_idle_time: Duration::from_std_duration(StdDuration::from_millis(100)),

--- a/lightway-server/src/connection.rs
+++ b/lightway-server/src/connection.rs
@@ -113,6 +113,8 @@ impl Connection {
 
             pub fn outside_data_received(&self, buf: OutsidePacket) -> ConnectionResult<usize>;
             pub fn inside_data_received(&self, pkt: &mut BytesMut) -> ConnectionResult<()>;
+            #[cfg(target_os = "linux")]
+            pub fn inside_data_received_gso(&self, pkt: &mut BytesMut, hdr: &lightway_core::gso::VirtioNetHdr) -> ConnectionResult<()>;
         }
     }
 

--- a/lightway-server/src/io/inside.rs
+++ b/lightway-server/src/io/inside.rs
@@ -11,6 +11,10 @@ use std::sync::Arc;
 pub trait InsideIORecv: Sync + Send {
     async fn recv_buf(&self, buf: &mut bytes::BytesMut) -> IOCallbackResult<usize>;
 
+    /// Raw read from inside IO, returning the full virtio frame (header + payload).
+    #[cfg(target_os = "linux")]
+    async fn recv_gso(&self, buf: &mut [u8]) -> IOCallbackResult<usize>;
+
     fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState>;
 }
 

--- a/lightway-server/src/io/inside.rs
+++ b/lightway-server/src/io/inside.rs
@@ -4,6 +4,8 @@ pub(crate) use tun::Tun;
 
 use crate::connection::ConnectionState;
 use async_trait::async_trait;
+#[cfg(target_os = "linux")]
+use lightway_core::VirtioNetHdr;
 use lightway_core::{IOCallbackResult, InsideIOSendCallback, InsideIOSendCallbackArg};
 use std::sync::Arc;
 
@@ -11,9 +13,22 @@ use std::sync::Arc;
 pub trait InsideIORecv: Sync + Send {
     async fn recv_buf(&self, buf: &mut bytes::BytesMut) -> IOCallbackResult<usize>;
 
-    /// Raw read from inside IO, returning the full virtio frame (header + payload).
+    /// Receive a GSO superpacket into `buf`.
+    ///
+    /// Implementations write into `buf.spare_capacity_mut()` so the
+    /// caller can reuse one allocation across iterations with no
+    /// zero-init cost. On `Ok((n, hdr))`, the virtio header has been
+    /// parsed (`hdr`), `set_len` + `advance(VIRTIO_NET_HDR_LEN)` have
+    /// run, and `buf` holds exactly the IP packet (`n == buf.len()`).
+    /// Caller must ensure `buf.capacity()` is large enough for one
+    /// virtio header plus the largest expected aggregate.
+    ///
+    /// Returns `WouldBlock` on EAGAIN, on a short read that didn't
+    /// contain a full virtio header, or when the virtio header
+    /// itself fails to decode (each cause is logged + metered
+    /// inside the impl). Returns `Err` on IO errors.
     #[cfg(target_os = "linux")]
-    async fn recv_gso(&self, buf: &mut [u8]) -> IOCallbackResult<usize>;
+    async fn recv_gso(&self, buf: &mut bytes::BytesMut) -> IOCallbackResult<(usize, VirtioNetHdr)>;
 
     fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState>;
 }

--- a/lightway-server/src/io/inside/tun.rs
+++ b/lightway-server/src/io/inside/tun.rs
@@ -53,6 +53,17 @@ impl InsideIORecv for Tun {
         }
     }
 
+    #[cfg(target_os = "linux")]
+    async fn recv_gso(&self, buf: &mut [u8]) -> IOCallbackResult<usize> {
+        match self.0.recv_gso(buf).await {
+            IOCallbackResult::Ok(n) => {
+                metrics::tun_to_client(n);
+                IOCallbackResult::Ok(n)
+            }
+            e => e,
+        }
+    }
+
     fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState> {
         self
     }

--- a/lightway-server/src/io/inside/tun.rs
+++ b/lightway-server/src/io/inside/tun.rs
@@ -8,6 +8,8 @@ use anyhow::Result;
 use async_trait::async_trait;
 use bytes::BytesMut;
 use lightway_app_utils::{Tun as AppUtilsTun, TunConfig};
+#[cfg(target_os = "linux")]
+use lightway_core::VirtioNetHdr;
 use lightway_core::{
     IOCallbackResult, InsideIOSendCallback, InsideIOSendCallbackArg, ipv4_update_source,
 };
@@ -54,13 +56,16 @@ impl InsideIORecv for Tun {
     }
 
     #[cfg(target_os = "linux")]
-    async fn recv_gso(&self, buf: &mut [u8]) -> IOCallbackResult<usize> {
+    async fn recv_gso(&self, buf: &mut BytesMut) -> IOCallbackResult<(usize, VirtioNetHdr)> {
         match self.0.recv_gso(buf).await {
-            IOCallbackResult::Ok(n) => {
+            IOCallbackResult::Ok((n, hdr)) => {
+                // Note: payload bytes (post-virtio-strip), not raw kernel
+                // bytes — see metrics::tun_to_client doc.
                 metrics::tun_to_client(n);
-                IOCallbackResult::Ok(n)
+                IOCallbackResult::Ok((n, hdr))
             }
-            e => e,
+            IOCallbackResult::WouldBlock => IOCallbackResult::WouldBlock,
+            IOCallbackResult::Err(e) => IOCallbackResult::Err(e),
         }
     }
 

--- a/lightway-server/src/io/outside/tcp.rs
+++ b/lightway-server/src/io/outside/tcp.rs
@@ -31,6 +31,10 @@ impl OutsideIOSendCallback for TcpStream {
         }
     }
 
+    fn send_gso(&self, _bufs: &[std::io::IoSlice<'_>], _gso_size: u16) -> IOCallbackResult<usize> {
+        IOCallbackResult::Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+    }
+
     fn peer_addr(&self) -> SocketAddr {
         self.peer_addr
     }

--- a/lightway-server/src/io/outside/udp.rs
+++ b/lightway-server/src/io/outside/udp.rs
@@ -15,6 +15,7 @@ use lightway_core::{
 use socket2::{MaybeUninitSlice, MsgHdr, MsgHdrMut, SockAddr, SockRef};
 use std::os::fd::AsRawFd;
 use std::{
+    io::IoSlice,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::{Arc, RwLock},
 };
@@ -49,32 +50,45 @@ impl std::fmt::Display for BindMode {
 
 fn send_to_socket(
     sock: &Arc<tokio::net::UdpSocket>,
-    buf: &[u8],
+    bufs: &[IoSlice<'_>],
     peer_addr: &SockAddr,
     pktinfo: Option<libc::in_pktinfo>,
+    gso_size: Option<u16>,
 ) -> IOCallbackResult<usize> {
+    #[cfg(target_vendor = "apple")]
+    const IP_PKTINFO_LEVEL: libc::c_int = libc::IPPROTO_IP;
+    #[cfg(not(target_vendor = "apple"))]
+    const IP_PKTINFO_LEVEL: libc::c_int = libc::SOL_IP;
+
+    const CMSG_SIZE: usize =
+        cmsg::Message::space::<libc::in_pktinfo>() + cmsg::Message::space::<u16>();
+
     let res = sock.try_io(Interest::WRITABLE, || {
         let sock = SockRef::from(sock.as_ref());
-        let bufs = [std::io::IoSlice::new(buf)];
 
-        let msghdr = MsgHdr::new().with_addr(peer_addr).with_buffers(&bufs);
-
-        const CMSG_SIZE: usize = cmsg::Message::space::<libc::in_pktinfo>();
+        // Track used bytes so we don't pass trailing zeroes that
+        // the kernel would interpret as a malformed cmsg header.
         let mut cmsg = cmsg::BufferMut::<CMSG_SIZE>::zeroed();
+        let mut cmsg_len: usize = 0;
 
-        let msghdr = if let Some(pktinfo) = pktinfo {
+        if pktinfo.is_some() || gso_size.is_some() {
             let mut builder = cmsg.builder();
-            #[cfg(target_vendor = "apple")]
-            let (cmsg_level, cmsg_type) = (libc::IPPROTO_IP, libc::IP_PKTINFO);
-            #[cfg(not(target_vendor = "apple"))]
-            let (cmsg_level, cmsg_type) = (libc::SOL_IP, libc::IP_PKTINFO);
+            if let Some(pi) = pktinfo {
+                builder.fill_next(IP_PKTINFO_LEVEL, libc::IP_PKTINFO, pi)?;
+                cmsg_len += cmsg::Message::space::<libc::in_pktinfo>();
+            }
+            #[cfg(target_os = "linux")]
+            if let Some(size) = gso_size {
+                builder.fill_next(libc::SOL_UDP, libc::UDP_SEGMENT, size)?;
+                cmsg_len += cmsg::Message::space::<u16>();
+            }
+        }
 
-            builder.fill_next(cmsg_level, cmsg_type, pktinfo)?;
-
-            msghdr.with_control(cmsg.as_ref())
-        } else {
-            msghdr
-        };
+        // If cmsg_len is 0, the kernel will never read cmsg.
+        let msghdr = MsgHdr::new()
+            .with_addr(peer_addr)
+            .with_buffers(bufs)
+            .with_control(&cmsg.as_ref()[..cmsg_len]);
 
         sock.sendmsg(&msghdr, 0)
     });
@@ -97,11 +111,24 @@ struct UdpSocket {
 impl OutsideIOSendCallback for UdpSocket {
     fn send(&self, buf: &[u8]) -> IOCallbackResult<usize> {
         let peer_addr = self.peer_addr.read().unwrap();
-        send_to_socket(&self.sock, buf, &peer_addr.1, self.reply_pktinfo)
+        send_to_socket(
+            &self.sock,
+            &[IoSlice::new(buf)],
+            &peer_addr.1,
+            self.reply_pktinfo,
+            None,
+        )
     }
 
-    fn send_gso(&self, _buf: &[u8], _gso_size: u16) -> IOCallbackResult<usize> {
-        todo!()
+    fn send_gso(&self, bufs: &[IoSlice<'_>], gso_size: u16) -> IOCallbackResult<usize> {
+        let peer_addr = self.peer_addr.read().unwrap();
+        send_to_socket(
+            &self.sock,
+            bufs,
+            &peer_addr.1,
+            self.reply_pktinfo,
+            Some(gso_size),
+        )
     }
 
     fn peer_addr(&self) -> SocketAddr {
@@ -292,7 +319,13 @@ impl UdpServer {
         msg.append_to_wire(&mut buf);
 
         // Ignore failure to send.
-        let _ = send_to_socket(&self.sock, &buf, &peer_addr, reply_pktinfo);
+        let _ = send_to_socket(
+            &self.sock,
+            &[IoSlice::new(&buf)],
+            &peer_addr,
+            reply_pktinfo,
+            None,
+        );
     }
 }
 

--- a/lightway-server/src/io/outside/udp.rs
+++ b/lightway-server/src/io/outside/udp.rs
@@ -100,6 +100,10 @@ impl OutsideIOSendCallback for UdpSocket {
         send_to_socket(&self.sock, buf, &peer_addr.1, self.reply_pktinfo)
     }
 
+    fn send_gso(&self, _buf: &[u8], _gso_size: u16) -> IOCallbackResult<usize> {
+        todo!()
+    }
+
     fn peer_addr(&self) -> SocketAddr {
         self.peer_addr.read().unwrap().0
     }

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -6,8 +6,6 @@ mod ip_manager;
 pub mod metrics;
 mod statistics;
 
-#[cfg(target_os = "linux")]
-use bytes::Buf;
 // re-export so server app does not need to depend on lightway-core
 pub use crate::connection_manager::DEFAULT_CONNECTION_AGE_EXPIRATION_INTERVAL;
 pub use crate::statistics::DEFAULT_STATISTICS_REPORTING_INTERVAL;
@@ -332,70 +330,34 @@ async fn inside_io_loop_gso(
         VIRTIO_NET_HDR_F_NEEDS_CSUM, VIRTIO_NET_HDR_GSO_NONE, VIRTIO_NET_HDR_LEN, gso_none_checksum,
     };
 
-    // Receive buffer reused across iterations. Allocate once and
-    // recv directly into it (no per-packet `BytesMut::from(&...)`
-    // copy + alloc).
+    // Receive buffer reused across iterations. `recv_gso` writes
+    // directly into `pkt.spare_capacity_mut()` (a `&mut
+    // [MaybeUninit<u8>]`), so there's no zero-init pass on the hot
+    // path. On success it has already done `set_len` + parsed the
+    // virtio header + `advance(VIRTIO_NET_HDR_LEN)`, so `pkt` holds
+    // exactly the IP packet on return.
     //
     // Mental model: `BytesMut` is a (ptr, len, cap) *window* into a
     // backing slab. `cap` is the distance from `ptr` to the end of
-    // the slab — NOT the slab size. Every `advance(N)` below slides
+    // the slab — NOT the slab size. Every `advance(N)` slides
     // `ptr += N` and shrinks `cap -= N`; the slab itself doesn't
-    // change. Without intervention, the window crawls toward the
-    // end of the slab and `cap` decays.
-    //
-    // `pkt.reserve(initial_cap)` below is the "slide back" call: if
-    // the window can already hold `initial_cap` more bytes after
-    // `len`, it's a free no-op; otherwise BytesMut compacts the
-    // window back to the start of the slab (with `len = 0` after
-    // `clear()`, this is just a pointer reset — no memcpy).
+    // change. `clear()` + `reserve(initial_cap)` at the top of the
+    // loop compacts the window back to the start of the slab (with
+    // `len = 0`, the reserve is a pointer reset — no memcpy).
     let initial_cap = VIRTIO_NET_HDR_LEN + 65535;
-    let mut pkt = bytes::BytesMut::zeroed(initial_cap);
+    let mut pkt = bytes::BytesMut::with_capacity(initial_cap);
 
     loop {
-        // Reset the window to start of slab (cheap; no-op while still
-        // at slab start, pointer-only reset after `advance()` has
-        // drifted us).
+        pkt.clear();
         pkt.reserve(initial_cap);
 
-        // Expose the full slab to `recv_gso` as `&mut [u8]`.
-        // SAFETY: every byte of the slab was zero-initialized at
-        // construction; subsequent iters only ever shrunk `len` or
-        // overwrote bytes. We never hand out uninitialized memory.
-        #[allow(unsafe_code)]
-        unsafe {
-            pkt.set_len(pkt.capacity());
-        }
-
-        let len = match inside_io.recv_gso(pkt.as_mut()).await {
-            IOCallbackResult::Ok(n) => n,
+        let (_, hdr) = match inside_io.recv_gso(&mut pkt).await {
+            IOCallbackResult::Ok(pair) => pair,
             IOCallbackResult::WouldBlock => continue,
             IOCallbackResult::Err(err) => {
                 break Err(anyhow!(err).context("InsideIO recv gso error"));
             }
         };
-
-        // SAFETY: `recv_gso` wrote `len` bytes; `len ≤ pkt.capacity()`.
-        #[allow(unsafe_code)]
-        unsafe {
-            pkt.set_len(len);
-        }
-
-        if len <= VIRTIO_NET_HDR_LEN {
-            tracing::warn!("TUN read too short ({len} <= {VIRTIO_NET_HDR_LEN})");
-            pkt.clear();
-            continue;
-        }
-
-        let hdr = match VirtioNetHdr::from_bytes(&pkt[..VIRTIO_NET_HDR_LEN]) {
-            Ok(hdr) => *hdr,
-            Err(err) => {
-                tracing::warn!("Failed to decode virtio header: {err}");
-                pkt.clear();
-                continue;
-            }
-        };
-        // Strip the virtio header — `pkt` is now the IP payload.
-        pkt.advance(VIRTIO_NET_HDR_LEN);
 
         if hdr.flags & VIRTIO_NET_HDR_F_NEEDS_CSUM != 0 {
             gso_none_checksum(pkt.as_mut(), hdr.csum_start, hdr.csum_offset);

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -6,6 +6,8 @@ mod ip_manager;
 pub mod metrics;
 mod statistics;
 
+#[cfg(target_os = "linux")]
+use bytes::Buf;
 // re-export so server app does not need to depend on lightway-core
 pub use crate::connection_manager::DEFAULT_CONNECTION_AGE_EXPIRATION_INTERVAL;
 pub use crate::statistics::DEFAULT_STATISTICS_REPORTING_INTERVAL;
@@ -207,6 +209,10 @@ pub struct ServerConfig<SA: for<'a> ServerAuth<AuthState<'a>>> {
     /// Enable Post Quantum Crypto
     pub enable_pqc: bool,
 
+    /// Enable TUN offload (GRO/GSO) for batch packet processing
+    #[cfg(target_os = "linux")]
+    pub enable_tun_offload: bool,
+
     #[cfg(feature = "io-uring")]
     /// Enable IO-uring interface for Tunnel
     pub enable_tun_iouring: bool,
@@ -280,6 +286,145 @@ pub(crate) fn handle_inside_io_error(conn: Arc<Connection>, result: ConnectionRe
     }
 }
 
+async fn inside_io_loop_default(
+    inside_io: Arc<dyn InsideIO>,
+    ip_manager: Arc<IpManager<Arc<Connection>>>,
+    lightway_client_ip: Ipv4Addr,
+) -> anyhow::Result<()> {
+    let mtu = inside_io.mtu();
+    let mut buf = BytesMut::with_capacity(mtu);
+    loop {
+        buf.clear();
+        buf.resize(mtu, 0);
+        match inside_io.recv_buf(&mut buf).await {
+            IOCallbackResult::Ok(_n) => {}
+            IOCallbackResult::WouldBlock => continue,
+            IOCallbackResult::Err(err) => {
+                break Err(anyhow!(err).context("InsideIO recv buf error"));
+            }
+        };
+
+        let packet = Ipv4Packet::new(buf.as_ref());
+        let Some(packet) = packet else {
+            eprintln!("Invalid inside packet size (less than Ipv4 header)!");
+            continue;
+        };
+        let conn = ip_manager.find_connection(packet.get_destination());
+
+        ipv4_update_destination(buf.as_mut(), lightway_client_ip);
+
+        if let Some(conn) = conn {
+            let result = conn.inside_data_received(&mut buf);
+            handle_inside_io_error(conn, result);
+        } else {
+            metrics::tun_rejected_packet_no_connection();
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+async fn inside_io_loop_gso(
+    inside_io: Arc<dyn InsideIO>,
+    ip_manager: Arc<IpManager<Arc<Connection>>>,
+    lightway_client_ip: Ipv4Addr,
+) -> anyhow::Result<()> {
+    use lightway_core::gso::{
+        VIRTIO_NET_HDR_F_NEEDS_CSUM, VIRTIO_NET_HDR_GSO_NONE, VIRTIO_NET_HDR_LEN, gso_none_checksum,
+    };
+
+    // Receive buffer reused across iterations. Allocate once and
+    // recv directly into it (no per-packet `BytesMut::from(&...)`
+    // copy + alloc).
+    //
+    // Mental model: `BytesMut` is a (ptr, len, cap) *window* into a
+    // backing slab. `cap` is the distance from `ptr` to the end of
+    // the slab — NOT the slab size. Every `advance(N)` below slides
+    // `ptr += N` and shrinks `cap -= N`; the slab itself doesn't
+    // change. Without intervention, the window crawls toward the
+    // end of the slab and `cap` decays.
+    //
+    // `pkt.reserve(initial_cap)` below is the "slide back" call: if
+    // the window can already hold `initial_cap` more bytes after
+    // `len`, it's a free no-op; otherwise BytesMut compacts the
+    // window back to the start of the slab (with `len = 0` after
+    // `clear()`, this is just a pointer reset — no memcpy).
+    let initial_cap = VIRTIO_NET_HDR_LEN + 65535;
+    let mut pkt = bytes::BytesMut::zeroed(initial_cap);
+
+    loop {
+        // Reset the window to start of slab (cheap; no-op while still
+        // at slab start, pointer-only reset after `advance()` has
+        // drifted us).
+        pkt.reserve(initial_cap);
+
+        // Expose the full slab to `recv_gso` as `&mut [u8]`.
+        // SAFETY: every byte of the slab was zero-initialized at
+        // construction; subsequent iters only ever shrunk `len` or
+        // overwrote bytes. We never hand out uninitialized memory.
+        #[allow(unsafe_code)]
+        unsafe {
+            pkt.set_len(pkt.capacity());
+        }
+
+        let len = match inside_io.recv_gso(pkt.as_mut()).await {
+            IOCallbackResult::Ok(n) => n,
+            IOCallbackResult::WouldBlock => continue,
+            IOCallbackResult::Err(err) => {
+                break Err(anyhow!(err).context("InsideIO recv gso error"));
+            }
+        };
+
+        // SAFETY: `recv_gso` wrote `len` bytes; `len ≤ pkt.capacity()`.
+        #[allow(unsafe_code)]
+        unsafe {
+            pkt.set_len(len);
+        }
+
+        if len <= VIRTIO_NET_HDR_LEN {
+            tracing::warn!("TUN read too short ({len} <= {VIRTIO_NET_HDR_LEN})");
+            pkt.clear();
+            continue;
+        }
+
+        let hdr = match VirtioNetHdr::from_bytes(&pkt[..VIRTIO_NET_HDR_LEN]) {
+            Ok(hdr) => *hdr,
+            Err(err) => {
+                tracing::warn!("Failed to decode virtio header: {err}");
+                pkt.clear();
+                continue;
+            }
+        };
+        // Strip the virtio header — `pkt` is now the IP payload.
+        pkt.advance(VIRTIO_NET_HDR_LEN);
+
+        if hdr.flags & VIRTIO_NET_HDR_F_NEEDS_CSUM != 0 {
+            gso_none_checksum(pkt.as_mut(), hdr.csum_start, hdr.csum_offset);
+        }
+
+        let packet = Ipv4Packet::new(pkt.as_ref());
+        let Some(packet) = packet else {
+            pkt.clear();
+            continue;
+        };
+        let conn = ip_manager.find_connection(packet.get_destination());
+
+        ipv4_update_destination(pkt.as_mut(), lightway_client_ip);
+
+        if let Some(conn) = conn {
+            let result = if hdr.gso_type == VIRTIO_NET_HDR_GSO_NONE {
+                conn.inside_data_received(&mut pkt)
+            } else {
+                conn.inside_data_received_gso(&mut pkt, &hdr)
+            };
+            handle_inside_io_error(conn, result);
+        } else {
+            metrics::tun_rejected_packet_no_connection();
+        }
+
+        pkt.clear();
+    }
+}
+
 pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'static>(
     mut config: ServerConfig<SA>,
 ) -> Result<()> {
@@ -324,6 +469,10 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
         Some(io) => io,
         None => {
             use io::inside::Tun;
+            #[cfg(target_os = "linux")]
+            if config.enable_tun_offload {
+                config.tun_config.offload = true;
+            }
             #[cfg(not(feature = "io-uring"))]
             let tun = Tun::new(&config.tun_config).await;
             #[cfg(feature = "io-uring")]
@@ -403,39 +552,31 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
         ),
     };
 
-    let inside_io_loop: JoinHandle<anyhow::Result<()>> = tokio::spawn(async move {
-        let mtu = inside_io.mtu();
-        let mut buf = BytesMut::with_capacity(mtu);
-        loop {
-            buf.clear();
-            buf.resize(mtu, 0);
-            match inside_io.recv_buf(&mut buf).await {
-                IOCallbackResult::Ok(_n) => {}
-                IOCallbackResult::WouldBlock => continue, // Spuriously failed to read, keep waiting
-                IOCallbackResult::Err(err) => {
-                    break Err(anyhow!(err).context("InsideIO recv buf error"));
-                }
-            };
+    let inside_io_loop: JoinHandle<anyhow::Result<()>> = {
+        #[cfg(target_os = "linux")]
+        let gso = config.enable_tun_offload;
+        #[cfg(not(target_os = "linux"))]
+        let gso = false;
 
-            // Find connection based on client ip (dest ip) and forward packet
-            let packet = Ipv4Packet::new(buf.as_ref());
-            let Some(packet) = packet else {
-                eprintln!("Invalid inside packet size (less than Ipv4 header)!");
-                continue;
-            };
-            let conn = ip_manager.find_connection(packet.get_destination());
-
-            // Update destination IP address to client's ip
-            ipv4_update_destination(buf.as_mut(), config.lightway_client_ip);
-
-            if let Some(conn) = conn {
-                let result = conn.inside_data_received(&mut buf);
-                handle_inside_io_error(conn, result);
-            } else {
-                metrics::tun_rejected_packet_no_connection();
+        if gso {
+            #[cfg(target_os = "linux")]
+            {
+                tokio::spawn(inside_io_loop_gso(
+                    inside_io,
+                    ip_manager.clone(),
+                    config.lightway_client_ip,
+                ))
             }
+            #[cfg(not(target_os = "linux"))]
+            unreachable!()
+        } else {
+            tokio::spawn(inside_io_loop_default(
+                inside_io,
+                ip_manager.clone(),
+                config.lightway_client_ip,
+            ))
         }
-    });
+    };
 
     let (ctrlc_tx, ctrlc_rx) = tokio::sync::oneshot::channel();
 
@@ -468,7 +609,7 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
 
     tokio::select! {
         err = server.run() => err.context("Outside IO loop exited"),
-        io = inside_io_loop =>  io.map_err(|e| anyhow!(e).context("Inside IO loop panicked"))?.context("Inside IO loop exited"),
+        io = inside_io_loop => io.map_err(|e| anyhow!(e).context("Inside IO loop panicked"))?.context("Inside IO loop exited"),
         _ = ctrlc_rx => {
             info!("Sigterm or Sigint received");
             conn_manager.shutdown();

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -175,6 +175,8 @@ async fn main() -> Result<()> {
         expresslane_metrics: None,
         event_cb: None,
         enable_pqc: config.enable_pqc,
+        #[cfg(target_os = "linux")]
+        enable_tun_offload: config.enable_tun_offload,
         #[cfg(feature = "io-uring")]
         enable_tun_iouring: config.enable_tun_iouring,
         #[cfg(feature = "io-uring")]

--- a/lightway-server/src/metrics.rs
+++ b/lightway-server/src/metrics.rs
@@ -339,6 +339,10 @@ pub fn tun_from_client(sz: usize) {
 }
 
 /// Bytes received from TUN device (destined for client).
+///
+/// Note: when GSO TUN offload is enabled, this counts the IP-payload
+/// bytes (post-virtio-header strip), not the raw kernel read length.
+/// The difference is one virtio header (12 bytes) per recv.
 pub fn tun_to_client(sz: usize) {
     METRIC_TUN_TO_CLIENT.increment(sz as u64);
 }

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -90,6 +90,10 @@ run-udp-pmtud-test:
 run-udp-iouring-test:
     DO +TEST --MODE=udp --SERVER_PORT=27690 --SERVER_EXTRA_ARGS="--enable-tun-iouring" --CLIENT_EXTRA_ARGS="--enable-tun-iouring"
 
+# run-udp-tun-offload-test runs e2e test using UDP with server TUN offload (GSO/GRO) enabled
+run-udp-tun-offload-test:
+    DO +TEST --MODE=udp --SERVER_PORT=27690 --SERVER_EXTRA_ARGS="--enable-tun-offload"
+
 # run-udp-client-batch-receive-test runs e2e test using UDP with batch receive enabled
 run-udp-client-batch-receive-test:
     DO +TEST --MODE=udp --SERVER_PORT=27690 --CLIENT_EXTRA_ARGS="--enable-batch-receive"
@@ -164,6 +168,7 @@ run-all-tests:
     BUILD +run-udp-floating-ip-test
     BUILD +run-udp-pmtud-test
     BUILD +run-udp-iouring-test
+    BUILD +run-udp-tun-offload-test
     BUILD +run-udp-client-batch-receive-test
     BUILD +run-udp-server-batch-receive-test
     BUILD +run-udp-both-batch-receive-test

--- a/tests/server/docker-entrypoint.sh
+++ b/tests/server/docker-entrypoint.sh
@@ -14,6 +14,10 @@ echo "====================================================================="
 
 ip tuntap add mode tun dev "${tunname}"
 ip link set dev "${tunname}" mtu 1350
+# Cap GSO superpacket intake. The default 65536 plus Lightway + TLS/expresslane
+# headers per segment can exceed what sendmsg(UDP_SEGMENT) accepts, causing the
+# kernel to return EMSGSIZE ("Message too long") on the outside socket.
+ip link set dev "${tunname}" gso_max_size 60300
 ip link set dev "${tunname}" up
 ip addr replace "${tun_local_ip}" dev "${tunname}"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implement GSO on server side on DTLS and Expresslane, specifically on bulk server->client traffic. This consistently halves the total syscalls used during bulk transfers, and also improves aggregated server throughput by 2x for multiple clients doing transfers.

When `--enable-tun-offload` is set, the server reads TSO superpackets from the TUN with `IFF_VNET_HDR`, segments them in userspace, and emits each superpacket as a single `sendmsg(UDP_SEGMENT)` instead of N per-segment syscalls. On a single-flow iperf3 reverse test the kernel UDP send path collapses near-completely: `udp_sendmsg` 0.71% → ~0.05%, `sock_alloc_send_pskb` 2.61% → ~0.13%, `mlx5e_xmit` 1.88% → ~0%.

Trade-off: kernel work is replaced with userspace work (per-segment IP/TCP/UDP checksum recomputation, segment assembly). Kernel-side wins are clear and measurable; userspace cost is now the dominant factor.

Pacing: each `sendmsg(UDP_SEGMENT)` produces a NIC burst of up to N segments. This can exceed receiver socket buffer depth and increase tail drops at peak rates. We will need to revisit better TX pacing under congested links.

Future work will focus on compatibility with TUN backends like io_uring, GRO on the server side, and full GSO/GRO on client side, where single-flow workloads should see the biggest visible speedup not in this PR.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See ticket CVPN-2346.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
