### PR TITLE
tun: Use given tunnel fd on desktop platform

### DIFF
--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -12,7 +12,7 @@ use std::{
     net::{IpAddr, Ipv4Addr},
 };
 
-#[cfg(mobile)]
+#[cfg(unix)]
 use std::os::fd::FromRawFd;
 #[cfg(feature = "io-uring")]
 use std::sync::Arc;
@@ -42,7 +42,7 @@ pub struct TunConfig {
     pub mtu: Option<u16>,
     /// Whether the interface should be brought up after creation
     pub enabled: bool,
-    /// File Descriptor of the Tunnel
+    /// File Descriptor of the Tunnel. If this is set, it will not create a TUN device from scratch.
     #[cfg(unix)]
     pub fd: Option<RawFd>,
     /// Whether to close the file descriptor when the TUN device is dropped
@@ -135,7 +135,7 @@ impl TunConfig {
         self
     }
 
-    /// Set the file descriptor
+    /// Set the file descriptor. If this is set, it will not create a TUN device from scratch.
     #[cfg(unix)]
     pub fn raw_fd(&mut self, fd: RawFd) -> &mut Self {
         self.fd = Some(fd);
@@ -181,8 +181,24 @@ impl TunConfig {
     }
 
     /// Creates an async device based on TunConfig
-    #[cfg(desktop)]
     pub fn create_as_async(&self) -> std::io::Result<AsyncDevice> {
+        // If a fd was provided (e.g. Apple Network Extension), wrap it directly
+        // instead of creating a new TUN device, which would require elevated privileges.
+        #[cfg(unix)]
+        match self.fd {
+            Some(fd) => {
+                // SAFETY: The caller must ensure `fd` is a valid TUN device file descriptor
+                // and transfer exclusive ownership to this function. The AsyncDevice will
+                // properly close the fd when dropped (unless close_fd_on_drop is false).
+                #[allow(unsafe_code)]
+                return Ok(unsafe { tun_rs::AsyncDevice::from_raw_fd(fd) });
+            }
+            #[cfg(mobile)]
+            None => return Err(std::io::Error::other("Unable to create device without fd")),
+            #[cfg(not(mobile))]
+            None => {}
+        };
+
         let mut builder = DeviceBuilder::new();
         if let Some(name) = self.tun_name.as_ref() {
             builder = builder.name(name);
@@ -240,25 +256,6 @@ impl TunConfig {
                 }
             }
         }
-        Ok(device)
-    }
-
-    /// Creates an async device based on TunConfig
-    #[allow(unsafe_code)]
-    #[cfg(mobile)]
-    pub fn create_as_async(&self) -> std::io::Result<AsyncDevice> {
-        let device = match self.fd {
-            Some(fd) => {
-                // SAFETY: The caller must ensure `fd` is a valid TUN device file descriptor
-                // and transfer exclusive ownership to this function. The AsyncDevice will
-                // properly close the fd when dropped.
-                unsafe { tun_rs::AsyncDevice::from_raw_fd(fd) }
-            }
-            None => {
-                return Err(std::io::Error::other("Unable to create device without fd"));
-            }
-        };
-
         Ok(device)
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use the given tunnel FD on desktop as well

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On macOS (and other desktop unix targets), TunConfig::create_as_async() previously ignored self.fd entirely and always called DeviceBuilder::new().build_async(), which creates a new TUN device from scratch. This requires elevated privileges or specific entitlements and fails with "operation not supported" in contexts where the TUN device is pre-created externally (e.g. a macOS Network Extension).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested this change on macOS network extension, verified we're able to use the tunnel device created by network extension properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
