### PR TITLE
CVPN-2559: Handle expresslane flags and session id tampering

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -229,6 +229,9 @@ jobs:
     - name: Check with mobile
       working-directory: ./lightway-client
       run: nix develop -c cargo check --features=mobile
+    - name: Clippy with mobile
+      working-directory: ./lightway-client
+      run: nix develop -c cargo clippy --features=mobile --all-targets -- -D warnings
     - name: Test with mobile features
       working-directory: ./lightway-client
       run: nix develop -c cargo test --features=mobile-test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,15 +885,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "easy-cast"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f40539c229fc2e4674bdecdf24bfcc2cb83631ca911c78a035fa9f2381c32b"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "educe"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,12 +1003,6 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "float-ord"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
 
 [[package]]
 name = "flume"
@@ -1575,12 +1560,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "lightway-app-utils"
 version = "0.1.0"
 dependencies = [
@@ -1702,7 +1681,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "average",
  "bytes",
  "bytesize",
  "clap",
@@ -2080,7 +2058,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/expressvpn/lightway"
 edition = "2024"
 authors = ["lightway-developers@expressvpn.com"]
 license = "AGPL-3.0-only"
-rust-version = "1.89.0"
+rust-version = "1.91.0"
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/docs/expresslane.md
+++ b/docs/expresslane.md
@@ -280,8 +280,13 @@ sequenceDiagram
 - **Auth Tag**: 128 bits (16 bytes)
 
 #### Authentication Vector
-- Combines session ID (8 bytes) + packet counter (8 bytes)
-- Provides replay protection and session binding
+- AES-GCM Additional Authenticated Data (AAD), 18 bytes total:
+  session ID (8 bytes) + packet counter (8 bytes) + flags (2 bytes)
+- Binds the in-clear flags field into the auth tag so an on-path attacker
+  cannot flip the `Encoded` bit (or any reserved bit) without invalidating
+  the tag. Tampered packets are rejected with `InvalidExpressData`.
+- Provides replay protection and session binding via the counter, and
+  cross-session isolation via the session ID.
 
 #### Fallback Mechanism
 - Always attempts current key first

--- a/docs/expresslane.md
+++ b/docs/expresslane.md
@@ -214,7 +214,7 @@ sequenceDiagram
             end
         end
 
-        loop Key Rotation (Every 60 seconds)
+        loop Key Rotation (every expresslane_keys_rotation_interval; default 15 min, configurable)
             T->>S: Key Rotation Timer
             S->>S: Generate new key K2, increment counter
             S->>C: ExpresslaneConfig(enabled=true, ack=false, counter=N, key=K2)

--- a/lightway-client/examples/route_monitor.rs
+++ b/lightway-client/examples/route_monitor.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
             Err(e) => {
                 error!("Error listening for route changes: {}", e);
                 // Continue monitoring even on errors with a small delay
-                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             }
         }
     }

--- a/lightway-client/src/config.rs
+++ b/lightway-client/src/config.rs
@@ -203,6 +203,11 @@ pub struct Config {
     pub enable_expresslane: bool,
 
     #[patch(attribute(clap(long)))]
+    #[patch(attribute(doc = "Interval between Expresslane key rotations"))]
+    #[schemars(schema_with = "lightway_app_utils::args::duration_schema")]
+    pub expresslane_keys_rotation_interval: Duration,
+
+    #[patch(attribute(clap(long)))]
     #[patch(empty_value = false)]
     #[patch(attribute(serde(default)))]
     #[patch(attribute(doc = "Enable PMTU discovery for [`ConnectionType::Udp`] connections"))]
@@ -389,6 +394,9 @@ impl Default for Config {
             dns_config_mode: DnsConfigMode::default(),
             log_level: LogLevel::Info,
             enable_expresslane: false,
+            expresslane_keys_rotation_interval: Duration::from_std_duration(
+                lightway_core::DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL,
+            ),
             enable_pmtud: false,
             pmtud_base_mtu: None,
             enable_tun_iouring: false,

--- a/lightway-client/src/config.rs
+++ b/lightway-client/src/config.rs
@@ -472,17 +472,16 @@ impl ConnectionConfig {
     pub fn load_ca(&self) -> Result<lightway_core::tls::RootCertificate<'_>, Error> {
         self.ca_cert
             .as_ref()
-            .map(|ca| load_ca(ca))
+            .map(load_ca)
             .ok_or(Error::InvalidCertificate)?
     }
 
     /// Try build SocketAddress from server field
     #[cfg(feature = "mobile")]
     pub fn skt_addr(&self) -> Result<std::net::SocketAddr, Error> {
-        Ok(self
-            .server
+        self.server
             .parse()
-            .map_err(|_e| Error::InvalidSocketAddress)?)
+            .map_err(|_e| Error::InvalidSocketAddress)
     }
 }
 
@@ -570,7 +569,7 @@ impl From<MobileConnectionConfig> for ConnectionConfig {
         }: MobileConnectionConfig,
     ) -> ConnectionConfig {
         ConnectionConfig {
-            server: format!("{}:{}", server_ip.ip.to_string(), port),
+            server: format!("{}:{}", server_ip.ip, port),
             mode: if use_tcp {
                 ConnectionType::Tcp
             } else {

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -43,8 +43,8 @@ use crate::route_manager::{RouteManager, RouteMode};
 #[cfg(batch_receive)]
 use lightway_core::MAX_IO_BATCH_SIZE;
 pub use lightway_core::{
-    AuthMethod, MAX_INSIDE_MTU, MAX_OUTSIDE_MTU, PluginFactoryError, PluginFactoryList,
-    RootCertificate, Version,
+    AuthMethod, DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL, MAX_INSIDE_MTU, MAX_OUTSIDE_MTU,
+    PluginFactoryError, PluginFactoryList, RootCertificate, Version,
 };
 #[cfg(feature = "debug")]
 // re-export so client app does not need to depend on lightway-core
@@ -211,6 +211,9 @@ pub struct ClientConfig<'cert, ExtAppState: Send + Sync> {
 
     /// Enable Expresslane for Udp connections
     pub enable_expresslane: bool,
+
+    /// Interval between Expresslane key rotations
+    pub expresslane_keys_rotation_interval: std::time::Duration,
 
     /// Callback for expresslane key updates
     #[educe(Debug(ignore))]
@@ -871,7 +874,9 @@ pub async fn connect<
     .with_cipher(server_config.cipher.into())?
     .with_inside_plugins(server_config.inside_plugins)
     .with_outside_plugins(server_config.outside_plugins)
-    .when(config.enable_expresslane, |b| b.with_expresslane())
+    .when(config.enable_expresslane, |b| {
+        b.with_expresslane(config.expresslane_keys_rotation_interval)
+    })
     .when(config.expresslane_cb.is_some(), |b| {
         b.with_expresslane_cb(config.expresslane_cb.clone().unwrap())
     })

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -254,6 +254,7 @@ async fn main() -> Result<()> {
         #[cfg(feature = "postquantum")]
         keyshare: config.keyshare,
         enable_expresslane: config.enable_expresslane,
+        expresslane_keys_rotation_interval: config.expresslane_keys_rotation_interval.into(),
         expresslane_cb: None,
         expresslane_metrics: None,
         keepalive_interval: config.keepalive_interval.into(),

--- a/lightway-client/src/mobile/lightway.rs
+++ b/lightway-client/src/mobile/lightway.rs
@@ -81,7 +81,7 @@ struct OutsideIOBuilder {
     server_sockaddr: SocketAddr,
 }
 
-impl<'a> OutsideIOBuilder {
+impl OutsideIOBuilder {
     fn new(socket: OutsideSocket, server_sockaddr: SocketAddr) -> Self {
         Self {
             socket,
@@ -409,7 +409,7 @@ pub(crate) async fn async_lightway_start(
             match result {
                 Ok(Ok(client_result)) => {
                     info!("network change task result: {client_result:?}");
-                    Ok(client_result.into())
+                    Ok(client_result)
                 },
                 Ok(Err(e)) => {
                     Err(anyhow!("error during network change: {e:?}"))
@@ -803,10 +803,9 @@ async fn handle_events<A: 'static + Send + EventCallback>(
             Event::ExpresslaneStateChanged(state) => {
                 if let Some(tx) = expresslane_event_tx.as_ref()
                     && let Ok(state) = (*state).try_into()
+                    && let Err(e) = tx.try_send(state)
                 {
-                    if let Err(e) = tx.try_send(state) {
-                        warn!("Unable to send Expresslane state change event: {:?}", e);
-                    }
+                    warn!("Unable to send Expresslane state change event: {:?}", e);
                 }
                 continue;
             }

--- a/lightway-client/src/mobile/lightway.rs
+++ b/lightway-client/src/mobile/lightway.rs
@@ -220,6 +220,9 @@ pub(crate) async fn async_lightway_start(
                     socket: outside_sockets[instance_id].take(),
                     enable_keepalive: config.keepalive_continuous,
                     enable_expresslane: config.enable_expresslane,
+                    expresslane_keys_rotation_interval: config
+                        .expresslane_keys_rotation_interval
+                        .into(),
                     online_signal_sender: online_signal_sender.clone(),
                     event_stream_handler: event_handler.clone(),
                     external_event_handler: external_event_handler.clone(),
@@ -557,6 +560,7 @@ struct LightwayClientConnectArgs {
     socket: Option<OutsideSocket>,
     enable_keepalive: bool,
     enable_expresslane: bool,
+    expresslane_keys_rotation_interval: std::time::Duration,
     online_signal_sender: tokio::sync::mpsc::Sender<usize>,
     event_stream_handler: EventStreamCallback,
     external_event_handler: Arc<dyn RustEventHandlers>,
@@ -571,6 +575,7 @@ async fn lightway_client_connect(
         socket,
         enable_keepalive,
         enable_expresslane,
+        expresslane_keys_rotation_interval,
         online_signal_sender,
         event_stream_handler,
         external_event_handler,
@@ -630,7 +635,7 @@ async fn lightway_client_connect(
     .with_inside_plugins(inside_plugins)
     .with_outside_plugins(outside_plugins)
     .when(connection_type.is_datagram() && enable_expresslane, |b| {
-        b.with_expresslane()
+        b.with_expresslane(expresslane_keys_rotation_interval)
     })
     .build()
     .start_connect(outside_io.clone().into_io_send_callback(), outside_mtu)?

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -550,7 +550,7 @@ impl RouteManagerInner {
                        Err(e) => {
                            // Continue monitoring even on transient errors
                            tracing::debug!("Error listening for route changes: {}", e);
-                           tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+                           tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                        }
                    }}
 
@@ -702,7 +702,7 @@ mod tests {
         // Add 50ms sleep to allow TUN device to be fully initialized
         // NOTE: This sometimes adds an additional route after the tests have stored the initial route
         //       which may lead to inaccurate tests. 50ms is eternity and enough to stabilise this.
-        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         let tun_index = tun_device.if_index()?;
 

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -1796,11 +1796,18 @@ impl<AppState: Send> Connection<AppState> {
         // If updating key failed, send disabled to peer
         let enabled = self.expresslane.data.update_next_self_key(key).is_ok();
 
+        // Outgoing version: if we have already negotiated a version
+        // with the peer, use that. Otherwise advertise our local max
+        let version = match self.expresslane.data.version {
+            ExpresslaneVersion::Unknown => ExpresslaneVersion::MAX,
+            v => v,
+        };
+
         self.expresslane.config_counter += 1;
         let config = wire::ExpresslaneConfig {
             enabled,
             key,
-            version: ExpresslaneVersion::MAX,
+            version,
             ack: false,
             counter: self.expresslane.config_counter,
         };
@@ -1826,11 +1833,16 @@ impl<AppState: Send> Connection<AppState> {
         let key = ExpresslaneKey::INVALID;
         let _ = self.expresslane.data.update_next_self_key(key);
 
+        let version = match self.expresslane.data.version {
+            ExpresslaneVersion::Unknown => ExpresslaneVersion::MAX,
+            v => v,
+        };
+
         self.expresslane.config_counter += 1;
         let config = wire::ExpresslaneConfig {
             enabled: false,
             key,
-            version: ExpresslaneVersion::MAX,
+            version,
             ack: false,
             counter: self.expresslane.config_counter,
         };

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -465,6 +465,7 @@ struct NewConnectionArgs<AppState> {
     expresslane: bool,
     expresslane_cb: Option<expresslane::ExpresslaneCbType<AppState>>,
     expresslane_metrics: Option<expresslane::ExpresslaneMetricsType>,
+    expresslane_keys_rotation_interval: std::time::Duration,
 }
 
 impl<AppState: Send> Connection<AppState> {
@@ -528,6 +529,7 @@ impl<AppState: Send> Connection<AppState> {
                 expresslane_state,
                 args.expresslane_cb,
                 args.expresslane_metrics,
+                args.expresslane_keys_rotation_interval,
             ),
         };
 

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -229,10 +229,6 @@ pub enum ConnectionError {
     /// A Packet Codec error occurred
     #[error("Packet Codec error: {0}")]
     PacketCodecError(Box<dyn std::error::Error + Sync + Send>),
-
-    /// Encoding Request Retransmit CB does not exist
-    #[error("Schedule Encoding Request Retransmit Cb Does Not Exist")]
-    EncodingReqRetransmitCbDoesNotExist,
 }
 
 impl ConnectionError {
@@ -258,7 +254,6 @@ impl ConnectionError {
                     PacketCodecDoesNotExist => true,
                     PacketCodecError(_) => true,
                     Disconnected => true,
-                    EncodingReqRetransmitCbDoesNotExist => true,
                     PathMtuDiscoveryRequired { .. } => true,
                     Tls(crate::tls::Error::Fatal(ErrorKind::DomainNameMismatch)) => true,
                     Tls(crate::tls::Error::Fatal(ErrorKind::DuplicateMessage)) => true,

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -1701,8 +1701,15 @@ impl<AppState: Send> Connection<AppState> {
         if !matches!(self.state, State::Online) {
             return Err(ConnectionError::InvalidState);
         }
-        if config.version != self.expresslane.data.version {
-            return Err(ConnectionError::ExpresslaneVersionMismatch);
+        let neg_version = ExpresslaneVersion::negotiate(config.version);
+        if neg_version != self.expresslane.data.version {
+            info!(
+                "Negotiated expresslane version: {:?} [max:{:?} peer:{:?}]",
+                neg_version,
+                ExpresslaneVersion::MAX,
+                config.version,
+            );
+            self.expresslane.data.version = neg_version;
         }
 
         // Handle acknowledgement from peer
@@ -1752,9 +1759,10 @@ impl<AppState: Send> Connection<AppState> {
             self.set_expresslane_state(ExpresslaneState::Inactive);
         }
 
-        // Send acknowledgement
+        // Send acknowledgement with the negotiated version
         let mut config = config;
         config.ack = true;
+        config.version = self.expresslane.data.version;
         let msg = wire::Frame::ExpresslaneConfig(config);
         let _ = self.send_frame_or_drop(msg);
 
@@ -1792,7 +1800,7 @@ impl<AppState: Send> Connection<AppState> {
         let config = wire::ExpresslaneConfig {
             enabled,
             key,
-            version: ExpresslaneVersion::Version1,
+            version: ExpresslaneVersion::MAX,
             ack: false,
             counter: self.expresslane.config_counter,
         };
@@ -1822,7 +1830,7 @@ impl<AppState: Send> Connection<AppState> {
         let config = wire::ExpresslaneConfig {
             enabled: false,
             key,
-            version: ExpresslaneVersion::Version1,
+            version: ExpresslaneVersion::MAX,
             ack: false,
             counter: self.expresslane.config_counter,
         };

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -249,7 +249,6 @@ impl ConnectionError {
                 match self {
                     TimedOut => true,
                     Unauthorized => true,
-                    InvalidProtocolVersion => true,
                     InvalidMode => true,
                     InvalidConnectionType => true,
                     NoAvailableClientIp => true,
@@ -270,8 +269,10 @@ impl ConnectionError {
                     WireError(wire::FromWireError::InsufficientData) => false,
                     WireError(wire::FromWireError::InvalidExpressData) => false,
                     WireError(wire::FromWireError::ReplayedExpressData) => false,
+                    WireError(wire::FromWireError::InvalidProtocolVersion(..)) => false,
                     WireError(_) => true,
 
+                    InvalidProtocolVersion => false,
                     InvalidState => false, // Can be due to out of order or repeated messages
                     InvalidInsideIo => false, // Can be used for test only test control plane
                     UnknownSessionID => false,

--- a/lightway-core/src/connection/builders.rs
+++ b/lightway-core/src/connection/builders.rs
@@ -260,6 +260,7 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
             expresslane: self.ctx.expresslane,
             expresslane_cb: self.ctx.expresslane_cb.clone(),
             expresslane_metrics: self.ctx.expresslane_metrics.clone(),
+            expresslane_keys_rotation_interval: self.ctx.expresslane_keys_rotation_interval,
         })?)
     }
 }
@@ -398,6 +399,7 @@ impl<'a, AppState: Send + 'static> ServerConnectionBuilder<'a, AppState> {
             expresslane: self.ctx.expresslane,
             expresslane_cb: self.ctx.expresslane_cb.clone(),
             expresslane_metrics: self.ctx.expresslane_metrics.clone(),
+            expresslane_keys_rotation_interval: self.ctx.expresslane_keys_rotation_interval,
         })?)
     }
 }

--- a/lightway-core/src/connection/dplpmtud.rs
+++ b/lightway-core/src/connection/dplpmtud.rs
@@ -22,7 +22,7 @@ const PROBE_SMALL_STEP: u16 = 8;
 /// Timeout for the PROBE_TIMER timer
 const PROBE_TIME_TIMEOUT: Duration = Duration::from_secs(5);
 /// Timeout for the PMTU_RAISE_TIMER timer. Also used a CONFIRMATION_TIMER.
-const PMTU_RAISE_TIMER_TIMEOUT: Duration = Duration::from_secs(600);
+const PMTU_RAISE_TIMER_TIMEOUT: Duration = Duration::from_mins(10);
 
 /// Returns the required [`wire::Ping`] payload size needed to
 /// construct a probe frame corresponding to the given PLPMTU.
@@ -1137,7 +1137,7 @@ mod tests {
         assert!(matches!(action, Action::None));
         assert!(matches!(pmtud.state, State::SearchComplete));
         assert!(pmtud.effective_pmtu().is_some());
-        timer.expect_pending(Duration::from_secs(600));
+        timer.expect_pending(Duration::from_mins(10));
 
         pmtud.plpmtu
     }
@@ -1180,7 +1180,7 @@ mod tests {
         // Search now complete with PMTU 1232 and PMTU_RAISE_TIMER pending
         assert!(matches!(pmtud.state, State::SearchComplete));
         assert_eq!(pmtud.plpmtu, 1282);
-        timer.expect_pending(Duration::from_secs(600));
+        timer.expect_pending(Duration::from_mins(10));
 
         (action, pmtud)
     }
@@ -1249,7 +1249,7 @@ mod tests {
 
         assert!(matches!(action, Action::None));
         assert!(matches!(pmtud.state, State::SearchComplete));
-        timer.expect_pending(Duration::from_secs(600));
+        timer.expect_pending(Duration::from_mins(10));
 
         pmtud.plpmtu
     }
@@ -1425,7 +1425,7 @@ mod tests {
         }
 
         assert!(matches!(pmtud.state, State::SearchComplete));
-        timer.expect_pending(Duration::from_secs(600));
+        timer.expect_pending(Duration::from_mins(10));
 
         pmtud.offline(&mut ());
         assert!(matches!(pmtud.state, State::Disabled));

--- a/lightway-core/src/connection/expresslane.rs
+++ b/lightway-core/src/connection/expresslane.rs
@@ -29,7 +29,7 @@ pub trait ExpresslaneCb<AppState> {
 pub type ExpresslaneCbType<AppState> = Arc<dyn ExpresslaneCb<AppState> + Sync + Send>;
 
 /// Default interval between expresslane key rotations
-pub const DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL: Duration = Duration::from_secs(60 * 15);
+pub const DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL: Duration = Duration::from_mins(15);
 
 /// Packet counters for ExpressLane health monitoring.
 #[derive(Debug, Default, Clone, Copy)]

--- a/lightway-core/src/connection/expresslane.rs
+++ b/lightway-core/src/connection/expresslane.rs
@@ -28,8 +28,8 @@ pub trait ExpresslaneCb<AppState> {
 /// Convenience type for [`ExpresslaneCb`] trait objects.
 pub type ExpresslaneCbType<AppState> = Arc<dyn ExpresslaneCb<AppState> + Sync + Send>;
 
-/// Interval between expresslane key rotations
-pub(crate) const EXPRESSLANE_KEYS_ROTATION_INTERVAL: Duration = Duration::from_secs(60 * 15);
+/// Default interval between expresslane key rotations
+pub const DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL: Duration = Duration::from_secs(60 * 15);
 
 /// Packet counters for ExpressLane health monitoring.
 #[derive(Debug, Default, Clone, Copy)]
@@ -82,6 +82,8 @@ pub(crate) struct Expresslane<AppState: Send> {
     pub(crate) cb: Option<ExpresslaneCbType<AppState>>,
     /// External metrics provider
     pub(crate) metrics: Option<ExpresslaneMetricsType>,
+    /// Interval between expresslane key rotations
+    pub(crate) keys_rotation_interval: Duration,
 }
 
 impl<AppState: Send> Expresslane<AppState> {
@@ -89,6 +91,7 @@ impl<AppState: Send> Expresslane<AppState> {
         state: ExpresslaneState,
         cb: Option<ExpresslaneCbType<AppState>>,
         metrics: Option<ExpresslaneMetricsType>,
+        keys_rotation_interval: Duration,
     ) -> Self {
         Self {
             state,
@@ -102,6 +105,7 @@ impl<AppState: Send> Expresslane<AppState> {
             data: ExpresslaneData::default(),
             cb,
             metrics,
+            keys_rotation_interval,
         }
     }
 
@@ -124,7 +128,7 @@ impl<AppState: Send> Expresslane<AppState> {
     pub(crate) fn time_to_rotate_key(&self) -> bool {
         match self.last_key_rotation {
             None => true,
-            Some(last) => last.elapsed() > EXPRESSLANE_KEYS_ROTATION_INTERVAL,
+            Some(last) => last.elapsed() > self.keys_rotation_interval,
         }
     }
 }

--- a/lightway-core/src/context.rs
+++ b/lightway-core/src/context.rs
@@ -8,7 +8,9 @@ use crate::{
     BuilderPredicates, Cipher, ClientConnectionBuilder, ConnectionBuilderError,
     InsideIOSendCallbackArg, OutsideIOSendCallbackArg, OutsidePacket, PluginResult,
     RootCertificate, Secret, ServerConnectionBuilder, ServerIpPoolArg, Version,
-    connection::expresslane::{ExpresslaneCbType, ExpresslaneMetricsType},
+    connection::expresslane::{
+        DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL, ExpresslaneCbType, ExpresslaneMetricsType,
+    },
     context::ip_pool::ClientIpConfigArg,
     packet::OutsidePacketError,
     plugin::{PluginFactoryError, PluginFactoryList, PluginList},
@@ -122,6 +124,7 @@ pub struct ClientContext<AppState> {
     pub(crate) expresslane: bool,
     pub(crate) expresslane_cb: Option<ExpresslaneCbType<AppState>>,
     pub(crate) expresslane_metrics: Option<ExpresslaneMetricsType>,
+    pub(crate) expresslane_keys_rotation_interval: std::time::Duration,
 }
 
 impl<AppState: Send + 'static> ClientContext<AppState> {
@@ -148,6 +151,7 @@ pub struct ClientContextBuilder<AppState> {
     expresslane: bool,
     expresslane_cb: Option<ExpresslaneCbType<AppState>>,
     expresslane_metrics: Option<ExpresslaneMetricsType>,
+    expresslane_keys_rotation_interval: std::time::Duration,
 }
 
 impl<AppState> ClientContextBuilder<AppState> {
@@ -179,6 +183,7 @@ impl<AppState> ClientContextBuilder<AppState> {
             expresslane: false,
             expresslane_cb: None,
             expresslane_metrics: None,
+            expresslane_keys_rotation_interval: DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL,
         })
     }
 
@@ -209,10 +214,11 @@ impl<AppState> ClientContextBuilder<AppState> {
         Ok(Self { tls_ctx, ..self })
     }
 
-    /// Enable expresslane data path
-    pub fn with_expresslane(self) -> Self {
+    /// Enable expresslane data path with the given key rotation interval
+    pub fn with_expresslane(self, keys_rotation_interval: std::time::Duration) -> Self {
         Self {
             expresslane: true,
+            expresslane_keys_rotation_interval: keys_rotation_interval,
             ..self
         }
     }
@@ -247,6 +253,7 @@ impl<AppState> ClientContextBuilder<AppState> {
             rng: Arc::new(Mutex::new(rand::make_rng::<rand::rngs::StdRng>())),
             expresslane: self.expresslane,
             expresslane_cb: self.expresslane_cb,
+            expresslane_keys_rotation_interval: self.expresslane_keys_rotation_interval,
             expresslane_metrics: self.expresslane_metrics,
         }
     }
@@ -297,6 +304,7 @@ pub struct ServerContext<AppState = ()> {
     pub(crate) expresslane: bool,
     pub(crate) expresslane_cb: Option<ExpresslaneCbType<AppState>>,
     pub(crate) expresslane_metrics: Option<ExpresslaneMetricsType>,
+    pub(crate) expresslane_keys_rotation_interval: std::time::Duration,
 }
 
 impl<AppState: Send + 'static> ServerContext<AppState> {
@@ -354,6 +362,7 @@ pub struct ServerContextBuilder<AppState> {
     expresslane: bool,
     expresslane_cb: Option<ExpresslaneCbType<AppState>>,
     expresslane_metrics: Option<ExpresslaneMetricsType>,
+    expresslane_keys_rotation_interval: std::time::Duration,
 }
 
 /// server curves when PQC is not enabled, in decreasing order of preference.
@@ -418,6 +427,7 @@ impl<AppState> ServerContextBuilder<AppState> {
             expresslane: false,
             expresslane_cb: None,
             expresslane_metrics: None,
+            expresslane_keys_rotation_interval: DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL,
         })
     }
 
@@ -471,10 +481,11 @@ impl<AppState> ServerContextBuilder<AppState> {
         }
     }
 
-    /// Enable expresslane data path
-    pub fn with_expresslane(self) -> Self {
+    /// Enable expresslane data path with the given key rotation interval
+    pub fn with_expresslane(self, keys_rotation_interval: std::time::Duration) -> Self {
         Self {
             expresslane: true,
+            expresslane_keys_rotation_interval: keys_rotation_interval,
             ..self
         }
     }
@@ -526,6 +537,7 @@ impl<AppState> ServerContextBuilder<AppState> {
             expresslane: self.expresslane,
             expresslane_cb: self.expresslane_cb,
             expresslane_metrics: self.expresslane_metrics,
+            expresslane_keys_rotation_interval: self.expresslane_keys_rotation_interval,
         })
     }
 }

--- a/lightway-core/src/wire/expresslane_config.rs
+++ b/lightway-core/src/wire/expresslane_config.rs
@@ -4,12 +4,42 @@ use bytes::{Buf, BufMut, BytesMut};
 
 use super::{FromWireError, FromWireResult, expresslane_data::ExpresslaneKey};
 
+/// On-wire expresslane version.
+///
+/// Unknown represents both "byte 0 (never advertised)" and "a future
+/// version byte this build does not yet recognise". Both cases are
+/// handled the same way at negotiation time - fall back to our local
+/// max - so collapsing them into one variant keeps the type simple
+/// without giving up forward compat.
 #[repr(u8)]
-#[derive(PartialEq, Debug, Copy, Clone, Default)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Copy, Clone, Default)]
 pub enum ExpresslaneVersion {
-    Unknown = 0,
     #[default]
+    Unknown = 0,
     Version1 = 1,
+}
+
+impl ExpresslaneVersion {
+    /// Highest expresslane version this build supports.
+    pub const MAX: Self = Self::Version1;
+
+    /// Negotiate the wire version against a peer's advertised value.
+    /// Forward-compatible by design: if the peer advertised a version
+    /// we don't recognise, we fall back to `Self::MAX`. Otherwise
+    /// we take the lower of our local max and the peer's advertised
+    /// version.
+    ///
+    /// Scenarios:
+    ///   * V1 peer + V1 build -> V1.
+    ///   * V1 peer + V2 build -> V2 build downgrades, both at V1.
+    ///   * V2 peer + V1 build -> V1 build sees Unknown, replies with
+    ///     its own MAX (V1). V2 peer downgrades on its side and stay at V1.
+    pub(crate) fn negotiate(peer: Self) -> Self {
+        match peer {
+            Self::Unknown => Self::MAX,
+            v => Self::MAX.min(v),
+        }
+    }
 }
 
 impl From<u8> for ExpresslaneVersion {
@@ -130,7 +160,7 @@ mod tests {
     #[test]
     fn default() {
         let config = ExpresslaneConfig::default();
-        assert_eq!(config.version, ExpresslaneVersion::Version1);
+        assert_eq!(config.version, ExpresslaneVersion::Unknown);
         assert!(!config.enabled);
         assert!(!config.ack);
         assert_eq!(config.counter, 0);
@@ -193,11 +223,29 @@ mod tests {
 
     #[test]
     fn version_enum_conversions() {
-        assert_eq!(ExpresslaneVersion::from(1), ExpresslaneVersion::Version1);
         assert_eq!(ExpresslaneVersion::from(0), ExpresslaneVersion::Unknown);
+        assert_eq!(ExpresslaneVersion::from(1), ExpresslaneVersion::Version1);
+        // Any byte > LOCAL_MAX collapses to Unknown.
+        assert_eq!(ExpresslaneVersion::from(2), ExpresslaneVersion::Unknown);
         assert_eq!(ExpresslaneVersion::from(255), ExpresslaneVersion::Unknown);
 
-        assert_eq!(ExpresslaneVersion::Version1 as u8, 1);
         assert_eq!(ExpresslaneVersion::Unknown as u8, 0);
+        assert_eq!(ExpresslaneVersion::Version1 as u8, 1);
+    }
+
+    #[test]
+    fn negotiation_handles_future_peer_versions() {
+        assert_eq!(ExpresslaneVersion::MAX, ExpresslaneVersion::Version1);
+
+        // Peer advertised V1 → matched.
+        assert_eq!(
+            ExpresslaneVersion::negotiate(ExpresslaneVersion::Version1),
+            ExpresslaneVersion::Version1
+        );
+
+        assert_eq!(
+            ExpresslaneVersion::negotiate(ExpresslaneVersion::Unknown),
+            ExpresslaneVersion::MAX,
+        );
     }
 }

--- a/lightway-core/src/wire/expresslane_config.rs
+++ b/lightway-core/src/wire/expresslane_config.rs
@@ -15,13 +15,18 @@ use super::{FromWireError, FromWireResult, expresslane_data::ExpresslaneKey};
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Copy, Clone, Default)]
 pub enum ExpresslaneVersion {
     #[default]
+    // Not used
     Unknown = 0,
+    // Initial Expresslane format
     Version1 = 1,
+    /// same wire layout as V1, but the expresslane flags field
+    /// is bound into the AEAD AAD. Incompatible with V1 builds
+    Version2 = 2,
 }
 
 impl ExpresslaneVersion {
     /// Highest expresslane version this build supports.
-    pub const MAX: Self = Self::Version1;
+    pub const MAX: Self = Self::Version2;
 
     /// Negotiate the wire version against a peer's advertised value.
     /// Forward-compatible by design: if the peer advertised a version
@@ -46,6 +51,7 @@ impl From<u8> for ExpresslaneVersion {
     fn from(value: u8) -> Self {
         match value {
             1 => Self::Version1,
+            2 => Self::Version2,
             _ => Self::Unknown,
         }
     }
@@ -225,22 +231,37 @@ mod tests {
     fn version_enum_conversions() {
         assert_eq!(ExpresslaneVersion::from(0), ExpresslaneVersion::Unknown);
         assert_eq!(ExpresslaneVersion::from(1), ExpresslaneVersion::Version1);
+        assert_eq!(ExpresslaneVersion::from(2), ExpresslaneVersion::Version2);
         // Any byte > LOCAL_MAX collapses to Unknown.
-        assert_eq!(ExpresslaneVersion::from(2), ExpresslaneVersion::Unknown);
+        assert_eq!(ExpresslaneVersion::from(3), ExpresslaneVersion::Unknown);
         assert_eq!(ExpresslaneVersion::from(255), ExpresslaneVersion::Unknown);
 
         assert_eq!(ExpresslaneVersion::Unknown as u8, 0);
         assert_eq!(ExpresslaneVersion::Version1 as u8, 1);
+        assert_eq!(ExpresslaneVersion::Version2 as u8, 2);
     }
 
+    /// Forward compatibility: a future peer advertising a higher
+    /// version byte than we know about must still negotiate cleanly
+    /// down to our local max - NOT cause expresslane to be rejected.
+    /// This is the property that lets us ship V2 today and add V3
+    /// later without breaking the binaries already in the field, in
+    /// either rollout direction (older talking to newer, or newer
+    /// talking to older).
     #[test]
     fn negotiation_handles_future_peer_versions() {
-        assert_eq!(ExpresslaneVersion::MAX, ExpresslaneVersion::Version1);
+        assert_eq!(ExpresslaneVersion::MAX, ExpresslaneVersion::Version2);
 
-        // Peer advertised V1 → matched.
+        // Peer advertised V1 → V1 (peer is the constraint).
         assert_eq!(
             ExpresslaneVersion::negotiate(ExpresslaneVersion::Version1),
             ExpresslaneVersion::Version1
+        );
+
+        // Peer advertised V2 → V2 (matched).
+        assert_eq!(
+            ExpresslaneVersion::negotiate(ExpresslaneVersion::Version2),
+            ExpresslaneVersion::Version2
         );
 
         assert_eq!(

--- a/lightway-core/src/wire/expresslane_data.rs
+++ b/lightway-core/src/wire/expresslane_data.rs
@@ -10,6 +10,25 @@ use tracing::debug;
 
 use super::{FromWireError, FromWireResult, SessionId, expresslane_config::ExpresslaneVersion};
 
+/// Build AEAD AAD for an expresslane data packet.
+/// Returns a fixed-size buffer and the number of significant bytes
+fn build_aad(
+    version: ExpresslaneVersion,
+    session_id: &SessionId,
+    wire_counter: u64,
+    flags: Flags,
+) -> ([u8; 18], usize) {
+    let mut buf = [0u8; 18];
+    buf[..8].copy_from_slice(&session_id.0[..]);
+    buf[8..16].copy_from_slice(&wire_counter.to_be_bytes()[..]);
+    if version >= ExpresslaneVersion::Version2 {
+        buf[16..].copy_from_slice(&u16::from(flags).to_be_bytes());
+        (buf, 18)
+    } else {
+        (buf, 16)
+    }
+}
+
 /// A expresslane data frame
 ///
 /// This is a variable sized request.
@@ -383,10 +402,9 @@ impl ExpresslaneData {
         let flags = Flags::from(buf.get_u16());
         let is_encoded = flags.encoded();
 
-        let mut auth_vec: [u8; 18] = [0; 18];
-        auth_vec[..8].copy_from_slice(&session_id.0[..]);
-        auth_vec[8..16].copy_from_slice(&wire_counter.to_be_bytes()[..]);
-        auth_vec[16..].copy_from_slice(&u16::from(flags).to_be_bytes());
+        let (auth_vec_buf, auth_vec_len) =
+            build_aad(self.version, &session_id, wire_counter, flags);
+        let auth_vec = &auth_vec_buf[..auth_vec_len];
 
         if buf.len() < data_len {
             return Err(FromWireError::InsufficientData);
@@ -401,7 +419,7 @@ impl ExpresslaneData {
 
         let plain_text = current
             .cipher
-            .decrypt(iv, data.as_ref(), &auth_vec[..], &auth_tag)
+            .decrypt(iv, data.as_ref(), auth_vec, &auth_tag)
             .map_err(|_| FromWireError::InvalidExpressData);
 
         let plain_text = match plain_text {
@@ -409,7 +427,7 @@ impl ExpresslaneData {
             Err(e) => {
                 if let Some(prev) = &mut self.prev_peer {
                     prev.cipher
-                        .decrypt(iv, data.as_ref(), &auth_vec[..], &auth_tag)
+                        .decrypt(iv, data.as_ref(), auth_vec, &auth_tag)
                         .inspect_err(metrics::expresslane_decrypt_failed)
                         .map_err(|_| e)?
                 } else {
@@ -446,14 +464,13 @@ impl ExpresslaneData {
 
         let flags = Flags::new().with_encoded(is_encoded);
 
-        let mut auth_vec: [u8; 18] = [0; 18];
-        auth_vec[..8].copy_from_slice(&session_id.0[..]);
-        auth_vec[8..16].copy_from_slice(&self.wire_counter.to_be_bytes()[..]);
-        auth_vec[16..].copy_from_slice(&u16::from(flags).to_be_bytes());
+        let (auth_vec_buf, auth_vec_len) =
+            build_aad(self.version, &session_id, self.wire_counter, flags);
+        let auth_vec = &auth_vec_buf[..auth_vec_len];
 
         let (cipher_text, auth_tag) = current
             .cipher
-            .encrypt(iv, plain_text.as_ref(), &auth_vec)
+            .encrypt(iv, plain_text.as_ref(), auth_vec)
             .expect("Encrypt failed");
 
         buf.put_u64(self.wire_counter);
@@ -931,12 +948,83 @@ mod tests {
         ));
     }
 
+    /// V1 sender ↔ V1 receiver roundtrip succeeds without flags-in-AAD.
+    /// Proves the downgrade path still interoperates with legacy V1
+    /// peers (which compute AAD over session_id||counter only).
+    #[test]
+    fn v1_roundtrip_without_flags_in_aad() {
+        let mut sender = ExpresslaneData {
+            version: ExpresslaneVersion::Version1,
+            ..Default::default()
+        };
+        let mut receiver = ExpresslaneData {
+            version: ExpresslaneVersion::Version1,
+            ..Default::default()
+        };
+
+        let test_key = ExpresslaneKey([42u8; EXPRESSLANE_KEY_SIZE]);
+        sender.update_next_self_key(test_key).unwrap();
+        sender.update_self_key();
+        receiver.update_peer_key(test_key).unwrap();
+
+        let session_id = SessionId([1u8, 2, 3, 4, 5, 6, 7, 8]);
+        let plain_text = b"v1 payload";
+        let iv = [9u8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+
+        let mut buf = BytesMut::new();
+        sender.append_to_wire(&mut buf, session_id, plain_text, iv, false);
+
+        let mut borrowed = crate::borrowed_bytesmut::BorrowedBytesMut::from(&mut buf);
+        let (decrypted, _) = receiver.try_from_wire(&mut borrowed, session_id).unwrap();
+        assert_eq!(decrypted.as_ref(), plain_text);
+    }
+
+    /// V1 sender ↔ V2 receiver must fail: AAD layouts differ (V1 omits
+    /// flags, V2 includes them) so AEAD verification cannot match. This
+    /// is intentional - version negotiation should have downgraded the
+    /// receiver to V1 long before this point.
+    #[test]
+    fn cross_version_v1_to_v2_fails() {
+        let mut sender = ExpresslaneData {
+            version: ExpresslaneVersion::Version1,
+            ..Default::default()
+        };
+        let mut receiver = ExpresslaneData {
+            version: ExpresslaneVersion::Version2,
+            ..Default::default()
+        };
+
+        let test_key = ExpresslaneKey([42u8; EXPRESSLANE_KEY_SIZE]);
+        sender.update_next_self_key(test_key).unwrap();
+        sender.update_self_key();
+        receiver.update_peer_key(test_key).unwrap();
+
+        let session_id = SessionId([1u8, 2, 3, 4, 5, 6, 7, 8]);
+        let plain_text = b"v1 to v2";
+        let iv = [9u8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+
+        let mut buf = BytesMut::new();
+        sender.append_to_wire(&mut buf, session_id, plain_text, iv, false);
+
+        let mut borrowed = crate::borrowed_bytesmut::BorrowedBytesMut::from(&mut buf);
+        let result = receiver.try_from_wire(&mut borrowed, session_id);
+        assert!(matches!(result, Err(FromWireError::InvalidExpressData)));
+    }
+
     /// On-path attacker flips the encoded flag on the wire. AEAD must reject
     /// the packet because the flags field is bound into the auth tag via AAD.
+    /// Only applies to V2 - V1 keeps the original AAD layout (no flags) for
+    /// backwards compatibility with old V1 peers.
     #[test]
     fn tampered_flags_rejected_by_aead() {
-        let mut sender = ExpresslaneData::default();
-        let mut receiver = ExpresslaneData::default();
+        let mut sender = ExpresslaneData {
+            version: ExpresslaneVersion::Version2,
+            ..Default::default()
+        };
+        let mut receiver = ExpresslaneData {
+            version: ExpresslaneVersion::Version2,
+            ..Default::default()
+        };
 
         let test_key = ExpresslaneKey([42u8; EXPRESSLANE_KEY_SIZE]);
         sender.update_next_self_key(test_key).unwrap();

--- a/lightway-core/src/wire/expresslane_data.rs
+++ b/lightway-core/src/wire/expresslane_data.rs
@@ -901,4 +901,38 @@ mod tests {
             FromWireError::ReplayedExpressData
         ));
     }
+
+    /// On-path attacker flips the encoded flag on the wire. AEAD must reject
+    /// the packet because the flags field is bound into the auth tag via AAD.
+    #[test]
+    fn tampered_flags_rejected_by_aead() {
+        let mut sender = ExpresslaneData::default();
+        let mut receiver = ExpresslaneData::default();
+
+        let test_key = ExpresslaneKey([42u8; EXPRESSLANE_KEY_SIZE]);
+        sender.update_next_self_key(test_key).unwrap();
+        sender.update_self_key();
+        receiver.update_peer_key(test_key).unwrap();
+
+        let session_id = SessionId([1u8, 2, 3, 4, 5, 6, 7, 8]);
+        let plain_text = b"sensitive payload";
+        let iv = [9u8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+
+        let mut buf = BytesMut::new();
+        sender.append_to_wire(&mut buf, session_id, plain_text, iv, false);
+
+        // Flags occupy bytes 38..40 (after counter[0..8], iv[8..20],
+        // auth_tag[20..36], data_len[36..38]). Encoded is the MSB of the
+        // u16 in MSB bit ordering, so 0x80 in byte 38 flips it.
+        assert_eq!(buf[38] & 0x80, 0, "precondition: encoded flag is clear");
+        buf[38] |= 0x80;
+
+        let mut borrowed_buf = crate::borrowed_bytesmut::BorrowedBytesMut::from(&mut buf);
+        let result = receiver.try_from_wire(&mut borrowed_buf, session_id);
+        assert!(
+            matches!(result, Err(FromWireError::InvalidExpressData)),
+            "tampered flags should fail AEAD auth, got {:?}",
+            result.as_ref().map(|_| "Ok")
+        );
+    }
 }

--- a/lightway-core/src/wire/expresslane_data.rs
+++ b/lightway-core/src/wire/expresslane_data.rs
@@ -353,10 +353,6 @@ impl ExpresslaneData {
             return Err(FromWireError::ReplayedExpressData);
         }
 
-        let mut auth_vec: [u8; 16] = [0; 16];
-        auth_vec[..8].copy_from_slice(&session_id.0[..]);
-        auth_vec[8..].copy_from_slice(&wire_counter.to_be_bytes()[..]);
-
         let mut iv = [0u8; 12];
         buf.copy_to_slice(&mut iv);
         let mut auth_tag = [0u8; 16];
@@ -364,6 +360,11 @@ impl ExpresslaneData {
         let data_len = buf.get_u16() as usize;
         let flags = Flags::from(buf.get_u16());
         let is_encoded = flags.encoded();
+
+        let mut auth_vec: [u8; 18] = [0; 18];
+        auth_vec[..8].copy_from_slice(&session_id.0[..]);
+        auth_vec[8..16].copy_from_slice(&wire_counter.to_be_bytes()[..]);
+        auth_vec[16..].copy_from_slice(&u16::from(flags).to_be_bytes());
 
         if buf.len() < data_len {
             return Err(FromWireError::InsufficientData);
@@ -416,16 +417,17 @@ impl ExpresslaneData {
 
         self.wire_counter = self.wire_counter.wrapping_add(1);
 
-        let mut auth_vec: [u8; 16] = [0; 16];
+        let flags = Flags::new().with_encoded(is_encoded);
+
+        let mut auth_vec: [u8; 18] = [0; 18];
         auth_vec[..8].copy_from_slice(&session_id.0[..]);
-        auth_vec[8..].copy_from_slice(&self.wire_counter.to_be_bytes()[..]);
+        auth_vec[8..16].copy_from_slice(&self.wire_counter.to_be_bytes()[..]);
+        auth_vec[16..].copy_from_slice(&u16::from(flags).to_be_bytes());
 
         let (cipher_text, auth_tag) = current
             .cipher
             .encrypt(iv, plain_text.as_ref(), &auth_vec)
             .expect("Encrypt failed");
-
-        let flags = Flags::new().with_encoded(is_encoded);
 
         buf.put_u64(self.wire_counter);
         buf.put(iv.as_ref());

--- a/lightway-core/src/wire/expresslane_data.rs
+++ b/lightway-core/src/wire/expresslane_data.rs
@@ -205,11 +205,33 @@ impl ReplayWindow {
         }
     }
 
-    /// Check if a wire counter should be accepted and update window state
+    /// To short-circuit obvious garbage before paying AEAD cost.
+    /// Returns true iff the packet should be rejected. Does NOT mutate
+    /// window state - that is reserved for [`Self::commit`] after the
+    /// packet has been deprotected successfully.
+    fn would_reject(&self, wire_counter: u64) -> bool {
+        if !self.initialized {
+            return false;
+        }
+        if wire_counter > self.max_counter {
+            return false;
+        }
+        let age = self.max_counter - wire_counter;
+        if age >= Self::WINDOW_SIZE {
+            // Too old.
+            return true;
+        }
+        // Within window: reject if bit already set (replay).
+        self.test_bit(age)
+    }
+
+    /// Commit a successfully-deprotected wire counter into the window.
     ///
-    /// Returns true if the packet is valid and should be processed.
-    /// Returns false if it's a replay or too old.
-    fn check_and_update(&mut self, wire_counter: u64) -> bool {
+    /// MUST only be called after AEAD verification succeeds. Returns
+    /// true if accepted and the window was updated; false if the
+    /// counter is a replay or too old (in which case state is
+    /// unchanged).
+    fn commit(&mut self, wire_counter: u64) -> bool {
         if !self.initialized {
             self.initialized = true;
             self.max_counter = wire_counter;
@@ -349,7 +371,7 @@ impl ExpresslaneData {
         let wire_counter = buf.get_u64();
 
         // Check for replay attacks using sliding window
-        if !self.replay_window.check_and_update(wire_counter) {
+        if self.replay_window.would_reject(wire_counter) {
             return Err(FromWireError::ReplayedExpressData);
         }
 
@@ -395,6 +417,11 @@ impl ExpresslaneData {
                 }
             }
         };
+
+        // AEAD verification succeeded - commit the wire counter
+        if !self.replay_window.commit(wire_counter) {
+            return Err(FromWireError::ReplayedExpressData);
+        }
 
         Ok((plain_text, is_encoded))
     }
@@ -702,7 +729,7 @@ mod tests {
     #[test]
     fn replay_window_accepts_first_packet() {
         let mut window = ReplayWindow::default();
-        assert!(window.check_and_update(100));
+        assert!(window.commit(100));
         assert_eq!(window.max_counter, 100);
         assert_eq!(window.packets_received, 1);
     }
@@ -710,18 +737,18 @@ mod tests {
     #[test]
     fn replay_window_detects_exact_replay() {
         let mut window = ReplayWindow::default();
-        assert!(window.check_and_update(100));
+        assert!(window.commit(100));
         // Replaying the same counter should be rejected
-        assert!(!window.check_and_update(100));
+        assert!(!window.commit(100));
         assert_eq!(window.packets_received, 1);
     }
 
     #[test]
     fn replay_window_accepts_newer_packets() {
         let mut window = ReplayWindow::default();
-        assert!(window.check_and_update(100));
-        assert!(window.check_and_update(101));
-        assert!(window.check_and_update(102));
+        assert!(window.commit(100));
+        assert!(window.commit(101));
+        assert!(window.commit(102));
         assert_eq!(window.max_counter, 102);
         assert_eq!(window.packets_received, 3);
     }
@@ -729,10 +756,10 @@ mod tests {
     #[test]
     fn replay_window_accepts_out_of_order_within_window() {
         let mut window = ReplayWindow::default();
-        assert!(window.check_and_update(100));
-        assert!(window.check_and_update(105));
-        assert!(window.check_and_update(103)); // Out of order, but within window
-        assert!(window.check_and_update(102)); // Out of order, but within window
+        assert!(window.commit(100));
+        assert!(window.commit(105));
+        assert!(window.commit(103)); // Out of order, but within window
+        assert!(window.commit(102)); // Out of order, but within window
         assert_eq!(window.max_counter, 105);
         assert_eq!(window.packets_received, 4);
     }
@@ -740,36 +767,36 @@ mod tests {
     #[test]
     fn replay_window_rejects_replayed_out_of_order_packet() {
         let mut window = ReplayWindow::default();
-        assert!(window.check_and_update(100));
-        assert!(window.check_and_update(105));
-        assert!(window.check_and_update(103));
+        assert!(window.commit(100));
+        assert!(window.commit(105));
+        assert!(window.commit(103));
         // Replaying 103 should be rejected
-        assert!(!window.check_and_update(103));
+        assert!(!window.commit(103));
         assert_eq!(window.packets_received, 3);
     }
 
     #[test]
     fn replay_window_rejects_too_old_packets() {
         let mut window = ReplayWindow::default();
-        assert!(window.check_and_update(100));
-        assert!(window.check_and_update(3000)); // Advance window past 2048
+        assert!(window.commit(100));
+        assert!(window.commit(3000)); // Advance window past 2048
         // Packet 100 is now outside the window (3000 - 2048 = 952)
-        assert!(!window.check_and_update(100));
-        assert!(!window.check_and_update(951));
+        assert!(!window.commit(100));
+        assert!(!window.commit(951));
         // But packets within window should work
-        assert!(window.check_and_update(953));
+        assert!(window.commit(953));
         assert_eq!(window.packets_received, 3);
     }
 
     #[test]
     fn replay_window_handles_large_jumps() {
         let mut window = ReplayWindow::default();
-        assert!(window.check_and_update(100));
+        assert!(window.commit(100));
         // Jump way ahead (> window size)
-        assert!(window.check_and_update(3000));
+        assert!(window.commit(3000));
         assert_eq!(window.max_counter, 3000);
         // Old packets should be rejected
-        assert!(!window.check_and_update(100));
+        assert!(!window.commit(100));
         assert_eq!(window.packets_received, 2);
     }
 
@@ -779,24 +806,24 @@ mod tests {
 
         // Receive packets 1-10 in order
         for i in 1..=10 {
-            assert!(window.check_and_update(i), "Failed to accept packet {}", i);
+            assert!(window.commit(i), "Failed to accept packet {}", i);
         }
 
         // Receive some out-of-order packets
-        assert!(window.check_and_update(15));
-        assert!(window.check_and_update(13));
-        assert!(window.check_and_update(11));
-        assert!(window.check_and_update(12));
-        assert!(window.check_and_update(14));
+        assert!(window.commit(15));
+        assert!(window.commit(13));
+        assert!(window.commit(11));
+        assert!(window.commit(12));
+        assert!(window.commit(14));
 
         // Try to replay some packets
-        assert!(!window.check_and_update(10));
-        assert!(!window.check_and_update(13));
-        assert!(!window.check_and_update(15));
+        assert!(!window.commit(10));
+        assert!(!window.commit(13));
+        assert!(!window.commit(15));
 
         // Continue with new packets
-        assert!(window.check_and_update(16));
-        assert!(window.check_and_update(17));
+        assert!(window.commit(16));
+        assert!(window.commit(17));
 
         // Verify total packets received: 10 + 5 + 2 = 17
         assert_eq!(window.packets_received, 17);
@@ -936,5 +963,95 @@ mod tests {
             "tampered flags should fail AEAD auth, got {:?}",
             result.as_ref().map(|_| "Ok")
         );
+    }
+
+    /// `would_reject` must NOT mutate window state - it only previews
+    /// the decision so AEAD work can be skipped for obvious garbage.
+    #[test]
+    fn would_reject_is_non_mutating() {
+        let mut window = ReplayWindow::default();
+        // Empty window: would_reject says no, state untouched
+        assert!(!window.would_reject(100));
+        assert!(!window.initialized);
+        assert_eq!(window.packets_received, 0);
+
+        assert!(window.commit(100));
+        // would_reject on replay: says yes, state still untouched
+        assert!(window.would_reject(100));
+        assert_eq!(window.max_counter, 100);
+        assert_eq!(window.packets_received, 1);
+
+        // Future counter not yet seen: would_reject says no (still future)
+        assert!(!window.would_reject(u64::MAX));
+        assert_eq!(window.max_counter, 100);
+        assert_eq!(window.packets_received, 1);
+    }
+
+    /// On-path attacker forges a packet with a huge wire_counter and a
+    /// bogus auth tag (no key). Prior implementation slid the window
+    /// forward before AEAD verify, poisoning state so every subsequent
+    /// valid packet was rejected as "too old". Verify the window is
+    /// untouched by the forgery and the next valid packet still goes
+    /// through.
+    #[test]
+    fn forged_packet_does_not_poison_replay_window() {
+        let mut sender = ExpresslaneData::default();
+        let mut receiver = ExpresslaneData::default();
+
+        let test_key = ExpresslaneKey([42u8; EXPRESSLANE_KEY_SIZE]);
+        sender.update_next_self_key(test_key).unwrap();
+        sender.update_self_key();
+        receiver.update_peer_key(test_key).unwrap();
+
+        let session_id = SessionId([1u8, 2, 3, 4, 5, 6, 7, 8]);
+        let plain_text = b"hello expresslane";
+        let iv = [9u8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+
+        // 1) Real packet from the legitimate sender (counter=1) goes
+        // through and advances the window to 1.
+        let mut buf = BytesMut::new();
+        sender.append_to_wire(&mut buf, session_id, plain_text, iv, false);
+        let mut borrowed = crate::borrowed_bytesmut::BorrowedBytesMut::from(&mut buf);
+        receiver.try_from_wire(&mut borrowed, session_id).unwrap();
+        assert_eq!(receiver.replay_window.max_counter, 1);
+        assert_eq!(receiver.replay_window.packets_received, 1);
+
+        // 2) On-path attacker forges a packet with an enormous
+        // wire_counter and random ciphertext+tag (no key).
+        let mut forged = BytesMut::new();
+        forged.put_u64(u64::MAX - 1); // huge counter
+        forged.put(&[0u8; 12][..]); // iv
+        forged.put(&[0u8; 16][..]); // bogus auth tag
+        forged.put_u16(plain_text.len() as u16); // data_len
+        forged.put_u16(0); // flags
+        forged.put(&vec![0u8; plain_text.len()][..]); // bogus ciphertext
+
+        let mut borrowed_forged = crate::borrowed_bytesmut::BorrowedBytesMut::from(&mut forged);
+        let result = receiver.try_from_wire(&mut borrowed_forged, session_id);
+        assert!(
+            matches!(result, Err(FromWireError::InvalidExpressData)),
+            "forged packet must fail AEAD auth, got {:?}",
+            result.as_ref().map(|_| "Ok")
+        );
+
+        // Window state must be untouched by the forgery.
+        assert_eq!(
+            receiver.replay_window.max_counter, 1,
+            "forgery poisoned max_counter"
+        );
+        assert_eq!(
+            receiver.replay_window.packets_received, 1,
+            "forgery poisoned packets_received"
+        );
+
+        // 3) Next valid packet from the real sender (counter=2) must
+        // still be accepted - proving the DoS is gone.
+        let mut buf2 = BytesMut::new();
+        sender.append_to_wire(&mut buf2, session_id, plain_text, iv, false);
+        let mut borrowed2 = crate::borrowed_bytesmut::BorrowedBytesMut::from(&mut buf2);
+        let (decrypted, _) = receiver.try_from_wire(&mut borrowed2, session_id).unwrap();
+        assert_eq!(decrypted.as_ref(), plain_text);
+        assert_eq!(receiver.replay_window.max_counter, 2);
+        assert_eq!(receiver.replay_window.packets_received, 2);
     }
 }

--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -231,7 +231,9 @@ async fn server<S: TestSock>(sock: Arc<S>, pqc: PQCrypto, enable_expresslane: bo
     .with_maximum_protocol_version(Version::MAXIMUM)
     .unwrap()
     .when(pqc.enable_server(), |s| s.with_pq_crypto().unwrap())
-    .when(enable_expresslane, |s| s.with_expresslane())
+    .when(enable_expresslane, |s| {
+        s.with_expresslane(DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL)
+    })
     .build()
     .unwrap();
 
@@ -413,7 +415,9 @@ async fn client<S: TestSock>(
     )
     .unwrap()
     .when_some(cipher, |b, cipher| b.with_cipher(cipher).unwrap())
-    .when(enable_expresslane, |b| b.with_expresslane())
+    .when(enable_expresslane, |b| {
+        b.with_expresslane(DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL)
+    })
     .build()
     .start_connect(sock.clone().into_io_send_callback(), MAX_OUTSIDE_MTU)
     .unwrap()

--- a/lightway-server/src/config.rs
+++ b/lightway-server/src/config.rs
@@ -91,6 +91,10 @@ pub struct Config {
     pub connection_age_expiration_interval: Duration,
 
     #[patch(attribute(clap(long)))]
+    #[patch(attribute(doc = "Interval between session statistics reports"))]
+    pub statistics_reporting_interval: Duration,
+
+    #[patch(attribute(clap(long)))]
     #[patch(empty_value = false)]
     #[patch(attribute(serde(default)))]
     #[patch(attribute(doc = "Enable Post Quantum Crypto"))]
@@ -183,6 +187,9 @@ impl Default for Config {
             ),
             connection_age_expiration_interval: Duration::from_std_duration(
                 lightway_server::DEFAULT_CONNECTION_AGE_EXPIRATION_INTERVAL,
+            ),
+            statistics_reporting_interval: Duration::from_std_duration(
+                lightway_server::DEFAULT_STATISTICS_REPORTING_INTERVAL,
             ),
             enable_pqc: false,
             enable_tun_iouring: false,

--- a/lightway-server/src/config.rs
+++ b/lightway-server/src/config.rs
@@ -83,6 +83,10 @@ pub struct Config {
     pub enable_expresslane: bool,
 
     #[patch(attribute(clap(long)))]
+    #[patch(attribute(doc = "Interval between Expresslane key rotations"))]
+    pub expresslane_keys_rotation_interval: Duration,
+
+    #[patch(attribute(clap(long)))]
     #[patch(empty_value = false)]
     #[patch(attribute(serde(default)))]
     #[patch(attribute(doc = "Enable Post Quantum Crypto"))]
@@ -170,6 +174,9 @@ impl Default for Config {
             lightway_client_ip: Ipv4Addr::new(10, 125, 0, 5),
             lightway_dns_ip: Ipv4Addr::new(10, 125, 0, 1),
             enable_expresslane: false,
+            expresslane_keys_rotation_interval: Duration::from_std_duration(
+                lightway_server::DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL,
+            ),
             enable_pqc: false,
             enable_tun_iouring: false,
             iouring_entry_count: 1024,

--- a/lightway-server/src/config.rs
+++ b/lightway-server/src/config.rs
@@ -87,6 +87,10 @@ pub struct Config {
     pub expresslane_keys_rotation_interval: Duration,
 
     #[patch(attribute(clap(long)))]
+    #[patch(attribute(doc = "How often to check for aged connections to expire"))]
+    pub connection_age_expiration_interval: Duration,
+
+    #[patch(attribute(clap(long)))]
     #[patch(empty_value = false)]
     #[patch(attribute(serde(default)))]
     #[patch(attribute(doc = "Enable Post Quantum Crypto"))]
@@ -176,6 +180,9 @@ impl Default for Config {
             enable_expresslane: false,
             expresslane_keys_rotation_interval: Duration::from_std_duration(
                 lightway_server::DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL,
+            ),
+            connection_age_expiration_interval: Duration::from_std_duration(
+                lightway_server::DEFAULT_CONNECTION_AGE_EXPIRATION_INTERVAL,
             ),
             enable_pqc: false,
             enable_tun_iouring: false,

--- a/lightway-server/src/connection_manager.rs
+++ b/lightway-server/src/connection_manager.rs
@@ -3,6 +3,7 @@ mod connection_map;
 use bytes::BytesMut;
 use delegate::delegate;
 use parking_lot::Mutex;
+use std::time::Duration;
 use std::{
     collections::HashMap,
     net::SocketAddr,
@@ -12,7 +13,6 @@ use std::{
     },
 };
 use thiserror::Error;
-use time::Duration;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio_stream::StreamExt;
 use tracing::{info, instrument, warn};
@@ -31,21 +31,21 @@ use lightway_core::{
 
 use crate::handle_inside_io_error;
 
-/// How often to check for connections to expire aged connections
-pub(crate) const CONNECTION_AGE_EXPIRATION_INTERVAL: Duration = Duration::minutes(1);
+/// Default interval to check for connections to expire aged connections
+pub const DEFAULT_CONNECTION_AGE_EXPIRATION_INTERVAL: Duration = Duration::from_secs(60);
 
 /// How often to check for connections to expire connections where authentication has expired
-const CONNECTION_AUTH_EXPIRATION_INTERVAL: Duration = Duration::hours(6);
+const CONNECTION_AUTH_EXPIRATION_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
 
 /// How often to check for pending session ids to cleanup
-const PENDING_SESSION_ID_EXPIRATION_INTERVAL: Duration = Duration::hours(6);
+const PENDING_SESSION_ID_EXPIRATION_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
 
 /// How long a connection can be idle for
-const CONNECTION_MAX_IDLE_AGE: Duration = Duration::days(1);
+const CONNECTION_MAX_IDLE_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// How long a connection can take to become Online
 /// If connection is not online by this time, it will be closed to save resources
-const CONNECTION_STALE_AGE: std::time::Duration = std::time::Duration::from_secs(60);
+const CONNECTION_STALE_AGE: Duration = Duration::from_secs(60);
 
 impl connection_map::Value for Connection {
     fn socket_addr(&self) -> SocketAddr {
@@ -93,6 +93,8 @@ pub(crate) struct ConnectionManager {
     inside_io_codec_factory: Option<PacketCodecFactoryType>,
     /// Optional callback to forward per-connection events with session ID
     event_cb: Option<crate::ServerEventCbType>,
+    /// How often to check for aged connections to expire
+    connection_age_expiration_interval: Duration,
 }
 
 #[instrument(level = "trace", skip_all)]
@@ -313,6 +315,7 @@ impl ConnectionManager {
         ctx: ServerContext<ConnectionState>,
         inside_io_codec_factory: Option<PacketCodecFactoryType>,
         event_cb: Option<crate::ServerEventCbType>,
+        connection_age_expiration_interval: Duration,
     ) -> Arc<Self> {
         let conn_manager = Arc::new(Self {
             ctx,
@@ -321,10 +324,11 @@ impl ConnectionManager {
             total_sessions: Default::default(),
             inside_io_codec_factory,
             event_cb,
+            connection_age_expiration_interval,
         });
 
         conn_manager.spawn_periodic_task(
-            CONNECTION_AGE_EXPIRATION_INTERVAL,
+            connection_age_expiration_interval,
             Self::evict_idle_connections,
         );
         conn_manager.spawn_periodic_task(
@@ -346,7 +350,7 @@ impl ConnectionManager {
         let weak_conn_manager = Arc::downgrade(self);
 
         tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(interval.unsigned_abs());
+            let mut ticker = tokio::time::interval(interval);
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             let mut ticker = tokio_stream::wrappers::IntervalStream::new(ticker);
 
@@ -369,6 +373,10 @@ impl ConnectionManager {
 
     pub(crate) fn total_sessions(&self) -> usize {
         self.total_sessions.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn connection_age_expiration_interval(&self) -> Duration {
+        self.connection_age_expiration_interval
     }
 
     pub(crate) fn pending_session_id_rotations_count(&self) -> usize {

--- a/lightway-server/src/connection_manager.rs
+++ b/lightway-server/src/connection_manager.rs
@@ -195,7 +195,9 @@ async fn handle_events(
             }
             Event::TlsKeysUpdateStart => handle_tls_keys_update_start(&conn),
             Event::TlsKeysUpdateCompleted => handle_tls_keys_update_complete(),
-            Event::ExpresslaneStateChanged(_) => {}
+            Event::ExpresslaneStateChanged(s) => {
+                info!("Setting expresslane state to {:?}", s);
+            }
             Event::FirstPacketReceived => {
                 unreachable!("client only event received");
             }

--- a/lightway-server/src/connection_manager.rs
+++ b/lightway-server/src/connection_manager.rs
@@ -32,20 +32,20 @@ use lightway_core::{
 use crate::handle_inside_io_error;
 
 /// Default interval to check for connections to expire aged connections
-pub const DEFAULT_CONNECTION_AGE_EXPIRATION_INTERVAL: Duration = Duration::from_secs(60);
+pub const DEFAULT_CONNECTION_AGE_EXPIRATION_INTERVAL: Duration = Duration::from_mins(1);
 
 /// How often to check for connections to expire connections where authentication has expired
-const CONNECTION_AUTH_EXPIRATION_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+const CONNECTION_AUTH_EXPIRATION_INTERVAL: Duration = Duration::from_hours(6);
 
 /// How often to check for pending session ids to cleanup
-const PENDING_SESSION_ID_EXPIRATION_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+const PENDING_SESSION_ID_EXPIRATION_INTERVAL: Duration = Duration::from_hours(6);
 
 /// How long a connection can be idle for
-const CONNECTION_MAX_IDLE_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+const CONNECTION_MAX_IDLE_AGE: Duration = Duration::from_hours(24);
 
 /// How long a connection can take to become Online
 /// If connection is not online by this time, it will be closed to save resources
-const CONNECTION_STALE_AGE: Duration = Duration::from_secs(60);
+const CONNECTION_STALE_AGE: Duration = Duration::from_mins(1);
 
 impl connection_map::Value for Connection {
     fn socket_addr(&self) -> SocketAddr {

--- a/lightway-server/src/io/outside/tcp.rs
+++ b/lightway-server/src/io/outside/tcp.rs
@@ -122,14 +122,12 @@ async fn handle_connection(
         return;
     };
 
+    let age_expiration_interval: Duration = conn_manager.connection_age_expiration_interval();
+
     // We no longer need to hold this reference.
     drop(conn_manager);
 
     let mut buf = BytesMut::with_capacity(MAX_OUTSIDE_MTU);
-    let age_expiration_interval: Duration =
-        crate::connection_manager::CONNECTION_AGE_EXPIRATION_INTERVAL
-            .try_into()
-            .unwrap();
     let err: anyhow::Error = loop {
         tokio::select! {
             res = sock.readable() => {

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -11,8 +11,9 @@ use connection::Connection;
 #[cfg(feature = "debug")]
 pub use lightway_core::enable_tls_debug;
 pub use lightway_core::{
-    ConnectionType, Event, ExpresslaneCbType, ExpresslaneMetricsType, PluginFactoryError,
-    PluginFactoryList, ServerAuth, ServerAuthHandle, ServerAuthResult, SessionId, Version,
+    ConnectionType, DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL, Event, ExpresslaneCbType,
+    ExpresslaneMetricsType, PluginFactoryError, PluginFactoryList, ServerAuth, ServerAuthHandle,
+    ServerAuthResult, SessionId, Version,
 };
 
 /// Callback type for receiving per-connection events with session ID.
@@ -177,6 +178,9 @@ pub struct ServerConfig<SA: for<'a> ServerAuth<AuthState<'a>>> {
     /// Enable Expresslane for Udp connections
     pub enable_expresslane: bool,
 
+    /// Interval between Expresslane key rotations
+    pub expresslane_keys_rotation_interval: Duration,
+
     /// Callback for expresslane key updates
     #[educe(Debug(ignore))]
     pub expresslane_cb: Option<ExpresslaneCbType<ConnectionState>>,
@@ -332,7 +336,9 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
         connection_ticker_cb,
     )?
     .with_key_update_interval(config.key_update_interval)
-    .when(config.enable_expresslane, |b| b.with_expresslane())
+    .when(config.enable_expresslane, |b| {
+        b.with_expresslane(config.expresslane_keys_rotation_interval)
+    })
     .when(config.expresslane_cb.is_some(), |b| {
         b.with_expresslane_cb(config.expresslane_cb.clone().unwrap())
     })

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -8,6 +8,7 @@ mod statistics;
 use bytesize::ByteSize;
 use connection::Connection;
 // re-export so server app does not need to depend on lightway-core
+pub use crate::connection_manager::DEFAULT_CONNECTION_AGE_EXPIRATION_INTERVAL;
 #[cfg(feature = "debug")]
 pub use lightway_core::enable_tls_debug;
 pub use lightway_core::{
@@ -213,6 +214,9 @@ pub struct ServerConfig<SA: for<'a> ServerAuth<AuthState<'a>>> {
     /// The key update interval for DTLS/TLS 1.3 connections
     pub key_update_interval: Duration,
 
+    /// How often to check for connections to expire aged connections
+    pub connection_age_expiration_interval: Duration,
+
     /// Inside plugins to use
     #[educe(Debug(method(debug_fmt_plugin_list)))]
     pub inside_plugins: PluginFactoryList,
@@ -350,7 +354,12 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
     .with_outside_plugins(config.outside_plugins)
     .build()?;
 
-    let conn_manager = ConnectionManager::new(ctx, config.inside_pkt_codec, config.event_cb);
+    let conn_manager = ConnectionManager::new(
+        ctx,
+        config.inside_pkt_codec,
+        config.event_cb,
+        config.connection_age_expiration_interval,
+    );
 
     tokio::spawn(statistics::run(conn_manager.clone(), ip_manager.clone()));
 

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -9,6 +9,7 @@ use bytesize::ByteSize;
 use connection::Connection;
 // re-export so server app does not need to depend on lightway-core
 pub use crate::connection_manager::DEFAULT_CONNECTION_AGE_EXPIRATION_INTERVAL;
+pub use crate::statistics::DEFAULT_STATISTICS_REPORTING_INTERVAL;
 #[cfg(feature = "debug")]
 pub use lightway_core::enable_tls_debug;
 pub use lightway_core::{
@@ -217,6 +218,9 @@ pub struct ServerConfig<SA: for<'a> ServerAuth<AuthState<'a>>> {
     /// How often to check for connections to expire aged connections
     pub connection_age_expiration_interval: Duration,
 
+    /// Interval between session statistics reports
+    pub statistics_reporting_interval: Duration,
+
     /// Inside plugins to use
     #[educe(Debug(method(debug_fmt_plugin_list)))]
     pub inside_plugins: PluginFactoryList,
@@ -361,7 +365,11 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
         config.connection_age_expiration_interval,
     );
 
-    tokio::spawn(statistics::run(conn_manager.clone(), ip_manager.clone()));
+    tokio::spawn(statistics::run(
+        conn_manager.clone(),
+        ip_manager.clone(),
+        config.statistics_reporting_interval,
+    ));
 
     let mut server: Box<dyn Server> = match connection_type {
         ServerConnectionMode::Datagram(may_be_sock) => Box::new(

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -183,6 +183,7 @@ async fn main() -> Result<()> {
         iouring_sqpoll_idle_time: config.iouring_sqpoll_idle_time.into(),
         key_update_interval: config.key_update_interval.into(),
         connection_age_expiration_interval: config.connection_age_expiration_interval.into(),
+        statistics_reporting_interval: config.statistics_reporting_interval.into(),
         inside_plugins: Default::default(),
         outside_plugins: Default::default(),
         inside_pkt_codec: None,

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -31,7 +31,7 @@ async fn metrics_debug() {
         return;
     }
 
-    let mut ticker = tokio::time::interval(std::time::Duration::from_secs(60));
+    let mut ticker = tokio::time::interval(std::time::Duration::from_mins(1));
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut ticker = tokio_stream::wrappers::IntervalStream::new(ticker);
 

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -170,6 +170,7 @@ async fn main() -> Result<()> {
         lightway_dns_ip: config.lightway_dns_ip,
         use_dynamic_client_ip: false,
         enable_expresslane: config.enable_expresslane,
+        expresslane_keys_rotation_interval: config.expresslane_keys_rotation_interval.into(),
         expresslane_cb: None,
         expresslane_metrics: None,
         event_cb: None,

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -182,6 +182,7 @@ async fn main() -> Result<()> {
         #[cfg(feature = "io-uring")]
         iouring_sqpoll_idle_time: config.iouring_sqpoll_idle_time.into(),
         key_update_interval: config.key_update_interval.into(),
+        connection_age_expiration_interval: config.connection_age_expiration_interval.into(),
         inside_plugins: Default::default(),
         outside_plugins: Default::default(),
         inside_pkt_codec: None,

--- a/lightway-server/src/statistics.rs
+++ b/lightway-server/src/statistics.rs
@@ -1,6 +1,6 @@
 use lightway_core::ConnectionActivity;
 use std::sync::{Arc, Weak};
-use time::Duration;
+use std::time::Duration;
 use tokio_stream::StreamExt;
 use tracing::info;
 
@@ -10,11 +10,12 @@ use crate::{
     metrics::{self, ConnectionIntervalStats},
 };
 
-const STATISTICS_REPORTING_INTERVAL: Duration = Duration::seconds(30);
+/// Default interval between statistics reports
+pub const DEFAULT_STATISTICS_REPORTING_INTERVAL: Duration = Duration::from_secs(30);
 
-const FIVE_MINUTES: Duration = Duration::minutes(5);
-const FIFTEEN_MINUTES: Duration = Duration::minutes(15);
-const SIXTY_MINUTES: Duration = Duration::hours(1);
+const FIVE_MINUTES: Duration = Duration::from_secs(5 * 60);
+const FIFTEEN_MINUTES: Duration = Duration::from_secs(15 * 60);
+const SIXTY_MINUTES: Duration = Duration::from_secs(60 * 60);
 
 /// Return is (standby, active)
 fn calculate_session_stats(
@@ -106,11 +107,15 @@ fn ip_manager_stats(ip_manager: &Weak<IpManager>) {
     metrics::assigned_internal_ips(count);
 }
 
-pub(crate) async fn run(conn_manager: Arc<ConnectionManager>, ip_manager: Arc<IpManager>) {
+pub(crate) async fn run(
+    conn_manager: Arc<ConnectionManager>,
+    ip_manager: Arc<IpManager>,
+    reporting_interval: Duration,
+) {
     let conn_manager = Arc::downgrade(&conn_manager);
     let ip_manager = Arc::downgrade(&ip_manager);
 
-    let mut ticker = tokio::time::interval(STATISTICS_REPORTING_INTERVAL.unsigned_abs());
+    let mut ticker = tokio::time::interval(reporting_interval);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut ticker = tokio_stream::wrappers::IntervalStream::new(ticker);
 
@@ -144,19 +149,19 @@ mod tests {
         assert_eq!(format!("{}+{}", standby.fmt(), active.fmt()), "0:0:0+0:0:0");
     }
 
-    #[test_case(Duration::ZERO,        Duration::ZERO        => "0:0:0+1:1:1" ; "active, very recent data")]
-    #[test_case(Duration::ZERO,        Duration::minutes(1)  => "0:0:0+1:1:1" ; "active, 1m since data")]
-    #[test_case(Duration::ZERO,        Duration::minutes(6)  => "1:0:0+0:1:1" ; "active, 5+ mins since data")]
-    #[test_case(Duration::ZERO,        Duration::minutes(16) => "1:1:0+0:0:1" ; "active, 15+ mins since data")]
-    #[test_case(Duration::ZERO,        Duration::minutes(61) => "1:1:1+0:0:0" ; "active, 60+ mins since data")]
-    #[test_case(Duration::minutes(1),  Duration::hours(2)    => "1:1:1+0:0:0" ; "inactive for 1 min, data older")]
-    #[test_case(Duration::minutes(6),  Duration::hours(2)    => "0:1:1+0:0:0" ; "inactive for 5+ min, data older")]
-    #[test_case(Duration::minutes(16), Duration::hours(2)    => "0:0:1+0:0:0" ; "inactive for 15+ min, data older")]
-    #[test_case(Duration::minutes(61), Duration::hours(2)    => "0:0:0+0:0:0" ; "inactive for 60+ min, data older")]
-    #[test_case(Duration::minutes(1),  Duration::minutes(1)  => "0:0:0+1:1:1" ; "inactive for 1 min, data same age")]
-    #[test_case(Duration::minutes(6),  Duration::minutes(6)  => "0:0:0+0:1:1" ; "inactive for 5+ min, data same age")]
-    #[test_case(Duration::minutes(16), Duration::minutes(16) => "0:0:0+0:0:1" ; "inactive for 15+ min, data same age")]
-    #[test_case(Duration::minutes(61), Duration::minutes(61) => "0:0:0+0:0:0" ; "inactive for 60+ min, recent data")]
+    #[test_case(Duration::ZERO,              Duration::ZERO              => "0:0:0+1:1:1" ; "active, very recent data")]
+    #[test_case(Duration::ZERO,              Duration::from_secs(60)     => "0:0:0+1:1:1" ; "active, 1m since data")]
+    #[test_case(Duration::ZERO,              Duration::from_secs(6*60)   => "1:0:0+0:1:1" ; "active, 5+ mins since data")]
+    #[test_case(Duration::ZERO,              Duration::from_secs(16*60)  => "1:1:0+0:0:1" ; "active, 15+ mins since data")]
+    #[test_case(Duration::ZERO,              Duration::from_secs(61*60)  => "1:1:1+0:0:0" ; "active, 60+ mins since data")]
+    #[test_case(Duration::from_secs(60),     Duration::from_secs(2*60*60) => "1:1:1+0:0:0" ; "inactive for 1 min, data older")]
+    #[test_case(Duration::from_secs(6*60),   Duration::from_secs(2*60*60) => "0:1:1+0:0:0" ; "inactive for 5+ min, data older")]
+    #[test_case(Duration::from_secs(16*60),  Duration::from_secs(2*60*60) => "0:0:1+0:0:0" ; "inactive for 15+ min, data older")]
+    #[test_case(Duration::from_secs(61*60),  Duration::from_secs(2*60*60) => "0:0:0+0:0:0" ; "inactive for 60+ min, data older")]
+    #[test_case(Duration::from_secs(60),     Duration::from_secs(60)     => "0:0:0+1:1:1" ; "inactive for 1 min, data same age")]
+    #[test_case(Duration::from_secs(6*60),   Duration::from_secs(6*60)   => "0:0:0+0:1:1" ; "inactive for 5+ min, data same age")]
+    #[test_case(Duration::from_secs(16*60),  Duration::from_secs(16*60)  => "0:0:0+0:0:1" ; "inactive for 15+ min, data same age")]
+    #[test_case(Duration::from_secs(61*60),  Duration::from_secs(61*60)  => "0:0:0+0:0:0" ; "inactive for 60+ min, recent data")]
     fn calculate_stats_aging(outside_data_age: Duration, data_traffic_age: Duration) -> String {
         assert_le!(
             outside_data_age,

--- a/lightway-server/src/statistics.rs
+++ b/lightway-server/src/statistics.rs
@@ -13,9 +13,9 @@ use crate::{
 /// Default interval between statistics reports
 pub const DEFAULT_STATISTICS_REPORTING_INTERVAL: Duration = Duration::from_secs(30);
 
-const FIVE_MINUTES: Duration = Duration::from_secs(5 * 60);
-const FIFTEEN_MINUTES: Duration = Duration::from_secs(15 * 60);
-const SIXTY_MINUTES: Duration = Duration::from_secs(60 * 60);
+const FIVE_MINUTES: Duration = Duration::from_mins(5);
+const FIFTEEN_MINUTES: Duration = Duration::from_mins(15);
+const SIXTY_MINUTES: Duration = Duration::from_hours(1);
 
 /// Return is (standby, active)
 fn calculate_session_stats(
@@ -150,18 +150,18 @@ mod tests {
     }
 
     #[test_case(Duration::ZERO,              Duration::ZERO              => "0:0:0+1:1:1" ; "active, very recent data")]
-    #[test_case(Duration::ZERO,              Duration::from_secs(60)     => "0:0:0+1:1:1" ; "active, 1m since data")]
-    #[test_case(Duration::ZERO,              Duration::from_secs(6*60)   => "1:0:0+0:1:1" ; "active, 5+ mins since data")]
-    #[test_case(Duration::ZERO,              Duration::from_secs(16*60)  => "1:1:0+0:0:1" ; "active, 15+ mins since data")]
-    #[test_case(Duration::ZERO,              Duration::from_secs(61*60)  => "1:1:1+0:0:0" ; "active, 60+ mins since data")]
-    #[test_case(Duration::from_secs(60),     Duration::from_secs(2*60*60) => "1:1:1+0:0:0" ; "inactive for 1 min, data older")]
-    #[test_case(Duration::from_secs(6*60),   Duration::from_secs(2*60*60) => "0:1:1+0:0:0" ; "inactive for 5+ min, data older")]
-    #[test_case(Duration::from_secs(16*60),  Duration::from_secs(2*60*60) => "0:0:1+0:0:0" ; "inactive for 15+ min, data older")]
-    #[test_case(Duration::from_secs(61*60),  Duration::from_secs(2*60*60) => "0:0:0+0:0:0" ; "inactive for 60+ min, data older")]
-    #[test_case(Duration::from_secs(60),     Duration::from_secs(60)     => "0:0:0+1:1:1" ; "inactive for 1 min, data same age")]
-    #[test_case(Duration::from_secs(6*60),   Duration::from_secs(6*60)   => "0:0:0+0:1:1" ; "inactive for 5+ min, data same age")]
-    #[test_case(Duration::from_secs(16*60),  Duration::from_secs(16*60)  => "0:0:0+0:0:1" ; "inactive for 15+ min, data same age")]
-    #[test_case(Duration::from_secs(61*60),  Duration::from_secs(61*60)  => "0:0:0+0:0:0" ; "inactive for 60+ min, recent data")]
+    #[test_case(Duration::ZERO,              Duration::from_mins(1)      => "0:0:0+1:1:1" ; "active, 1m since data")]
+    #[test_case(Duration::ZERO,              Duration::from_mins(6)      => "1:0:0+0:1:1" ; "active, 5+ mins since data")]
+    #[test_case(Duration::ZERO,              Duration::from_mins(16)     => "1:1:0+0:0:1" ; "active, 15+ mins since data")]
+    #[test_case(Duration::ZERO,              Duration::from_mins(61)     => "1:1:1+0:0:0" ; "active, 60+ mins since data")]
+    #[test_case(Duration::from_mins(1),      Duration::from_hours(2)     => "1:1:1+0:0:0" ; "inactive for 1 min, data older")]
+    #[test_case(Duration::from_mins(6),      Duration::from_hours(2)     => "0:1:1+0:0:0" ; "inactive for 5+ min, data older")]
+    #[test_case(Duration::from_mins(16),     Duration::from_hours(2)     => "0:0:1+0:0:0" ; "inactive for 15+ min, data older")]
+    #[test_case(Duration::from_mins(61),     Duration::from_hours(2)     => "0:0:0+0:0:0" ; "inactive for 60+ min, data older")]
+    #[test_case(Duration::from_mins(1),      Duration::from_mins(1)      => "0:0:0+1:1:1" ; "inactive for 1 min, data same age")]
+    #[test_case(Duration::from_mins(6),      Duration::from_mins(6)      => "0:0:0+0:1:1" ; "inactive for 5+ min, data same age")]
+    #[test_case(Duration::from_mins(16),     Duration::from_mins(16)     => "0:0:0+0:0:1" ; "inactive for 15+ min, data same age")]
+    #[test_case(Duration::from_mins(61),     Duration::from_mins(61)     => "0:0:0+0:0:0" ; "inactive for 60+ min, recent data")]
     fn calculate_stats_aging(outside_data_age: Duration, data_traffic_age: Duration) -> String {
         assert_le!(
             outside_data_age,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

**Changes:**
- Add expresslane flags in AAD to detect the flags tampering and update expresslane version to v2
- Make the Protocol Version mismatch as nonfatal since it is a plaintext header
- Make expresslane keys rotation interval as configurable
- Make connection expiration interval and stats report interval also as configurable

## Motivation and Context

Since expresslane flags are not included in AAD, a onpath attacker can modfiy expresslane flags without being detected and close the connection. We got notified by a researcher about this bug.

Also the protocol version in UDP lightway packets can be tampered by on-path attacker and make server close the client connection. Ignore protocol version error too since it is a plaintext header.

## How Has This Been Tested?

Added unit test to verify this tampering

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change. This would break compat with existing clients. But we have not deploy any clients yet, also clients will fallback to DTLS.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
