### PR TITLE
CVPN-2515: TUN `recv_buf` to take in BytesMut

### DIFF
--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -290,12 +290,20 @@ impl Tun {
         ))
     }
 
-    /// Recv a packet from `Tun`
-    pub async fn recv_buf(&self) -> IOCallbackResult<bytes::BytesMut> {
+    /// Recv a packet from `Tun` into `buf`.
+    ///
+    /// On success, `buf` holds the packet bytes and `buf.len()` equals the
+    /// returned size. The caller must size `buf` to at least the interface
+    /// MTU before calling (e.g. via `resize(mtu, 0)`).
+    ///
+    /// The [`Tun::Direct`] backend fills `buf` in place. The `IoUring` backend
+    /// swaps `buf` for a buffer from its internal pool, so the underlying
+    /// allocation may differ between calls.
+    pub async fn recv_buf(&self, buf: &mut BytesMut) -> IOCallbackResult<usize> {
         match self {
-            Tun::Direct(t) => t.recv_buf().await,
+            Tun::Direct(t) => t.recv_buf(buf).await,
             #[cfg(feature = "io-uring")]
-            Tun::IoUring(t) => t.recv_buf().await,
+            Tun::IoUring(t) => t.recv_buf(buf).await,
         }
     }
 
@@ -381,16 +389,15 @@ impl TunDirect {
     }
 
     /// Recv from Tun
-    pub async fn recv_buf(&self) -> IOCallbackResult<bytes::BytesMut> {
+    pub async fn recv_buf(&self, buf: &mut BytesMut) -> IOCallbackResult<usize> {
         let tun = self.tun.as_ref().unwrap();
-        let mut buf = BytesMut::zeroed(self.mtu as usize);
-        match tun.recv(buf.as_mut()).await {
+        match tun.recv(buf).await {
             // TODO: Check whether we can use poll
             // Getting spurious reads
             Ok(0) => IOCallbackResult::WouldBlock,
             Ok(nr) => {
-                let _ = buf.split_off(nr);
-                IOCallbackResult::Ok(buf)
+                buf.truncate(nr);
+                IOCallbackResult::Ok(nr)
             }
             Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
                 IOCallbackResult::WouldBlock
@@ -488,9 +495,13 @@ impl TunIoUring {
     }
 
     /// Recv from Tun
-    pub async fn recv_buf(&self) -> IOCallbackResult<BytesMut> {
+    pub async fn recv_buf(&self, buf: &mut BytesMut) -> IOCallbackResult<usize> {
         match self.tun_io_uring.recv().await {
-            Ok(pkt) => IOCallbackResult::Ok(pkt),
+            Ok(pkt) => {
+                let len = pkt.len();
+                *buf = pkt;
+                IOCallbackResult::Ok(len)
+            }
             Err(e) => IOCallbackResult::Err(std::io::Error::other(e)),
         }
     }

--- a/lightway-client/src/io/inside.rs
+++ b/lightway-client/src/io/inside.rs
@@ -16,9 +16,12 @@ use crate::ConnectionState;
 /// Trait for InsideIORecv
 /// This will be used client app to fetch inside packets
 pub trait InsideIORecv<ExtAppState: Send + Sync>: Send + Sync {
-    async fn recv_buf(&self) -> IOCallbackResult<BytesMut>;
+    async fn recv_buf(&self, buf: &mut BytesMut) -> IOCallbackResult<usize>;
 
     fn try_send(&self, pkt: BytesMut, ip_config: Option<InsideIpConfig>) -> Result<usize>;
+
+    /// MTU of the underlying interface.
+    fn mtu(&self) -> usize;
 
     fn into_io_send_callback(
         self: Arc<Self>,

--- a/lightway-client/src/io/inside/tun.rs
+++ b/lightway-client/src/io/inside/tun.rs
@@ -50,8 +50,8 @@ impl Tun {
 
 #[async_trait]
 impl<ExtAppState: Send + Sync> InsideIORecv<ExtAppState> for Tun {
-    async fn recv_buf(&self) -> IOCallbackResult<BytesMut> {
-        self.tun.recv_buf().await
+    async fn recv_buf(&self, buf: &mut BytesMut) -> IOCallbackResult<usize> {
+        self.tun.recv_buf(buf).await
     }
 
     /// Api to send packet in the tunnel
@@ -72,6 +72,10 @@ impl<ExtAppState: Send + Sync> InsideIORecv<ExtAppState> for Tun {
 
         self.tun.try_send(pkt);
         Ok(pkt_len)
+    }
+
+    fn mtu(&self) -> usize {
+        self.tun.mtu()
     }
 
     fn into_io_send_callback(

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -509,9 +509,13 @@ pub async fn inside_io_task<ExtAppState: Send + Sync>(
             .unwrap_or(DEFAULT_TRACER_TRIGGER_TIMEOUT)
     };
     let mut tracer_timeout_last_outside_data_rcvd: Option<Instant> = None;
+    let mtu = inside_io.mtu();
+    let mut buf = BytesMut::with_capacity(mtu);
     loop {
-        let mut buf = match inside_io.recv_buf().await {
-            IOCallbackResult::Ok(buf) => buf,
+        buf.clear();
+        buf.resize(mtu, 0);
+        match inside_io.recv_buf(&mut buf).await {
+            IOCallbackResult::Ok(_n) => {}
             IOCallbackResult::WouldBlock => continue, // Spuriously failed to read, keep waiting
             IOCallbackResult::Err(err) => {
                 // Fatal error

--- a/lightway-server/src/io/inside.rs
+++ b/lightway-server/src/io/inside.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 #[async_trait]
 pub trait InsideIORecv: Sync + Send {
-    async fn recv_buf(&self) -> IOCallbackResult<bytes::BytesMut>;
+    async fn recv_buf(&self, buf: &mut bytes::BytesMut) -> IOCallbackResult<usize>;
 
     fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState>;
 }

--- a/lightway-server/src/io/inside/tun.rs
+++ b/lightway-server/src/io/inside/tun.rs
@@ -43,11 +43,11 @@ impl AsRawFd for Tun {
 
 #[async_trait]
 impl InsideIORecv for Tun {
-    async fn recv_buf(&self) -> IOCallbackResult<bytes::BytesMut> {
-        match self.0.recv_buf().await {
-            IOCallbackResult::Ok(buf) => {
-                metrics::tun_to_client(buf.len());
-                IOCallbackResult::Ok(buf)
+    async fn recv_buf(&self, buf: &mut BytesMut) -> IOCallbackResult<usize> {
+        match self.0.recv_buf(buf).await {
+            IOCallbackResult::Ok(n) => {
+                metrics::tun_to_client(n);
+                IOCallbackResult::Ok(n)
             }
             e => e,
         }

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -20,6 +20,7 @@ pub use lightway_core::{
 pub type ServerEventCbType = Arc<dyn Fn(SessionId, &Event) + Send + Sync>;
 
 use anyhow::{Context, Result, anyhow};
+use bytes::BytesMut;
 use ipnet::Ipv4Net;
 use lightway_app_utils::{PacketCodecFactoryType, TunConfig, connection_ticker_cb};
 use lightway_core::{
@@ -369,9 +370,13 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
     };
 
     let inside_io_loop: JoinHandle<anyhow::Result<()>> = tokio::spawn(async move {
+        let mtu = inside_io.mtu();
+        let mut buf = BytesMut::with_capacity(mtu);
         loop {
-            let mut buf = match inside_io.recv_buf().await {
-                IOCallbackResult::Ok(buf) => buf,
+            buf.clear();
+            buf.resize(mtu, 0);
+            match inside_io.recv_buf(&mut buf).await {
+                IOCallbackResult::Ok(_n) => {}
                 IOCallbackResult::WouldBlock => continue, // Spuriously failed to read, keep waiting
                 IOCallbackResult::Err(err) => {
                     break Err(anyhow!(err).context("InsideIO recv buf error"));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We currently keep allocating a new BytesMut whenever we run `recv_buf`. Updating it to take in a BytesMut from the outer-loop instead, so that we can just clear + resize BytesMut whenever we wish to receive a packet.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reduce unnecessary memory allocation + unify/interface between this and batch receiving/sending packets to TUN

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passed CI

Some very minor speed improvements as well, on a M2 macBook Pro with a 10Gbps line:
Download: 1469.32 Mbps -> 1505.16 Mbps
Upload: 536.96 Mbps -> 534.32 Mbps (so similar speed here, nothing much)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
