### PR TITLE
CVPN-2515: Process multiple outside packets at once

### DIFF
--- a/lightway-client/src/io/outside.rs
+++ b/lightway-client/src/io/outside.rs
@@ -8,6 +8,8 @@ pub use udp::Udp;
 
 use anyhow::Result;
 use async_trait::async_trait;
+#[cfg(batch_receive)]
+use lightway_core::MAX_IO_BATCH_SIZE;
 use lightway_core::{IOCallbackResult, OutsideIOSendCallbackArg};
 use std::{net::SocketAddr, sync::Arc};
 
@@ -17,10 +19,6 @@ use std::{net::SocketAddr, sync::Arc};
 pub type RawSocketHandle = std::os::fd::RawFd;
 #[cfg(windows)]
 pub type RawSocketHandle = std::os::windows::io::RawSocket;
-
-/// Maximum number of packets to receive in a single batch syscall.
-#[cfg(batch_receive)]
-pub const BATCH_RECV_SIZE: usize = 32;
 
 /// The underlying outside socket, tagged with its transport type.
 /// Lets callers distinguish UDP from TCP without peeking at the handle.
@@ -57,7 +55,10 @@ pub trait OutsideIO: Sync + Send {
     /// appropriate for stream transports (e.g. TCP) or UDP without batch support.
     /// Transports with a native batch-receive syscall should override this.
     #[cfg(batch_receive)]
-    fn recv_bufs(&self, bufs: &mut [bytes::BytesMut; BATCH_RECV_SIZE]) -> IOCallbackResult<usize> {
+    fn recv_bufs(
+        &self,
+        bufs: &mut [bytes::BytesMut; MAX_IO_BATCH_SIZE],
+    ) -> IOCallbackResult<usize> {
         match self.recv_buf(&mut bufs[0]) {
             IOCallbackResult::Ok(_size) => IOCallbackResult::Ok(1),
             others => others,

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -100,7 +100,7 @@ impl OutsideIO for Udp {
     /// If the config explicitly turned off batch receive, it will just run regular `recv_from` function.
     fn recv_bufs(
         &self,
-        bufs: &mut [bytes::BytesMut; super::BATCH_RECV_SIZE],
+        bufs: &mut [bytes::BytesMut; lightway_core::MAX_IO_BATCH_SIZE],
     ) -> IOCallbackResult<usize> {
         if !self.batch_receive_enabled {
             return match self.recv_buf(&mut bufs[0]) {
@@ -115,7 +115,7 @@ impl OutsideIO for Udp {
 
         loop {
             match self.sock.try_io(tokio::io::Interest::READABLE, || {
-                udp_batch_receiver::recv_multiple(fd, bufs, super::BATCH_RECV_SIZE)
+                udp_batch_receiver::recv_multiple(fd, bufs, lightway_core::MAX_IO_BATCH_SIZE)
             }) {
                 Ok(n) => return IOCallbackResult::Ok(n),
                 // try_io may return WouldBlock even if the socket isn't actually

--- a/lightway-client/src/io/outside/udp_batch_receiver.rs
+++ b/lightway-client/src/io/outside/udp_batch_receiver.rs
@@ -1,7 +1,7 @@
 #![cfg(batch_receive)]
 
-use super::BATCH_RECV_SIZE;
 use bytes::BytesMut;
+use lightway_core::MAX_IO_BATCH_SIZE;
 use std::io;
 
 /// Platform-specific batch receive syscall.
@@ -10,7 +10,7 @@ trait BatchRecvSyscall {
     /// Returns the number of packets actually received.
     fn recv_multiple(
         fd: libc::c_int,
-        recv_bufs: &mut [BytesMut; BATCH_RECV_SIZE],
+        recv_bufs: &mut [BytesMut; MAX_IO_BATCH_SIZE],
         msg_count: usize,
     ) -> io::Result<usize>;
 }
@@ -29,18 +29,17 @@ type PlatformBatchRecv = linux::Recvmmsg;
 
 pub(crate) fn recv_multiple(
     fd: libc::c_int,
-    recv_bufs: &mut [BytesMut; BATCH_RECV_SIZE],
+    recv_bufs: &mut [BytesMut; MAX_IO_BATCH_SIZE],
     max_batch_size: usize,
 ) -> io::Result<usize> {
-    let max_batch_size = max_batch_size.min(BATCH_RECV_SIZE);
+    let max_batch_size = max_batch_size.min(MAX_IO_BATCH_SIZE);
     PlatformBatchRecv::recv_multiple(fd, recv_bufs, max_batch_size)
 }
 
 #[cfg(apple)]
 mod apple {
-    use super::BATCH_RECV_SIZE;
     use bytes::BytesMut;
-    use lightway_core::MAX_OUTSIDE_MTU;
+    use lightway_core::{MAX_IO_BATCH_SIZE, MAX_OUTSIDE_MTU};
     use std::sync::LazyLock;
     use std::{io, mem};
 
@@ -98,13 +97,13 @@ mod apple {
         #[allow(unsafe_code)]
         fn recv_multiple(
             fd: libc::c_int,
-            recv_bufs: &mut [BytesMut; BATCH_RECV_SIZE],
+            recv_bufs: &mut [BytesMut; MAX_IO_BATCH_SIZE],
             msg_count: usize,
         ) -> io::Result<usize> {
             // SAFETY: zeroed iovec is valid (null pointer + zero length).
-            let mut iovecs = unsafe { mem::zeroed::<[libc::iovec; BATCH_RECV_SIZE]>() };
+            let mut iovecs = unsafe { mem::zeroed::<[libc::iovec; MAX_IO_BATCH_SIZE]>() };
             // SAFETY: zeroed msghdr_x is valid (null pointers + zero lengths).
-            let mut hdrs = unsafe { mem::zeroed::<[msghdr_x; BATCH_RECV_SIZE]>() };
+            let mut hdrs = unsafe { mem::zeroed::<[msghdr_x; MAX_IO_BATCH_SIZE]>() };
             for i in 0..msg_count {
                 iovecs[i].iov_base =
                     recv_bufs[i].spare_capacity_mut().as_mut_ptr() as *mut libc::c_void;
@@ -164,9 +163,8 @@ mod apple {
 
 #[cfg(any(linux, android))]
 mod linux {
-    use crate::io::outside::udp_batch_receiver::BATCH_RECV_SIZE;
     use bytes::BytesMut;
-    use lightway_core::MAX_OUTSIDE_MTU;
+    use lightway_core::{MAX_IO_BATCH_SIZE, MAX_OUTSIDE_MTU};
     use std::{io, mem};
 
     pub(crate) struct Recvmmsg;
@@ -177,13 +175,13 @@ mod linux {
         #[allow(unsafe_code)]
         fn recv_multiple(
             fd: libc::c_int,
-            recv_bufs: &mut [BytesMut; BATCH_RECV_SIZE],
+            recv_bufs: &mut [BytesMut; MAX_IO_BATCH_SIZE],
             msg_count: usize,
         ) -> io::Result<usize> {
             // SAFETY: zeroed iovec is valid (null pointer + zero length).
-            let mut iovecs = unsafe { mem::zeroed::<[libc::iovec; BATCH_RECV_SIZE]>() };
+            let mut iovecs = unsafe { mem::zeroed::<[libc::iovec; MAX_IO_BATCH_SIZE]>() };
             // SAFETY: zeroed mmsghdr is valid (null pointers + zero lengths).
-            let mut hdrs = unsafe { mem::zeroed::<[libc::mmsghdr; BATCH_RECV_SIZE]>() };
+            let mut hdrs = unsafe { mem::zeroed::<[libc::mmsghdr; MAX_IO_BATCH_SIZE]>() };
             for i in 0..msg_count {
                 iovecs[i].iov_base =
                     recv_bufs[i].spare_capacity_mut().as_mut_ptr() as *mut libc::c_void;
@@ -252,7 +250,7 @@ mod tests {
 
         sender.send(b"hello").await.unwrap();
 
-        let mut bufs: [BytesMut; BATCH_RECV_SIZE] =
+        let mut bufs: [BytesMut; MAX_IO_BATCH_SIZE] =
             std::array::from_fn(|_| BytesMut::with_capacity(MAX_OUTSIDE_MTU));
 
         tokio::time::timeout(Duration::from_secs(2), receiver.readable())
@@ -261,7 +259,7 @@ mod tests {
             .unwrap();
 
         let fd = std::os::fd::AsRawFd::as_raw_fd(&receiver);
-        let count = PlatformBatchRecv::recv_multiple(fd, &mut bufs, BATCH_RECV_SIZE).unwrap();
+        let count = PlatformBatchRecv::recv_multiple(fd, &mut bufs, MAX_IO_BATCH_SIZE).unwrap();
         assert!(count >= 1);
         assert_eq!(&bufs[0][..], b"hello");
     }
@@ -277,7 +275,7 @@ mod tests {
         // Give packets time to arrive in kernel buffer.
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        let mut bufs: [BytesMut; BATCH_RECV_SIZE] =
+        let mut bufs: [BytesMut; MAX_IO_BATCH_SIZE] =
             std::array::from_fn(|_| BytesMut::with_capacity(MAX_OUTSIDE_MTU));
 
         tokio::time::timeout(Duration::from_secs(2), receiver.readable())
@@ -286,7 +284,7 @@ mod tests {
             .unwrap();
 
         let fd = std::os::fd::AsRawFd::as_raw_fd(&receiver);
-        let count = PlatformBatchRecv::recv_multiple(fd, &mut bufs, BATCH_RECV_SIZE).unwrap();
+        let count = PlatformBatchRecv::recv_multiple(fd, &mut bufs, MAX_IO_BATCH_SIZE).unwrap();
         assert!(count >= 1);
         // Verify received packets are in order.
         for (i, b) in bufs.iter().enumerate().take(count) {

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -450,19 +450,13 @@ pub async fn outside_io_task<ExtAppState: Send + Sync>(
             IOCallbackResult::Err(err) => return Err(err.into()),
         };
 
-        // TODO: Batch send the packets into the tun device at once
-        {
-            let mut conn = conn.lock().unwrap();
-            for b in &mut bufs[..count] {
-                let pkt = OutsidePacket::Wire(b, connection_type);
-                if let Err(err) = conn.outside_data_received(pkt) {
-                    if err.is_fatal(connection_type) {
-                        return Err(err.into());
-                    }
-                    tracing::error!("Failed to process outside data: {err}");
-                }
-            }
-        }
+        let pkts = bufs
+            .iter_mut()
+            .take(count)
+            .map(|b| OutsidePacket::Wire(b, connection_type));
+        conn.lock()
+            .unwrap()
+            .multiple_outside_data_received(pkts, |err| err.is_fatal(connection_type))?;
 
         for b in &mut bufs[..count] {
             b.clear();

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -37,13 +37,13 @@ use tokio::sync::mpsc::UnboundedReceiver;
 use crate::debug::WiresharkKeyLogger;
 #[cfg(desktop)]
 use crate::dns_manager::{DnsConfigMode, DnsManager, DnsManagerError, DnsSetup};
-#[cfg(batch_receive)]
-use crate::io::outside::BATCH_RECV_SIZE;
 use crate::keepalive::Config as KeepaliveConfig;
 #[cfg(desktop)]
 use crate::route_manager::{RouteManager, RouteMode};
 #[cfg(feature = "debug")]
 use lightway_app_utils::wolfssl_tracing_callback;
+#[cfg(batch_receive)]
+use lightway_core::MAX_IO_BATCH_SIZE;
 pub use lightway_core::{
     AuthMethod, MAX_INSIDE_MTU, MAX_OUTSIDE_MTU, PluginFactoryError, PluginFactoryList,
     RootCertificate, Version,
@@ -421,7 +421,7 @@ pub async fn outside_io_task<ExtAppState: Send + Sync>(
     mut ready_signal: Option<oneshot::Sender<()>>,
 ) -> Result<()> {
     #[cfg(batch_receive)]
-    const BUF_COUNT: usize = BATCH_RECV_SIZE;
+    const BUF_COUNT: usize = MAX_IO_BATCH_SIZE;
     #[cfg(not(batch_receive))]
     const BUF_COUNT: usize = 1;
 

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -892,6 +892,28 @@ impl<AppState: Send> Connection<AppState> {
         result
     }
 
+    /// Process multiple outside packets.
+    ///
+    /// `is_fatal` is invoked for every per-packet error encountered. If it
+    /// returns `true`, processing stops and the error is returned immediately.
+    /// If it returns `false`, the error is treated as transient
+    /// and processing continues with the next packet with a single error log for debugging.
+    pub fn multiple_outside_data_received<'a>(
+        &mut self,
+        pkts: impl IntoIterator<Item = OutsidePacket<'a>>,
+        is_fatal: impl Fn(&ConnectionError) -> bool,
+    ) -> ConnectionResult<usize> {
+        let mut total = 0;
+        for pkt in pkts {
+            match self.outside_data_received(pkt) {
+                Ok(n) => total += n,
+                Err(e) if is_fatal(&e) => return Err(e),
+                Err(e) => error!("Failed to process outside data: {e}"),
+            }
+        }
+        Ok(total)
+    }
+
     /// Consume data received from inside path and send it as
     /// outside data packet.
     /// The returned Poll value reflects the inside I/O requirements.

--- a/lightway-core/src/io.rs
+++ b/lightway-core/src/io.rs
@@ -2,6 +2,11 @@ use bytes::BytesMut;
 use std::{net::SocketAddr, sync::Arc};
 use wolfssl::IOCallbackResult;
 
+/// Maximum number of packets handled in a single batched IO call —
+/// covers both inbound (recvmmsg-style) reads and outbound
+/// (sendmmsg-style) writes across both inside (TUN) and outside (socket) IO paths.
+pub const MAX_IO_BATCH_SIZE: usize = 32;
+
 /// Application provided callback used to send inside data.
 pub trait InsideIOSendCallback<AppState> {
     /// Called when Lightway wishes to send some inside data

--- a/lightway-core/src/lib.rs
+++ b/lightway-core/src/lib.rs
@@ -42,7 +42,8 @@ pub use context::{
 };
 pub use features::LightwayFeature;
 pub use io::{
-    InsideIOSendCallback, InsideIOSendCallbackArg, OutsideIOSendCallback, OutsideIOSendCallbackArg,
+    InsideIOSendCallback, InsideIOSendCallbackArg, MAX_IO_BATCH_SIZE, OutsideIOSendCallback,
+    OutsideIOSendCallbackArg,
 };
 #[cfg(feature = "postquantum")]
 pub use keyshare::KeyShare;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
To prepare for batch sending the processed outside packets into the TUN device, add a new function that is explicitly for processing multiple outside packets.

Right now it's kinda basic, but later it'll be modified to help flush packets in

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prepare for sending multiple packets to the TUN device

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passed CI + tested locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
