### PR TITLE
CVPN-2549: Centralise TLS imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,8 +516,8 @@ The resulting file can then be exported to Wireshark to decrypt data traffic. Th
 https://www.wireshark.org/docs/wsug_html_chunked/ChIOExportSection.html#ChIOExportTLSSessionKeys
 https://wiki.wireshark.org/TLS#using-the-pre-master-secret
 
-### WolfSSL debug logging
+### TLS debug logging
 
 Both `lightway-client` and `lightway-server` support a `--tls-debug`
 option when built with their respective `debug` feature enabled. This
-enables WolfSSL's debug logging.
+enables TLS's debug logging.

--- a/docs/connection_state_machine.md
+++ b/docs/connection_state_machine.md
@@ -19,7 +19,7 @@ stateDiagram-v2
     note left of Connecting
       Secure (D)TLS connection negotiated
 
-      wolfssl#colon;#colon;Session#colon;#colon;try_negotiate()
+      tls#colon;#colon;Session#colon;#colon;try_negotiate()
       called until success or failure.
     end note
 

--- a/docs/inside_packet_codec.md
+++ b/docs/inside_packet_codec.md
@@ -3,8 +3,8 @@
 Lightway core in UDP supports encoding the inside packets through the packet codec interface.
 
 A codec consists of:
-- An encoder that encodes the inside packets that are sent from the tunnel (i.e., before they are encrypted by WolfSSL).
-- A decoder that decodes the inside packets that are to be sent to the tunnel (i.e., after they are decrypted by WolfSSL).
+- An encoder that encodes the inside packets that are sent from the tunnel (i.e., before they are encrypted by TLS).
+- A decoder that decodes the inside packets that are to be sent to the tunnel (i.e., after they are decrypted by TLS).
 
 The codec is not necessarily used all the time; it is not required that all packets are encoded throughout the connection. 
 1. The codec can decide whether the packet should be encoded based on its internal implementation.
@@ -18,11 +18,11 @@ Lightway-core accepts either encoded or non-encoded packets when its state is `C
 The following describes the path the packet flows through when a codec is enabled and the packet is accepted by the codec:
 ### Inside to Outside
 ```
-Tunnel -> Inside IO Loop -> Plugin -> Encoder -> Encoded Packet Handler Loop -> WolfSSL Encrypt -> ...
+Tunnel -> Inside IO Loop -> Plugin -> Encoder -> Encoded Packet Handler Loop -> TLS Encrypt -> ...
 ```
 ### Outside to Inside
 ```
-... -> WolfSSL Decrypt -> Decoder -> Decoded Packet Handler Loop -> Plugin -> Tunnel
+... -> TLS Decrypt -> Decoder -> Decoded Packet Handler Loop -> Plugin -> Tunnel
 ```
 
 ## Implementation

--- a/docs/logs_and_metrics.md
+++ b/docs/logs_and_metrics.md
@@ -30,7 +30,7 @@ Lightway server also supports metrics to monitor. The following are the metrics 
 | connection_accept_proxy_header_failed | server | Counter | A new connection did cnot present a valid PROXY header |
 | conn_create_failed | server | Counter | A new connection could not be created |
 | conn_alloc_frag_map | core | Counter | A connection has used a fragmented data packet.<br>Therefore the 2M FragmentMap has been allocated |
-| wolfssl_appdata | core | Counter | An AppData result occurred during a WolfSSL operation.<br><br>Given current configuration we do not expect this to be non-zero |
+| tls_appdata | core | Counter | An AppData result occurred during a TLS operation.<br><br>Given current configuration we do not expect this to be non-zero |
 | session_id_mismatch | core | Counter | Server has received a mismatched session_id in the header after the packet content has been validated <br><br>Should generally be expected to happen rarely|
 | received_encoding_req_non_online | core | Counter | Server received an encoding request when the Connection state is not Online |
 | received_encoding_req_with_tcp | core | Counter | Server received an encoding request when the Connection type is TCP |
@@ -43,8 +43,8 @@ Lightway server also supports metrics to monitor. The following are the metrics 
 | conn_online | server | Counter | Counts connection which have reached the “online” state after successful authentication |
 | conn_rejected_no_free_ip | server | Counter | Counts connections which were rejected at auth time due to a lack of free IPs in the server pool<br><br>Should generally be expected to be 0 |
 | conn_rejected_access_denied | server | Counter | Counts connections rejected due to invalid auth |
-| conn_tls_error | server | Counter | Counts connections which failed due to a TLS failure from WolfSSL |
-| conn_unknown_error | server | Counter | Counts connections which failed due to a non-TLS failure from WolfSSL |
+| conn_tls_error | server | Counter | Counts connections which failed due to a TLS failure|
+| conn_unknown_error | server | Counter | Counts connections which failed due to a non-TLS failure |
 | conn_aged_out | server | Counter | Counts connections which are disconnected due to being idle (after 1 day of inactivity) |
 | user_auth_eviction | server | Counter | Counts connections which are disconnected due to their auth expiring |
 | conn_client_closed | server | Counter | Counts connections which have been closed since client initiate Disconnect |

--- a/lightway-client/src/config.rs
+++ b/lightway-client/src/config.rs
@@ -250,7 +250,7 @@ pub struct Config {
     #[patch(attribute(clap(long)))]
     #[patch(empty_value = false)]
     #[patch(attribute(serde(default)))]
-    #[patch(attribute(doc = "Enable WolfSSL debug logging"))]
+    #[patch(attribute(doc = "Enable TLS debug logging"))]
     pub tls_debug: bool,
 
     #[cfg(windows)]
@@ -284,7 +284,7 @@ impl Config {
     }
 
     /// Try build CA from ca_crt
-    pub fn load_ca(&self) -> Result<lightway_core::wolfssl::RootCertificate<'_>, Error> {
+    pub fn load_ca(&self) -> Result<lightway_core::tls::RootCertificate<'_>, Error> {
         load_ca(&self.ca_cert)
     }
 
@@ -293,7 +293,7 @@ impl Config {
     pub fn load_ca_file<'a>(
         &self,
         ca_path: &'a mut Option<PathBuf>,
-    ) -> lightway_core::wolfssl::RootCertificate<'a> {
+    ) -> lightway_core::tls::RootCertificate<'a> {
         if ca_path.is_none() {
             *ca_path = Some(PathBuf::from(&self.ca_cert));
         }
@@ -461,7 +461,7 @@ impl ConnectionConfig {
 
     /// Try build CA from ca_crt
     #[cfg(feature = "mobile")]
-    pub fn load_ca(&self) -> Result<lightway_core::wolfssl::RootCertificate<'_>, Error> {
+    pub fn load_ca(&self) -> Result<lightway_core::tls::RootCertificate<'_>, Error> {
         self.ca_cert
             .as_ref()
             .map(|ca| load_ca(ca))
@@ -644,7 +644,7 @@ fn take_auth(
     }
 }
 
-fn load_ca(ca: &String) -> Result<lightway_core::wolfssl::RootCertificate<'_>, Error> {
+fn load_ca(ca: &String) -> Result<lightway_core::tls::RootCertificate<'_>, Error> {
     if ca.starts_with("-----BEGIN CERTIFICATE-----") {
         Ok(RootCertificate::PemBuffer(ca.as_bytes()))
     } else {

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -38,7 +38,7 @@ impl Udp {
         };
         let default_ip_pmtudisc = sockopt::get_ip_mtu_discover(&sock)?;
         // Check for the socket's writable ready status, so that it can be used
-        // successfuly in WolfSsl's `OutsideIOSendCallback` callback
+        // successfuly in TLS's `OutsideIOSendCallback` callback
         sock.writable().await?;
 
         Ok(Self {
@@ -162,14 +162,14 @@ impl OutsideIOSendCallback for Udp {
             Err(err) if matches!(err.kind(), std::io::ErrorKind::ConnectionRefused) => {
                 // Possibly the server isn't listening (yet).
                 //
-                // Swallow the error so the WolfSSL socket does not
-                // enter the error state, and DTLS would handle retransmission as well.
+                // Swallow the error so the TLS socket does not
+                // enter the error state, and DTLS would handles the retransmission as well.
                 //
                 // This way we can continue if/when the server shows up.
                 //
                 // Returning the number of bytes requested to be sent to mock
                 // that the send is successful.
-                // Otherwise, WolfSSL perceives that no data is sent and try
+                // Otherwise, TLS perceives that no data is sent and try
                 // to send the same data again, creating a live-lock until
                 // the network is reachable.
                 IOCallbackResult::Ok(buf.len())

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -261,7 +261,7 @@ pub struct ClientConfig<'cert, ExtAppState: Send + Sync> {
     #[educe(Debug(ignore))]
     pub best_connection_selected_signal: Option<oneshot::Sender<BestConnectionInfo>>,
 
-    /// Enable WolfSsl debugging
+    /// Enable TLS debugging
     #[cfg(feature = "debug")]
     pub tls_debug: bool,
 

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -119,7 +119,7 @@ async fn main() -> Result<()> {
 
     let mut config = Config::default();
     // NOTE:
-    // RootCertificate of wolfssl is not a self handled Struct
+    // RootCertificate of TLS library is not a self handled Struct
     // we need keep the PathBuf live outside
     let mut _root_ca_cert_path: Option<PathBuf> = None;
 

--- a/lightway-client/src/mobile.rs
+++ b/lightway-client/src/mobile.rs
@@ -70,10 +70,10 @@ fn get_lightway_client_hash() -> String {
     env!("GIT_HASH").to_string()
 }
 
-/// Get the version for WolfSSL
+/// Get the version for TLS library
 #[cfg_attr(not(feature = "mobile-test"), uniffi::export)]
-fn get_wolfssl_version() -> String {
-    lightway_core::wolfssl::get_wolfssl_version_string().to_string()
+fn get_tls_library_version() -> String {
+    lightway_core::tls::get_version_string().to_string()
 }
 
 /// Sets up a global default logging bridge between Rust and the mobile app, while

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -6,6 +6,7 @@ mod fragment_map;
 mod io_adapter;
 mod key_update;
 
+use crate::tls::{ErrorKind, IOCallbackResult, ProtocolVersion};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use dplpmtud::BASE_PLPMTU;
 use rand::distr::{Distribution, StandardUniform};
@@ -19,7 +20,6 @@ use std::{
 };
 use thiserror::Error;
 use tracing::{debug, error, info, trace, warn};
-use wolfssl::{ErrorKind, IOCallbackResult, ProtocolVersion};
 
 use crate::context::ExpresslaneTickData;
 use crate::{
@@ -46,20 +46,20 @@ use crate::wire::{AuthSuccessWithConfigV4, ExpresslaneError, ExpresslaneKey, Exp
 pub use builders::{ClientConnectionBuilder, ConnectionBuilderError, ServerConnectionBuilder};
 pub use event::Event;
 use fragment_map::{FragmentMap, FragmentMapResult};
-pub(crate) use io_adapter::{SendBuffer as IOAdapterSendBuffer, WolfSSLIOAdapter};
+pub(crate) use io_adapter::TlsIOAdapter;
 
 /// D/TLS is a UDP based protocol and requires the application
 /// (rather than the OS as with TCP) to keep track of the need to do
 /// retransmits on packet loss.
 ///
-/// Currently Wolf has timeouts based in seconds. However this is not
+/// Currently the TLS library has timeouts based in seconds. However this is not
 /// sufficient for our goal of sub-second connection times.
 ///
-/// As WolfSSL lacks millisecond timers we use its internal timers but
+/// As the TLS library lacks millisecond timers we use its internal timers but
 /// change its definition to be in 100 millisecond intervals instead of
-/// seconds. So a wolf timeout of 1 second means 100 milliseconds.
+/// seconds. So a TLS timeout of 1 second means 100 milliseconds.
 ///
-/// By default wolf's DTLS max timeout is 64 seconds which translates to
+/// By default the TLS library's DTLS max timeout is 64 seconds which translates to
 /// 6.4 seconds. Since it scales from 1 to 64 by a factor
 /// of 2 each timeout. The total timeout is 12.7 seconds with this scaling
 /// which for our purposes is plenty.
@@ -68,9 +68,9 @@ pub(crate) use io_adapter::{SendBuffer as IOAdapterSendBuffer, WolfSSLIOAdapter}
 /// timeout (firing after a period of inactivity) but instead treat it
 /// as a tick (albeit with an interval which may be adjusted over
 /// time). This tick runs until the connection reaches `State::Online`.
-const WOLF_TICK_INTERVAL_DIVISOR: u32 = 1000 / 100;
+const TLS_TICK_INTERVAL_DIVISOR: u32 = 1000 / 100;
 
-const WOLF_TICK_DTLS13_QUICK_TIMEOUT_DIVISOR: u32 = 4;
+const TLS_TICK_DTLS13_QUICK_TIMEOUT_DIVISOR: u32 = 4;
 
 /// Maximum number of retransmissions attempts for lightway frames
 const MAX_RETRANSMISSION_ATTEMPTS: u8 = 5;
@@ -206,9 +206,9 @@ pub enum ConnectionError {
     #[error("Data Fragment Error: {0}")]
     DataFragmentError(#[from] fragment_map::FragmentMapError),
 
-    /// A WolfSSL error occurred
-    #[error("WolfSSL Error: {0}")]
-    WolfSSL(#[from] wolfssl::Error),
+    /// A TLS error occurred
+    #[error("TLS Error: {0}")]
+    Tls(#[from] crate::tls::Error),
 
     /// Expresslane version mismatch
     #[error("Expresslane version mismatch")]
@@ -261,10 +261,10 @@ impl ConnectionError {
                     Disconnected => true,
                     EncodingReqRetransmitCbDoesNotExist => true,
                     PathMtuDiscoveryRequired { .. } => true,
-                    WolfSSL(wolfssl::Error::Fatal(ErrorKind::DomainNameMismatch)) => true,
-                    WolfSSL(wolfssl::Error::Fatal(ErrorKind::DuplicateMessage)) => true,
-                    WolfSSL(wolfssl::Error::Fatal(ErrorKind::PeerClosed)) => true,
-                    WolfSSL(wolfssl::Error::Fatal(ErrorKind::CaCertNotAvailable)) => true,
+                    Tls(crate::tls::Error::Fatal(ErrorKind::DomainNameMismatch)) => true,
+                    Tls(crate::tls::Error::Fatal(ErrorKind::DuplicateMessage)) => true,
+                    Tls(crate::tls::Error::Fatal(ErrorKind::PeerClosed)) => true,
+                    Tls(crate::tls::Error::Fatal(ErrorKind::CaCertNotAvailable)) => true,
 
                     WireError(wire::FromWireError::UnknownFrameType) => false,
                     WireError(wire::FromWireError::InsufficientData) => false,
@@ -284,7 +284,7 @@ impl ConnectionError {
                     ExpresslaneVersionMismatch => false,
                     ExpreslaneDegraded => false,
                     ExpresslaneError(_) => false,
-                    WolfSSL(_) => false,
+                    Tls(_) => false,
                 }
             }
         }
@@ -362,8 +362,8 @@ pub struct Connection<AppState: Send = ()> {
     /// Current state of the connection
     state: State,
 
-    /// The WolfSSL connection/session
-    session: wolfssl::Session<WolfSSLIOAdapter>,
+    /// The TLS connection/session
+    session: crate::tls::Session<TlsIOAdapter>,
 
     /// Client vs Server state.
     mode: ConnectionMode<AppState>,
@@ -406,14 +406,13 @@ pub struct Connection<AppState: Send = ()> {
     /// When is next tick due (independent of
     /// `is_tick_timer_running`, since application might be using
     /// [`Connection::tick_interval`] and [`Connection::tick`] instead)
-    wolfssl_tick_interval: Option<Duration>,
+    tls_tick_interval: Option<Duration>,
 
-    /// Pending packet to write to WolfSSL
+    /// Pending packet to write to the TLS library
     /// In nonblocking I/O mode, if the underlying I/O could not satisfy the
-    /// needs of wolfSSL_write() to continue, the api will return SSL_ERROR_WANT_WRITE.
+    /// needs of the TLS write to continue, the api will return WANT_WRITE.
     /// In that case, application has to call the api with same buffer again.
-    /// Ref: <https://www.wolfssl.com/documentation/manuals/wolfssl/ssl_8h.html#function-wolfssl_write>
-    wolfssl_pending_pkt: Option<BytesMut>,
+    tls_pending_pkt: Option<BytesMut>,
 
     /// Track partially constructed data fragments from [`wire::DataFrag`].
     fragment_map: once_cell::unsync::Lazy<FragmentMap, Box<dyn FnOnce() -> FragmentMap + Send>>,
@@ -449,7 +448,7 @@ struct NewConnectionArgs<AppState> {
     app_state: AppState,
     connection_type: ConnectionType,
     protocol_version: Version,
-    session: wolfssl::Session<WolfSSLIOAdapter>,
+    session: crate::tls::Session<TlsIOAdapter>,
     session_id: SessionId,
     mode: ConnectionMode<AppState>,
     rng: Arc<Mutex<dyn rand_core::CryptoRng + Send>>,
@@ -503,8 +502,8 @@ impl<AppState: Send> Connection<AppState> {
                 last_data_traffic_from_peer: now,
                 last_outside_data_received: now,
             },
-            wolfssl_tick_interval: None,
-            wolfssl_pending_pkt: None,
+            tls_tick_interval: None,
+            tls_pending_pkt: None,
             fragment_map: once_cell::unsync::Lazy::new(Box::new(move || {
                 metrics::connection_alloc_frag_map();
                 FragmentMap::new(max_fragment_map_entries)
@@ -536,9 +535,9 @@ impl<AppState: Send> Connection<AppState> {
         // more data than will be available. It's just about possible
         // it might succeed under test conditions.
         match conn.session.try_negotiate()? {
-            wolfssl::Poll::PendingWrite | wolfssl::Poll::PendingRead => {}
-            wolfssl::Poll::Ready(_) => conn.set_state(State::LinkUp)?,
-            wolfssl::Poll::AppData(_) => metrics::wolfssl_appdata(&ProtocolVersion::Unknown),
+            crate::tls::Poll::PendingWrite | crate::tls::Poll::PendingRead => {}
+            crate::tls::Poll::Ready(_) => conn.set_state(State::LinkUp)?,
+            crate::tls::Poll::AppData(_) => metrics::tls_appdata(&ProtocolVersion::Unknown),
         }
 
         conn.update_tick_interval();
@@ -712,19 +711,19 @@ impl<AppState: Send> Connection<AppState> {
         };
 
         if matches!(self.state, State::Online) && !key_update_pending {
-            self.wolfssl_tick_interval = None;
+            self.tls_tick_interval = None;
             return;
         }
 
         // Get and scale the tick interval
-        let mut interval = self.session.dtls_current_timeout() / WOLF_TICK_INTERVAL_DIVISOR;
+        let mut interval = self.session.dtls_current_timeout() / TLS_TICK_INTERVAL_DIVISOR;
 
         if matches!(self.tls_protocol_version(), ProtocolVersion::DtlsV1_3)
             && self.session.dtls13_use_quick_timeout()
         {
-            interval /= WOLF_TICK_DTLS13_QUICK_TIMEOUT_DIVISOR;
+            interval /= TLS_TICK_DTLS13_QUICK_TIMEOUT_DIVISOR;
         }
-        self.wolfssl_tick_interval = Some(interval);
+        self.tls_tick_interval = Some(interval);
 
         // Trigger a callback if timer is not already running
         if !self.is_tick_timer_running {
@@ -753,7 +752,7 @@ impl<AppState: Send> Connection<AppState> {
     /// `Some(_)`, [`Connection::tick`] should be called that amount
     /// of time later.
     pub fn tick_interval(&self) -> Option<Duration> {
-        self.wolfssl_tick_interval
+        self.tls_tick_interval
     }
 
     /// Inject a tick to the connection. See
@@ -785,15 +784,15 @@ impl<AppState: Send> Connection<AppState> {
                 return Err(ConnectionError::Disconnected);
             }
             _ if self.connection_type.is_datagram() => match self.session.dtls_has_timed_out() {
-                wolfssl::Poll::Ready(true) => {
+                crate::tls::Poll::Ready(true) => {
                     warn!(session_id = ?self.session_id, "DTLS timed out, disconnecting client");
                     let _ = self.disconnect();
                     return Err(ConnectionError::TimedOut);
                 }
-                wolfssl::Poll::PendingWrite
-                | wolfssl::Poll::PendingRead
-                | wolfssl::Poll::Ready(false) => {}
-                wolfssl::Poll::AppData(_) => metrics::wolfssl_appdata(&self.tls_protocol_version()),
+                crate::tls::Poll::PendingWrite
+                | crate::tls::Poll::PendingRead
+                | crate::tls::Poll::Ready(false) => {}
+                crate::tls::Poll::AppData(_) => metrics::tls_appdata(&self.tls_protocol_version()),
             },
             _ => {}
         };
@@ -820,7 +819,7 @@ impl<AppState: Send> Connection<AppState> {
         Ok(auth_handle.expired())
     }
 
-    /// Update WolfSSL Session to use the new outside IO Callback
+    /// Update TLS Session to use the new outside IO Callback
     pub fn set_outside_io(&mut self, new_io: OutsideIOSendCallbackArg) {
         self.session.io_cb_mut().io = new_io;
     }
@@ -1139,7 +1138,7 @@ impl<AppState: Send> Connection<AppState> {
     /// and send the frame in next call.
     fn send_frame_or_drop(&mut self, frame: wire::Frame) -> ConnectionResult<()> {
         // If there is a packet pending, send it first and drop the current one
-        let mut buf = match self.wolfssl_pending_pkt.take() {
+        let mut buf = match self.tls_pending_pkt.take() {
             None => {
                 let mut buf = BytesMut::new();
                 frame.append_to_wire(&mut buf);
@@ -1149,13 +1148,13 @@ impl<AppState: Send> Connection<AppState> {
         };
 
         match self.session.try_write(&mut buf)? {
-            wolfssl::Poll::PendingWrite | wolfssl::Poll::PendingRead => {
-                self.wolfssl_pending_pkt = Some(buf);
+            crate::tls::Poll::PendingWrite | crate::tls::Poll::PendingRead => {
+                self.tls_pending_pkt = Some(buf);
                 Ok(())
             }
-            wolfssl::Poll::Ready(_) => Ok(()),
-            wolfssl::Poll::AppData(_) => {
-                metrics::wolfssl_appdata(&self.tls_protocol_version());
+            crate::tls::Poll::Ready(_) => Ok(()),
+            crate::tls::Poll::AppData(_) => {
+                metrics::tls_appdata(&self.tls_protocol_version());
                 Ok(())
             }
         }
@@ -1306,21 +1305,20 @@ impl<AppState: Send> Connection<AppState> {
         // It's time to update keys!
         info!(session = ?self.session_id, "Update TLS keys");
         match self.session.try_trigger_update_key()? {
-            // From https://github.com/wolfSSL/wolfssl/blob/3b3c175af0e993ffaae251871421e206cc41963f/src/tls13.c#L12167:
-            //
-            // > If using non-blocking I/O and
-            // > WOLFSSL_ERROR_WANT_WRITE is returned then calling
-            // > wolfSSL_write() will have the message sent when ready.
+            // If using non-blocking I/O and WANT_WRITE is returned,
+            // calling try_write() again will have the message sent when ready.
             //
             // So we need not worry about `PendingWrite` here -- the
             // actual update will happen at some future `try_write`.
-            wolfssl::Poll::PendingWrite | wolfssl::Poll::PendingRead | wolfssl::Poll::Ready(_) => {
+            crate::tls::Poll::PendingWrite
+            | crate::tls::Poll::PendingRead
+            | crate::tls::Poll::Ready(_) => {
                 self.event(Event::TlsKeysUpdateStart);
                 self.update_tick_interval();
                 Ok(())
             }
-            wolfssl::Poll::AppData(_) => {
-                metrics::wolfssl_appdata(&self.tls_protocol_version());
+            crate::tls::Poll::AppData(_) => {
+                metrics::tls_appdata(&self.tls_protocol_version());
                 Ok(())
             }
         }
@@ -1350,20 +1348,20 @@ impl<AppState: Send> Connection<AppState> {
 
         let frame_read_count_result = match self.state {
             State::Connecting => match self.session.try_negotiate()? {
-                wolfssl::Poll::PendingWrite => {
+                crate::tls::Poll::PendingWrite => {
                     self.update_tick_interval();
                     Ok(0)
                 }
-                wolfssl::Poll::PendingRead => {
+                crate::tls::Poll::PendingRead => {
                     self.update_tick_interval();
                     Ok(0)
                 }
-                wolfssl::Poll::Ready(_) => {
+                crate::tls::Poll::Ready(_) => {
                     self.set_state(State::LinkUp)?;
                     self.handle_messages()
                 }
-                wolfssl::Poll::AppData(_) => {
-                    metrics::wolfssl_appdata(&self.tls_protocol_version());
+                crate::tls::Poll::AppData(_) => {
+                    metrics::tls_appdata(&self.tls_protocol_version());
                     Ok(0)
                 }
             },
@@ -1401,12 +1399,12 @@ impl<AppState: Send> Connection<AppState> {
                     self.receive_buf.reserve(self.outside_mtu);
 
                     match self.session.try_read(&mut self.receive_buf)? {
-                        wolfssl::Poll::PendingWrite => break,
-                        wolfssl::Poll::PendingRead => break,
-                        wolfssl::Poll::Ready(_) => continue,
-                        wolfssl::Poll::AppData(data) => {
+                        crate::tls::Poll::PendingWrite => break,
+                        crate::tls::Poll::PendingRead => break,
+                        crate::tls::Poll::Ready(_) => continue,
+                        crate::tls::Poll::AppData(data) => {
                             self.receive_buf.extend_from_slice(&data[..]);
-                            metrics::wolfssl_appdata(&self.tls_protocol_version());
+                            metrics::tls_appdata(&self.tls_protocol_version());
                             continue;
                         }
                     }

--- a/lightway-core/src/connection/builders.rs
+++ b/lightway-core/src/connection/builders.rs
@@ -5,7 +5,7 @@ use rand::distr::{Distribution, StandardUniform};
 use thiserror::Error;
 
 #[cfg(feature = "debug")]
-use wolfssl::Tls13SecretCallbacksArg;
+use crate::tls::Tls13SecretCallbacksArg;
 
 #[cfg(feature = "postquantum")]
 use crate::KeyShare;
@@ -36,8 +36,8 @@ pub enum ConnectionBuilderError {
     #[error("Unsupported Outside MTU: {0}")]
     UnsupportedOutsideMtu(usize),
     /// Failed to create a new Session
-    #[error("WolfSSL Error: {0}")]
-    FailedNew(#[from] wolfssl::NewSessionError),
+    #[error("TLS Error: {0}")]
+    FailedNew(#[from] crate::tls::NewSessionError),
     /// Plugin factory error occurred
     #[error("PluginFactory Error: {0}")]
     PluginFactory(#[from] PluginFactoryError),
@@ -55,7 +55,7 @@ pub struct ClientConnectionBuilder<AppState> {
     outside_mtu: usize,
     pmtud_base_mtu: Option<u16>,
     auth_method: Option<AuthMethod>,
-    session_config: wolfssl::SessionConfig<super::WolfSSLIOAdapter>,
+    session_config: crate::tls::SessionConfig<super::TlsIOAdapter>,
     event_cb: Option<EventCallbackArg>,
     max_fragment_map_entries: NonZeroU16,
     pmtud_timer: Option<dplpmtud::TimerArg<AppState>>,
@@ -78,19 +78,19 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
         let outside_plugins = ctx.outside_plugins.build()?;
         let outside_plugins = Arc::new(outside_plugins);
 
-        let io = super::WolfSSLIOAdapter {
+        let io = super::TlsIOAdapter {
             connection_type,
             protocol_version: Version::MAXIMUM,
             aggressive_send: connection_type.is_datagram(),
             outside_mtu,
             recv_buf: BytesMut::new(),
-            send_buf: super::IOAdapterSendBuffer::new(outside_mtu),
+            send_buf: super::io_adapter::SendBuffer::new(outside_mtu),
             io: outside_io,
             session_id: SessionId::EMPTY,
             outside_plugins: outside_plugins.clone(),
         };
         let session_config =
-            wolfssl::SessionConfig::new(io).when(connection_type.is_datagram(), |s| {
+            crate::tls::SessionConfig::new(io).when(connection_type.is_datagram(), |s| {
                 s.with_dtls_mtu(max_dtls_outside_mtu(outside_mtu) as u16)
                     .with_dtls_nonblocking(true)
             });
@@ -230,7 +230,7 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
             .auth_method
             .ok_or(ConnectionBuilderError::AuthRequired)?;
 
-        let session = self.ctx.wolfssl.new_session(self.session_config)?;
+        let session = self.ctx.tls_ctx.new_session(self.session_config)?;
 
         tracing::info!("New Connection");
 
@@ -275,7 +275,7 @@ pub struct ServerConnectionBuilder<'a, AppState> {
     ctx: &'a ServerContext<AppState>,
     auth: ServerAuthArg<AppState>,
     ip_pool: ServerIpPoolArg<AppState>,
-    session_config: wolfssl::SessionConfig<super::WolfSSLIOAdapter>,
+    session_config: crate::tls::SessionConfig<super::TlsIOAdapter>,
     session_id: SessionId,
     event_cb: Option<EventCallbackArg>,
     max_fragment_map_entries: NonZeroU16,
@@ -300,19 +300,19 @@ impl<'a, AppState: Send + 'static> ServerConnectionBuilder<'a, AppState> {
         let outside_plugins = ctx.outside_plugins.build()?;
         let outside_plugins = Arc::new(outside_plugins);
 
-        let io = super::WolfSSLIOAdapter {
+        let io = super::TlsIOAdapter {
             connection_type,
             protocol_version,
             aggressive_send: false,
             outside_mtu,
             recv_buf: BytesMut::new(),
-            send_buf: super::IOAdapterSendBuffer::new(outside_mtu),
+            send_buf: super::io_adapter::SendBuffer::new(outside_mtu),
             io: outside_io,
             session_id,
             outside_plugins: outside_plugins.clone(),
         };
         let session_config =
-            wolfssl::SessionConfig::new(io).when(connection_type.is_datagram(), |s| {
+            crate::tls::SessionConfig::new(io).when(connection_type.is_datagram(), |s| {
                 s.with_dtls_mtu(max_dtls_outside_mtu(outside_mtu) as u16)
                     .with_dtls_nonblocking(true)
                     .with_dtls13_allow_ch_frag(true)
@@ -369,7 +369,7 @@ impl<'a, AppState: Send + 'static> ServerConnectionBuilder<'a, AppState> {
             ));
         }
 
-        let session = self.ctx.wolfssl.new_session(self.session_config)?;
+        let session = self.ctx.tls_ctx.new_session(self.session_config)?;
 
         Ok(Connection::new(NewConnectionArgs {
             app_state,

--- a/lightway-core/src/connection/io_adapter.rs
+++ b/lightway-core/src/connection/io_adapter.rs
@@ -4,7 +4,7 @@ use bytes::{Buf, BytesMut};
 use delegate::delegate;
 use more_asserts::*;
 
-use wolfssl::IOCallbackResult;
+use crate::tls::IOCallbackResult;
 
 use crate::{
     ConnectionType, OutsideIOSendCallbackArg, PluginResult, Version, plugin::PluginList, wire,
@@ -78,9 +78,8 @@ impl SendBuffer {
     }
 }
 
-/// Adapt requirements of [`crate::Connection`] to those of the
-/// [`wolfssl::IOCallbacks`] API.
-pub(crate) struct WolfSSLIOAdapter {
+/// Adapt requirements of [`crate::Connection`] to those of the TLS/DTLS I/O API.
+pub(crate) struct TlsIOAdapter {
     pub(crate) connection_type: ConnectionType,
 
     pub(crate) protocol_version: Version,
@@ -96,7 +95,7 @@ pub(crate) struct WolfSSLIOAdapter {
 
     /// In case of TCP, send can succeed even for partial data and the caller
     /// has to call send again with remaining data.
-    /// But since we run the data through plugins, we cannot reliably let WolfSSL
+    /// But since we run the data through plugins, we cannot reliably let the TLS layer
     /// know about the remaining data to send.
     /// This buffer will be used to save the remaining data, to be sent in next call.
     pub(crate) send_buf: SendBuffer,
@@ -110,7 +109,7 @@ pub(crate) struct WolfSSLIOAdapter {
     pub(crate) outside_plugins: Arc<PluginList>,
 }
 
-impl WolfSSLIOAdapter {
+impl TlsIOAdapter {
     pub(crate) fn set_session_id(&mut self, session_id: wire::SessionId) {
         self.session_id = session_id;
     }
@@ -192,12 +191,12 @@ impl WolfSSLIOAdapter {
                 // `wire::Header::WIRE_SIZE` + `b.len()` that we
                 // tried to send.
                 //
-                // WolfSSL does not know about header, so return buf.len()
+                // TLS library does not know about header, so return buf.len()
                 if n > wire::Header::WIRE_SIZE {
                     IOCallbackResult::Ok(buf.len())
                 } else {
                     // We didn't even manage to side the header, so we
-                    // sent nothing from WolfSSL's point of view.
+                    // sent nothing from the TLS library's point of view.
                     IOCallbackResult::Ok(0)
                 }
             }
@@ -243,7 +242,7 @@ impl WolfSSLIOAdapter {
             // We have buffered data, so we have previously returned
             // `WouldBlock` and continue to send the remaining data.
             //
-            // WolfSSL API says we will be called back with the same
+            // TLS API says we will be called back with the same
             // data, possibly plus some extra (so the new `buf` we've
             // been given this time should have the original `buf`
             // from last time as a prefix).
@@ -275,7 +274,7 @@ impl WolfSSLIOAdapter {
     }
 }
 
-impl wolfssl::IOCallbacks for WolfSSLIOAdapter {
+impl crate::tls::IOCallbacks for TlsIOAdapter {
     fn recv(&mut self, buf: &mut [u8]) -> IOCallbackResult<usize> {
         let pending_buf = &mut self.recv_buf;
         if pending_buf.is_empty() {
@@ -365,8 +364,8 @@ mod tests {
         connection_type: ConnectionType,
         io: OutsideIOSendCallbackArg,
         outside_plugins: PluginList,
-    ) -> WolfSSLIOAdapter {
-        WolfSSLIOAdapter {
+    ) -> TlsIOAdapter {
+        TlsIOAdapter {
             connection_type,
             protocol_version: Version::MAXIMUM,
             aggressive_send: false,

--- a/lightway-core/src/connection/key_update.rs
+++ b/lightway-core/src/connection/key_update.rs
@@ -50,7 +50,7 @@ impl State {
     /// Implicitly transitions to `Self::Pending` if required.
     ///
     /// On a true result the caller must start a key update i.e. call
-    /// `wolfssl::Session.try_trigger_update_key()`.
+    /// `Session::try_trigger_update_key()`.
     pub fn required(&mut self) -> bool {
         match *self {
             Self::Disabled | Self::Initializing { .. } | Self::Pending { .. } => false,
@@ -71,7 +71,7 @@ impl State {
     /// Implicitly transitions to `Self::Waiting` if required.
     ///
     /// Should be called whenever
-    /// `wolfssl::Session::is_update_keys_pending()` is false.
+    /// `Session::is_update_keys_pending()` is false.
     pub fn complete(&mut self) -> bool {
         match *self {
             Self::Disabled | Self::Initializing { .. } | Self::Waiting { .. } => false,

--- a/lightway-core/src/context.rs
+++ b/lightway-core/src/context.rs
@@ -26,12 +26,12 @@ pub enum ContextBuilderError {
     InvalidInsideMtu(usize),
 
     /// Failed to create a new ContextBuilder
-    #[error("WolfSSL Error: {0}")]
-    FailedNew(#[from] wolfssl::NewContextBuilderError),
+    #[error("TLS Error: {0}")]
+    FailedNew(#[from] crate::tls::NewContextBuilderError),
 
-    /// A WolfSSL error occurred
-    #[error("WolfSSL Error: {0}")]
-    WolfSSL(#[from] wolfssl::Error),
+    /// A TLS error occurred
+    #[error("TLS Error: {0}")]
+    Tls(#[from] crate::tls::Error),
 
     /// Plugin factory error occurred
     #[error("PluginFactory Error: {0}")]
@@ -111,7 +111,7 @@ pub type ScheduleTickCb<AppState> =
 
 /// The core Lightway Client-side context.
 pub struct ClientContext<AppState> {
-    pub(crate) wolfssl: wolfssl::Context,
+    pub(crate) tls_ctx: crate::tls::Context,
     pub(crate) connection_type: ConnectionType,
     pub(crate) inside_io: Option<InsideIOSendCallbackArg<AppState>>,
     pub(crate) schedule_tick_cb: ScheduleTickCb<AppState>,
@@ -138,7 +138,7 @@ impl<AppState: Send + 'static> ClientContext<AppState> {
 
 /// Builder for a client side instance of [`ClientContext`].
 pub struct ClientContextBuilder<AppState> {
-    wolfssl: wolfssl::ContextBuilder,
+    tls_ctx: crate::tls::ContextBuilder,
     connection_type: ConnectionType,
     inside_io: Option<InsideIOSendCallbackArg<AppState>>,
     schedule_tick_cb: ScheduleTickCb<AppState>,
@@ -160,16 +160,16 @@ impl<AppState> ClientContextBuilder<AppState> {
         schedule_tick_cb: ScheduleTickCb<AppState>,
     ) -> ContextBuilderResult<Self> {
         let protocol = match connection_type {
-            ConnectionType::Stream => wolfssl::Method::TlsClientV1_3,
-            ConnectionType::Datagram => wolfssl::Method::DtlsClientV1_3,
+            ConnectionType::Stream => crate::tls::Method::TlsClientV1_3,
+            ConnectionType::Datagram => crate::tls::Method::DtlsClientV1_3,
         };
 
-        let wolfssl = wolfssl::ContextBuilder::new(protocol)?
+        let tls_ctx = crate::tls::ContextBuilder::new(protocol)?
             .with_root_certificate(root_ca)?
             .with_cipher_list(Cipher::default().as_cipher_list(connection_type))?;
 
         Ok(Self {
-            wolfssl,
+            tls_ctx,
             connection_type,
             inside_io,
             schedule_tick_cb,
@@ -203,10 +203,10 @@ impl<AppState> ClientContextBuilder<AppState> {
     /// Sets the cipher which should be used for Lightway connection.
     /// See [`Cipher`].
     pub fn with_cipher(self, cipher: Cipher) -> ContextBuilderResult<Self> {
-        let wolfssl = self
-            .wolfssl
+        let tls_ctx = self
+            .tls_ctx
             .with_cipher_list(cipher.as_cipher_list(self.connection_type))?;
-        Ok(Self { wolfssl, ..self })
+        Ok(Self { tls_ctx, ..self })
     }
 
     /// Enable expresslane data path
@@ -235,9 +235,9 @@ impl<AppState> ClientContextBuilder<AppState> {
 
     /// Finalize the builder, creating a [`ClientContext`].
     pub fn build(self) -> ClientContext<AppState> {
-        let wolfssl = self.wolfssl.build();
+        let tls_ctx = self.tls_ctx.build();
         ClientContext {
-            wolfssl,
+            tls_ctx,
             connection_type: self.connection_type,
             inside_io: self.inside_io,
             schedule_tick_cb: self.schedule_tick_cb,
@@ -282,7 +282,7 @@ pub enum ContextError {
 
 /// The core Lightway Server-side context.
 pub struct ServerContext<AppState = ()> {
-    pub(crate) wolfssl: wolfssl::Context,
+    pub(crate) tls_ctx: crate::tls::Context,
     pub(crate) connection_type: ConnectionType,
     pub(crate) schedule_tick_cb: ScheduleTickCb<AppState>,
     pub(crate) inside_io: InsideIOSendCallbackArg<AppState>,
@@ -341,7 +341,7 @@ impl<AppState: Send + 'static> ServerContext<AppState> {
 
 /// Builder for a server side instance of [`ServerContext`].
 pub struct ServerContextBuilder<AppState> {
-    wolfssl: wolfssl::ContextBuilder,
+    tls_ctx: crate::tls::ContextBuilder,
     connection_type: ConnectionType,
     schedule_tick_cb: ScheduleTickCb<AppState>,
     inside_io: InsideIOSendCallbackArg<AppState>,
@@ -357,21 +357,21 @@ pub struct ServerContextBuilder<AppState> {
 }
 
 /// server curves when PQC is not enabled, in decreasing order of preference.
-const SERVER_CURVE_BASE_GROUPS: &[wolfssl::CurveGroup] = &[
-    wolfssl::CurveGroup::EccSecp256R1,
-    wolfssl::CurveGroup::EccX25519,
+const SERVER_CURVE_BASE_GROUPS: &[crate::tls::CurveGroup] = &[
+    crate::tls::CurveGroup::EccSecp256R1,
+    crate::tls::CurveGroup::EccX25519,
 ];
 
 /// server curves when PQC is enabled, in decreasing order of preference.
 #[cfg(feature = "postquantum")]
-const SERVER_CURVE_PQC_GROUPS: &[wolfssl::CurveGroup] = &[
-    wolfssl::CurveGroup::P521MLKEM1024,
-    wolfssl::CurveGroup::P521KyberLevel5,
-    wolfssl::CurveGroup::X25519MLKEM768,
-    wolfssl::CurveGroup::P256MLKEM512,
-    wolfssl::CurveGroup::P256KyberLevel1,
-    wolfssl::CurveGroup::EccSecp256R1,
-    wolfssl::CurveGroup::EccX25519,
+const SERVER_CURVE_PQC_GROUPS: &[crate::tls::CurveGroup] = &[
+    crate::tls::CurveGroup::P521MLKEM1024,
+    crate::tls::CurveGroup::P521KyberLevel5,
+    crate::tls::CurveGroup::X25519MLKEM768,
+    crate::tls::CurveGroup::P256MLKEM512,
+    crate::tls::CurveGroup::P256KyberLevel1,
+    crate::tls::CurveGroup::EccSecp256R1,
+    crate::tls::CurveGroup::EccX25519,
 ];
 
 impl<AppState> ServerContextBuilder<AppState> {
@@ -386,9 +386,9 @@ impl<AppState> ServerContextBuilder<AppState> {
         schedule_tick_cb: ScheduleTickCb<AppState>,
     ) -> ContextBuilderResult<Self> {
         let protocol = match connection_type {
-            ConnectionType::Stream => wolfssl::Method::TlsServerV1_3,
-            // `wolfssl::Method::DtlsServer` supports both DTLS 1.2 and 1.3
-            ConnectionType::Datagram => wolfssl::Method::DtlsServer,
+            ConnectionType::Stream => crate::tls::Method::TlsServerV1_3,
+            // `crate::tls::Method::DtlsServer` supports both DTLS 1.2 and 1.3
+            ConnectionType::Datagram => crate::tls::Method::DtlsServer,
         };
 
         let cipher_list = match connection_type {
@@ -398,14 +398,14 @@ impl<AppState> ServerContextBuilder<AppState> {
             }
         };
 
-        let wolfssl = wolfssl::ContextBuilder::new(protocol)?
+        let tls_ctx = crate::tls::ContextBuilder::new(protocol)?
             .with_private_key(server_key)?
             .with_certificate(server_cert)?
             .with_groups(SERVER_CURVE_BASE_GROUPS)?
             .with_cipher_list(cipher_list)?;
 
         Ok(Self {
-            wolfssl,
+            tls_ctx,
             connection_type,
             auth,
             ip_pool,
@@ -499,7 +499,7 @@ impl<AppState> ServerContextBuilder<AppState> {
     #[cfg(feature = "postquantum")]
     pub fn with_pq_crypto(self) -> ContextBuilderResult<Self> {
         Ok(Self {
-            wolfssl: self.wolfssl.with_groups(SERVER_CURVE_PQC_GROUPS)?,
+            tls_ctx: self.tls_ctx.with_groups(SERVER_CURVE_PQC_GROUPS)?,
             ..self
         })
     }
@@ -509,9 +509,9 @@ impl<AppState> ServerContextBuilder<AppState> {
         debug_assert!(self.supported_protocol_versions.valid());
         let outside_plugins_instance = self.outside_plugins.build()?;
 
-        let wolfssl = self.wolfssl.build();
+        let tls_ctx = self.tls_ctx.build();
         Ok(ServerContext {
-            wolfssl,
+            tls_ctx,
             connection_type: self.connection_type,
             auth: self.auth,
             ip_pool: self.ip_pool,

--- a/lightway-core/src/io.rs
+++ b/lightway-core/src/io.rs
@@ -1,6 +1,6 @@
+use crate::tls::IOCallbackResult;
 use bytes::BytesMut;
 use std::{net::SocketAddr, sync::Arc};
-use wolfssl::IOCallbackResult;
 
 /// Maximum number of packets handled in a single batched IO call —
 /// covers both inbound (recvmmsg-style) reads and outbound
@@ -39,7 +39,7 @@ pub trait OutsideIOSendCallback {
     /// block [`std::io::ErrorKind::WouldBlock`] then return
     /// [`IOCallbackResult::WouldBlock`].
     ///
-    /// This is the same method as [`wolfssl::IOCallbacks::send`].
+    /// This is the same method as [`crate::tls::IOCallbacks::send`].
     fn send(&self, buf: &[u8]) -> IOCallbackResult<usize>;
 
     /// Get the peer's [`SocketAddr`]

--- a/lightway-core/src/keyshare.rs
+++ b/lightway-core/src/keyshare.rs
@@ -12,10 +12,10 @@ pub enum KeyShare {
 
 impl KeyShare {
     /// Get the corresponding curve group
-    pub fn as_curve_group(&self) -> wolfssl::CurveGroup {
+    pub fn as_curve_group(&self) -> crate::tls::CurveGroup {
         match self {
-            KeyShare::P521MLKEM1024 => wolfssl::CurveGroup::P521MLKEM1024,
-            KeyShare::X25519MLKEM768 => wolfssl::CurveGroup::X25519MLKEM768,
+            KeyShare::P521MLKEM1024 => crate::tls::CurveGroup::P521MLKEM1024,
+            KeyShare::X25519MLKEM768 => crate::tls::CurveGroup::X25519MLKEM768,
         }
     }
 }

--- a/lightway-core/src/lib.rs
+++ b/lightway-core/src/lib.rs
@@ -16,15 +16,13 @@ mod metrics;
 mod packet;
 mod packet_codec;
 mod plugin;
+pub mod tls;
 mod utils;
 mod version;
 mod wire;
 
-// Reexport wolfssl types
-pub use wolfssl::{IOCallbackResult, ProtocolVersion, RootCertificate, Secret};
-
-// Re-export wolfssl in case applications need it
-pub use wolfssl;
+// Reexport TLS types
+pub use tls::{IOCallbackResult, ProtocolVersion, RootCertificate, Secret};
 
 // Reexport our own types
 pub use builder_predicates::BuilderPredicates;
@@ -56,14 +54,14 @@ pub use plugin::{
     Plugin, PluginFactory, PluginFactoryError, PluginFactoryList, PluginFactoryType, PluginResult,
     PluginType,
 };
+#[cfg(feature = "debug")]
+pub use tls::{LoggingCallback as TlsLoggingCallback, Tls13SecretCallbacks};
 pub use utils::{
     ChecksumUpdate, ipv4_adjust_packet_checksum, ipv4_update_destination, ipv4_update_source,
     tcp_adjust_packet_checksum, udp_adjust_packet_checksum,
 };
 pub use version::Version;
 pub use wire::{AuthMethod, ExpresslaneKey, Header, SessionId};
-#[cfg(feature = "debug")]
-pub use wolfssl::{LoggingCallback, Tls13SecretCallbacks};
 
 /// Default MTU size for a packet on the outside path (on the wire)
 pub const MAX_OUTSIDE_MTU: usize = 1500;
@@ -102,16 +100,16 @@ pub const MIN_INSIDE_MTU: usize = 1250;
 /// The largest supported inside MTU.
 pub const MAX_INSIDE_MTU: usize = 1500;
 
-/// Enable debug logging from WolfSSL
+/// Enable debug logging from the TLS library
 #[cfg(feature = "debug")]
 pub fn enable_tls_debug() {
-    wolfssl::enable_debugging(true)
+    tls::enable_debugging(true)
 }
 
-/// Sets the callback for the logs from WolfSSL
+/// Sets the callback for the logs from the TLS library
 #[cfg(feature = "debug")]
-pub fn set_logging_callback(cb: LoggingCallback) {
-    wolfssl::install_logging_callback(cb)
+pub fn set_logging_callback(cb: TlsLoggingCallback) {
+    tls::install_logging_callback(cb)
 }
 
 #[cfg(feature = "fuzzing_api")]

--- a/lightway-core/src/metrics.rs
+++ b/lightway-core/src/metrics.rs
@@ -1,11 +1,11 @@
+use crate::tls::{Aes256GcmError, ProtocolVersion};
 use metrics::{Counter, counter};
 use std::sync::LazyLock;
 use tracing::{debug, warn};
-use wolfssl::{Aes256GcmError, ProtocolVersion};
 
 static METRIC_CONNECTION_ALLOC_FRAG_MAP: LazyLock<Counter> =
     LazyLock::new(|| counter!("conn_alloc_frag_map"));
-const METRIC_WOLFSSL_APPDATA: &str = "wolfssl_appdata";
+const METRIC_TLS_APPDATA: &str = "tls_appdata";
 static METRIC_INSIDE_IO_SEND_FAILED: LazyLock<Counter> =
     LazyLock::new(|| counter!("inside_io_send_failed"));
 static METRIC_SESSION_ID_MISMATCH: LazyLock<Counter> =
@@ -33,11 +33,10 @@ pub(crate) fn connection_alloc_frag_map() {
     METRIC_CONNECTION_ALLOC_FRAG_MAP.increment(1);
 }
 
-/// [`wolfssl`] returned [`wolfssl::Poll::AppData`] which is not expected with
+/// TLS library returned [`crate::tls::Poll::AppData`] which is not expected with
 /// TLS/DTLS 1.3
-pub(crate) fn wolfssl_appdata(tls_version: &ProtocolVersion) {
-    counter!(METRIC_WOLFSSL_APPDATA, TLS_PROTOCOL_VERSION_LABEL => tls_version.as_str())
-        .increment(1);
+pub(crate) fn tls_appdata(tls_version: &ProtocolVersion) {
+    counter!(METRIC_TLS_APPDATA, TLS_PROTOCOL_VERSION_LABEL => tls_version.as_str()).increment(1);
 }
 
 /// A call to [`crate::io::InsideIOSendCallback::send`] failed

--- a/lightway-core/src/tls/mod.rs
+++ b/lightway-core/src/tls/mod.rs
@@ -1,0 +1,5 @@
+//! TLS library layer — re-exports the wolfssl crate's public API; in-tree
+//! code imports TLS types from here rather than from `wolfssl` directly.
+
+pub use wolfssl::get_wolfssl_version_string as get_version_string;
+pub use wolfssl::*;

--- a/lightway-core/src/wire/expresslane_data.rs
+++ b/lightway-core/src/wire/expresslane_data.rs
@@ -78,16 +78,16 @@ impl From<[u8; EXPRESSLANE_KEY_SIZE]> for ExpresslaneKey {
     }
 }
 
-// Make sure WolfSsl Aes256Gcm key size is as expected
+// Make sure TLS library Aes256Gcm key size is as expected
 const _: () = {
-    assert!(wolfssl::Aes256Gcm::KEY_SIZE == EXPRESSLANE_KEY_SIZE);
+    assert!(crate::tls::Aes256Gcm::KEY_SIZE == EXPRESSLANE_KEY_SIZE);
 };
 
 struct ExpresslaneDataCipher {
     // Expresslane key
     pub key: ExpresslaneKey,
     // Underlying cipher algo
-    cipher: wolfssl::Aes256Gcm,
+    cipher: crate::tls::Aes256Gcm,
 }
 
 impl Debug for ExpresslaneDataCipher {
@@ -308,7 +308,7 @@ impl ExpresslaneData {
 
     pub(crate) fn update_next_self_key(&mut self, key: ExpresslaneKey) -> ExpresslaneResult<()> {
         let mut cipher =
-            wolfssl::Aes256Gcm::new().map_err(|_| ExpresslaneError::NewCipherFailed)?;
+            crate::tls::Aes256Gcm::new().map_err(|_| ExpresslaneError::NewCipherFailed)?;
         cipher
             .set_key(key.0)
             .map_err(|_| ExpresslaneError::SetKeyFailed)?;
@@ -325,7 +325,7 @@ impl ExpresslaneData {
 
     pub(crate) fn update_peer_key(&mut self, key: ExpresslaneKey) -> ExpresslaneResult<()> {
         let mut cipher =
-            wolfssl::Aes256Gcm::new().map_err(|_| ExpresslaneError::NewCipherFailed)?;
+            crate::tls::Aes256Gcm::new().map_err(|_| ExpresslaneError::NewCipherFailed)?;
         cipher
             .set_key(key.0)
             .map_err(|_| ExpresslaneError::SetKeyFailed)?;

--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -138,7 +138,7 @@ impl OutsideIOSendCallback for TestDatagramSock {
         match self.0.try_send(buf) {
             Ok(nr) => IOCallbackResult::Ok(nr),
             Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
-                // Real sockets never block (and doing so confuses WolfSSL!), but they do drop, so we do too!
+                // Real sockets never block (and doing so confuses the TLS library!), but they do drop, so we do too!
                 IOCallbackResult::Ok(buf.len())
             }
             Err(err) => IOCallbackResult::Err(err),
@@ -642,7 +642,8 @@ impl PQCrypto {
         match self.keyshare {
             Some(KeyShare::P521MLKEM1024) => "SecP521r1MLKEM1024",
             Some(KeyShare::X25519MLKEM768) => "X25519MLKEM768",
-            None => "X25519MLKEM768", // wolfSSL 5.0.0 default
+            // Based on the default set in KeyShare
+            None => "X25519MLKEM768", // wolfssl 5.0.0 default
         }
     }
 }
@@ -752,7 +753,7 @@ async fn test_stream_connection(cipher: Option<Cipher>, pqc: PQCrypto) {
 
 #[test_case(None; "No server domain name")]
 #[test_case(Some("example.com"); "Valid server domain name")]
-#[test_case(Some("invalid") => panics "WolfSSL Error: Fatal: Domain name mismatch"; "Invalid server domain name")]
+#[test_case(Some("invalid") => panics "TLS Error: Fatal: Domain name mismatch"; "Invalid server domain name")]
 #[tokio::test]
 async fn test_server_dn(server_dn: Option<&str>) {
     // Communicate over a local stream socket for simplicity

--- a/lightway-server/src/config.rs
+++ b/lightway-server/src/config.rs
@@ -136,7 +136,7 @@ pub struct Config {
     #[patch(attribute(clap(long)))]
     #[patch(empty_value = false)]
     #[patch(attribute(serde(default)))]
-    #[patch(attribute(doc = "Enable WolfSSL debug logging"))]
+    #[patch(attribute(doc = "Enable TLS debug logging"))]
     pub tls_debug: bool,
 
     #[cfg(feature = "debug")]

--- a/lightway-server/src/connection.rs
+++ b/lightway-server/src/connection.rs
@@ -132,7 +132,7 @@ impl Connection {
             ConnectionError::Disconnected => {
                 metrics::connection_data_after_disconnect();
             }
-            ConnectionError::WolfSSL(_) => {
+            ConnectionError::Tls(_) => {
                 metrics::connection_tls_error(fatal);
             }
             _ => {

--- a/lightway-server/src/io/outside/udp.rs
+++ b/lightway-server/src/io/outside/udp.rs
@@ -136,7 +136,7 @@ impl UdpServer {
         sockopt::set_ip_mtu_discover(&sock, sockopt::IpPmtudisc::Omit)?;
 
         // Check for the socket's writable ready status, so that it can be used
-        // successfuly in WolfSsl's `OutsideIOSendCallback` callback
+        // successfully in `OutsideIOSendCallback` callback
         sock.writable().await?;
         let sock = Arc::new(sock);
 
@@ -228,7 +228,7 @@ impl UdpServer {
         match conn.outside_data_received(pkt) {
             Ok(0) => {
                 // We will hit this case when there is UDP packet duplication.
-                // Wolfssl skip duplicate packets and thus no frames read.
+                // TLS library skips duplicate packets and thus no frames read.
                 // It is also possible that adversary can capture the packet
                 // and replay it. In any case, skip processing further
                 if update_peer_address {
@@ -236,7 +236,7 @@ impl UdpServer {
                 }
             }
             Ok(_) => {
-                // NOTE: We wait until the first successful WolfSSL
+                // NOTE: We wait until the first successful TLS
                 // decrypt to protect against the case where a crafted
                 // packet with a session ID causes us to change the
                 // connection IP without verifying the SSL connection


### PR DESCRIPTION
Introduce lightway-core::tls as the single re-export point for TLS types used across the workspace. In-tree crates now import TLS types from crate::tls instead of from wolfssl crate directly, keeping TLS-related imports in one place.