### PR TITLE
client: tolerate outside IO socket buffer size errors

### DIFF
--- a/lightway-client/src/io/outside/tcp.rs
+++ b/lightway-client/src/io/outside/tcp.rs
@@ -28,12 +28,16 @@ impl Tcp {
 impl OutsideIO for Tcp {
     fn set_send_buffer_size(&self, size: usize) -> Result<()> {
         let socket = socket2::SockRef::from(&self.0);
-        socket.set_send_buffer_size(size)?;
+        if let Err(e) = socket.set_send_buffer_size(size) {
+            tracing::warn!("Failed to set TCP send buffer size to {size}: {e}");
+        }
         Ok(())
     }
     fn set_recv_buffer_size(&self, size: usize) -> Result<()> {
         let socket = socket2::SockRef::from(&self.0);
-        socket.set_recv_buffer_size(size)?;
+        if let Err(e) = socket.set_recv_buffer_size(size) {
+            tracing::warn!("Failed to set TCP recv buffer size to {size}: {e}");
+        }
         Ok(())
     }
 

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -72,12 +72,16 @@ impl Udp {
 impl OutsideIO for Udp {
     fn set_send_buffer_size(&self, size: usize) -> Result<()> {
         let socket = socket2::SockRef::from(&self.sock);
-        socket.set_send_buffer_size(size)?;
+        if let Err(e) = socket.set_send_buffer_size(size) {
+            tracing::warn!("Failed to set UDP send buffer size to {size}: {e}");
+        }
         Ok(())
     }
     fn set_recv_buffer_size(&self, size: usize) -> Result<()> {
         let socket = socket2::SockRef::from(&self.sock);
-        socket.set_recv_buffer_size(size)?;
+        if let Err(e) = socket.set_recv_buffer_size(size) {
+            tracing::warn!("Failed to set UDP recv buffer size to {size}: {e}");
+        }
         Ok(())
     }
 


### PR DESCRIPTION
SO_SNDBUF / SO_RCVBUF are tuning hints. Some platforms reject the requested size, and propagating that as an error broke connection setup on those platforms.

Make set_send_buffer_size and set_recv_buffer_size on the UDP and TCP outside IO impls log a warning and continue instead of failing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CI tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
