### PR TITLE
CVPN-1597 Reduce fragment map size

### DIFF
--- a/lightway-core/src/connection/fragment_map.rs
+++ b/lightway-core/src/connection/fragment_map.rs
@@ -20,7 +20,7 @@ pub(crate) enum FragmentMapResult {
 pub(crate) struct FragmentMap(LruCache<u16, FragmentedPacket>);
 
 impl FragmentMap {
-    pub(crate) const DEFAULT_MAX_ENTRIES: NonZeroU16 = NonZeroU16::MAX;
+    pub(crate) const DEFAULT_MAX_ENTRIES: NonZeroU16 = NonZeroU16::new(4096).unwrap();
 
     pub(crate) fn new(max_capacity: NonZeroU16) -> Self {
         Self(LruCache::new(max_capacity.into()))


### PR DESCRIPTION
## Description
Previously max size was 65536 (uint16), which can take up to 8GB of memory per connection, assuming maximum fragment size. Reduced to 4000.

## Motivation and Context

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## 
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
