### PR TITLE
CVPN-2546: Use connected UDP socket on macOS

### DIFF
--- a/lightway-client/src/io/outside.rs
+++ b/lightway-client/src/io/outside.rs
@@ -67,6 +67,16 @@ pub trait OutsideIO: Sync + Send {
 
     fn peer_addr(&self) -> SocketAddr;
 
+    /// Re-establish the socket's connected route after a network change.
+    ///
+    /// On macOS the outside UDP socket is `connect()`-ed so each send can skip
+    /// the per-packet route lookup. When the network changes the cached route
+    /// and bound source address go stale, so the association has to be
+    /// refreshed. Default is a no-op for transports that don't use a connected
+    /// socket.
+    #[cfg(macos)]
+    fn reconnect(&self) {}
+
     /// Returns the underlying socket tagged with its transport type.
     fn socket(&self) -> OutsideSocket;
 }

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -16,6 +16,11 @@ pub struct Udp {
     sock: Arc<tokio::net::UdpSocket>,
     peer_addr: SocketAddr,
     default_ip_pmtudisc: sockopt::IpPmtudisc,
+    /// Whether the socket has been `connect()`-ed to `peer_addr` so that `send`
+    /// can be used in place of `send_to`. macOS only; see
+    /// [`Udp::enable_connected_send`].
+    #[cfg(macos)]
+    connected: bool,
     #[cfg(batch_receive)]
     batch_receive_enabled: bool,
 }
@@ -46,9 +51,34 @@ impl Udp {
             sock: Arc::new(sock),
             peer_addr,
             default_ip_pmtudisc,
+            #[cfg(macos)]
+            connected: false,
             #[cfg(batch_receive)]
             batch_receive_enabled: false,
         })
+    }
+
+    /// `connect()` the underlying socket to `peer_addr`.
+    ///
+    /// On a connected UDP socket the kernel resolves the route once, at connect
+    /// time, so each subsequent `send` skips the per-packet route lookup that
+    /// `send_to` performs.
+    #[cfg(macos)]
+    fn connect_socket(&self) -> std::io::Result<()> {
+        socket2::SockRef::from(&self.sock).connect(&self.peer_addr.into())
+    }
+
+    /// Switch this socket to connected-send mode for upload throughput on macOS.
+    ///
+    /// The cached route is bound to the current egress interface, so the caller
+    /// MUST invoke [`OutsideIO::reconnect`] on every network change — otherwise
+    /// a network change strands the socket on a dead route/source address.
+    #[cfg(macos)]
+    pub fn enable_connected_send(&mut self) -> std::io::Result<()> {
+        self.connect_socket()?;
+        self.connected = true;
+        tracing::info!("Outside UDP socket connected; using connected send");
+        Ok(())
     }
 
     #[cfg(batch_receive)]
@@ -144,6 +174,18 @@ impl OutsideIO for Udp {
         self.peer_addr()
     }
 
+    #[cfg(macos)]
+    fn reconnect(&self) {
+        // Only refresh the route if connected-send mode is actually in use.
+        if !self.connected {
+            return;
+        }
+        match self.connect_socket() {
+            Ok(()) => tracing::debug!("Reconnected outside UDP socket after network change"),
+            Err(e) => tracing::warn!("Failed to reconnect outside UDP socket: {e}"),
+        }
+    }
+
     fn socket(&self) -> OutsideSocket {
         #[cfg(unix)]
         use std::os::fd::AsRawFd;
@@ -159,7 +201,21 @@ impl OutsideIO for Udp {
 
 impl OutsideIOSendCallback for Udp {
     fn send(&self, buf: &[u8]) -> IOCallbackResult<usize> {
-        match self.sock.try_send_to(buf, self.peer_addr) {
+        // On a connected socket the destination is already known, so `send`
+        // skips the per-packet route lookup that `send_to` performs - a
+        // measurable upload throughput win on macOS. Falls back to `send_to`
+        // when the socket isn't connected (e.g. no network change monitoring to
+        // refresh the cached route after a network change).
+        #[cfg(macos)]
+        let result = if self.connected {
+            self.sock.try_send(buf)
+        } else {
+            self.sock.try_send_to(buf, self.peer_addr)
+        };
+        #[cfg(not(macos))]
+        let result = self.sock.try_send_to(buf, self.peer_addr);
+
+        match result {
             Ok(nr) => IOCallbackResult::Ok(nr),
             Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
                 IOCallbackResult::WouldBlock
@@ -198,6 +254,17 @@ impl OutsideIOSendCallback for Udp {
                 // It should eventually recover by itself after a while.
                 // If the user has disconnected from the internet, keepalive should fail
                 // due to missed reply (`keepalive_timeout`).
+                IOCallbackResult::Ok(buf.len())
+            }
+            #[cfg(macos)]
+            Err(err)
+                if self.connected && matches!(err.kind(), std::io::ErrorKind::HostUnreachable) =>
+            {
+                // A connected socket can surface "no route to host" the moment a
+                // network change tears down the cached route. The reconnect on
+                // network change refreshes it; swallow so TLS does not enter an
+                // error state in the meantime. Only relevant when we explicitly
+                // use `send`; `send_to` should surface this error as before.
                 IOCallbackResult::Ok(buf.len())
             }
             Err(err) => {

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -42,7 +42,7 @@ use crate::debug::WiresharkKeyLogger;
 use crate::dns_manager::{DnsConfigMode, DnsManager, DnsManagerError, DnsSetup};
 use crate::keepalive::Config as KeepaliveConfig;
 #[cfg(desktop)]
-use crate::route_manager::{RouteManager, RouteMode};
+use crate::route_manager::{NetworkChangeCallback, RouteManager, RouteMode};
 #[cfg(batch_receive)]
 use lightway_core::MAX_IO_BATCH_SIZE;
 pub use lightway_core::{
@@ -761,7 +761,33 @@ impl<ExtAppState: Send + Sync> ClientConnection<ExtAppState> {
         );
         let mut route_manager =
             RouteManager::new(route_mode, server_ip, tun_index, tun_peer_ip, tun_dns_ip)?;
-        route_manager.start(network_change_rx).await?;
+
+        // On macOS the outside UDP socket is connected for upload throughput, so
+        // its cached route must be refreshed whenever the network changes. Run it
+        // after the route table is updated so the reconnect resolves the new path.
+        // A weak ref keeps the route manager task from extending the socket's
+        // lifetime. (NoExec mode does no route management; that path's reconnect
+        // is driven off the network change signal directly - see `connect`.)
+        let on_network_change: Option<NetworkChangeCallback> = {
+            #[cfg(macos)]
+            {
+                let outside_io = Arc::downgrade(&self.outside_io);
+                let cb: NetworkChangeCallback = Arc::new(move || {
+                    if let Some(io) = outside_io.upgrade() {
+                        io.reconnect();
+                    }
+                });
+                Some(cb)
+            }
+            #[cfg(not(macos))]
+            {
+                None
+            }
+        };
+
+        route_manager
+            .start(network_change_rx, on_network_change)
+            .await?;
 
         self.route_manager = Some(route_manager);
         info!("Routes configured");
@@ -841,6 +867,21 @@ pub async fn connect<
 
                 sock.set_send_buffer_size(config.sndbuf.as_u64().try_into()?)?;
                 sock.set_recv_buffer_size(config.rcvbuf.as_u64().try_into()?)?;
+
+                // On macOS a connected UDP socket lets `send` skip the per-packet
+                // route lookup, improving upload throughput. Only safe when a
+                // network change will re-connect the socket: the route manager
+                // does so after updating the server route (non-NoExec), or a
+                // client-supplied `network_change_signal` drives it directly.
+                // Otherwise fall back to `send_to`.
+                #[cfg(macos)]
+                if (config.route_mode != RouteMode::NoExec
+                    || config.network_change_signal.is_some())
+                    && let Err(e) = sock.enable_connected_send()
+                {
+                    tracing::warn!("Failed to connect outside UDP socket, using send_to: {e}");
+                }
+
                 (ConnectionType::Datagram, Arc::new(sock))
             }
             ClientConnectionMode::Stream(maybe_sock) => {
@@ -1386,6 +1427,25 @@ pub async fn client<
                 Some(rx),
             )
             .await?;
+
+        // In NoExec mode the route manager performs no route operations and so
+        // never refreshes the connected outside socket. When connected-send is in
+        // use (macOS) and the embedder supplied a network change signal, drive the
+        // reconnect off that signal directly instead.
+        #[cfg(macos)]
+        if config.route_mode == RouteMode::NoExec
+            && let Some(mut signal) = config.network_change_signal.clone()
+        {
+            let outside_io = Arc::downgrade(&connection.outside_io);
+            tokio::spawn(async move {
+                while signal.changed().await.is_ok() {
+                    let Some(io) = outside_io.upgrade() else {
+                        break;
+                    };
+                    io.reconnect();
+                }
+            });
+        }
     }
 
     #[cfg(desktop)]

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -3,6 +3,7 @@ use route_manager::{AsyncRouteManager, Route, RouteManager as SyncRouteManager};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
@@ -111,6 +112,12 @@ fn same_ip_family(ip1: &IpAddr, ip2: &IpAddr) -> bool {
     )
 }
 
+/// Hook invoked after the server route has been refreshed in response to a
+/// network change. Currently used (on macOS) to re-`connect()` the outside UDP
+/// socket so its cached route stays valid; it runs after the routing table
+/// update so the reconnect resolves via the new path.
+pub type NetworkChangeCallback = Arc<dyn Fn() + Send + Sync>;
+
 pub struct RouteManager {
     inner: Option<RouteManagerInner>,
     task: Option<JoinHandle<()>>,
@@ -150,12 +157,13 @@ impl RouteManager {
     pub async fn start(
         &mut self,
         network_change_rx: Option<watch::Receiver<()>>,
+        on_network_change: Option<NetworkChangeCallback>,
     ) -> Result<(), RoutingTableError> {
         let Some(inner) = self.inner.take() else {
             return Err(RoutingTableError::InsufficientPermissions);
         };
 
-        self.task = inner.start(network_change_rx).await?;
+        self.task = inner.start(network_change_rx, on_network_change).await?;
         Ok(())
     }
 
@@ -479,6 +487,7 @@ impl RouteManagerInner {
     async fn start(
         mut self,
         network_change_rx: Option<watch::Receiver<()>>,
+        on_network_change: Option<NetworkChangeCallback>,
     ) -> Result<Option<JoinHandle<()>>, RoutingTableError> {
         if self.routing_mode == RouteMode::NoExec {
             return Ok(None);
@@ -495,6 +504,12 @@ impl RouteManagerInner {
                     while rx.changed().await.is_ok() {
                         if let Err(e) = inner.check_and_update_server_route().await {
                             tracing::warn!("Updating server route failed: {:?}", e);
+                        }
+                        // Refresh anything bound to the previous route (e.g. a
+                        // connected outside socket) now that the routing table
+                        // is up to date.
+                        if let Some(cb) = &on_network_change {
+                            cb();
                         }
                     }
                 }
@@ -979,7 +994,7 @@ mod tests {
             RouteManager::new(route_mode, EXTERNAL_IP_V4, 0, TUN_PEER_IP, TUN_DNS_IP).unwrap();
 
         // Test that we can start the route manager
-        let start_result = route_manager.start(None).await;
+        let start_result = route_manager.start(None, None).await;
         if route_mode == RouteMode::NoExec {
             // NoExec mode should succeed but not actually do anything
             assert!(start_result.is_ok());
@@ -1029,10 +1044,10 @@ mod tests {
         .unwrap();
 
         // First start should succeed
-        assert!(route_manager.start(None).await.is_ok());
+        assert!(route_manager.start(None, None).await.is_ok());
 
         // Second start should fail since inner is already taken
-        let second_start_result = route_manager.start(None).await;
+        let second_start_result = route_manager.start(None, None).await;
         assert!(second_start_result.is_err());
         assert!(matches!(
             second_start_result.unwrap_err(),
@@ -1083,7 +1098,7 @@ mod tests {
         .unwrap();
 
         // NoExec mode should return None (no monitoring task)
-        let monitor_task = inner.start(None).await;
+        let monitor_task = inner.start(None, None).await;
         assert!(monitor_task.is_ok());
         assert!(monitor_task.unwrap().is_none());
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
On macOS this switches the outside UDP socket's send path from send_to to a connected socket (connect + send), so the kernel resolves the route once at connect time and each send skips the per-packet route lookup. In testing on a 10 Gbps line this improved upload throughput by ~200 Mbps. The downside of a connected socket is that it caches the route to the current egress interface, so the socket is re-connect()-ed whenever the network changes — driven from the route manager's monitoring loop just after the /32 server route is refreshed (or, in NoExec mode, directly off a client-supplied network change signal). Connected-send is only enabled when one of those reconnect drivers exists; otherwise the socket keeps using send_to.

All of the connected-socket behaviour is #[cfg(macos)]-gated, so other platforms are unchanged and the shared RouteManager stays platform-neutral.  This PR only changes macOS platform, iOS/tvOS upload speed is relatively okay right now, would explore updating iOS/tvOS in the future.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Upload speed improvements on macOS

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally, speed improvements up to 200 Mbps most of time when tested with 10 Gbps

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
