### PR TITLE
CVPN-2584: Do not derive Debug trait on sensitive fields on AuthMethod and CA certs

### DIFF
--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -286,6 +286,7 @@ pub struct ClientConnectionConfig<EventHandler: 'static + Send + EventCallback> 
     pub auth: AuthMethod,
 
     /// Content of CA certificate
+    #[educe(Debug(ignore))]
     pub cert_content: String,
 
     /// Inside plugins to use

--- a/lightway-core/src/wire/auth_request.rs
+++ b/lightway-core/src/wire/auth_request.rs
@@ -2,6 +2,7 @@ use crate::{Version, borrowed_bytesmut::BorrowedBytesMut};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use more_asserts::*;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
+use std::fmt;
 
 use super::{FromWireError, FromWireResult};
 
@@ -57,7 +58,7 @@ mod test_auth_method_kind {
 /// The auth method to use.
 ///
 /// See [`AuthRequest`] for the containing wire format.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq)]
 pub enum AuthMethod {
     /// Authenticate with username and password
     ///
@@ -153,6 +154,37 @@ pub enum AuthMethod {
         /// Application defined data buffer with authentication data
         data: Bytes,
     },
+}
+
+/// Manual `Debug` to avoid leaking credentials, tokens, or opaque callback
+/// payloads into logs. Variant kind and non-sensitive metadata (username,
+/// version, byte lengths) are shown; secret is redacted.
+impl fmt::Debug for AuthMethod {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AuthMethod::UserPass { user, password } => f
+                .debug_struct("UserPass")
+                .field("user", user)
+                .field(
+                    "password",
+                    &format_args!("<redacted {} length>", password.len()),
+                )
+                .finish(),
+            AuthMethod::Token { token } => f
+                .debug_struct("Token")
+                .field("token", &format_args!("<redacted {} length>", token.len()))
+                .finish(),
+            AuthMethod::VersionedToken { version, token } => f
+                .debug_struct("VersionedToken")
+                .field("version", version)
+                .field("token", &format_args!("<redacted {} length>", token.len()))
+                .finish(),
+            AuthMethod::CustomCallback { data } => f
+                .debug_struct("CustomCallback")
+                .field("data", &format_args!("<{} bytes>", data.len()))
+                .finish(),
+        }
+    }
 }
 
 impl AuthMethod {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We should not log sensitive fields like password/token and CA cert content. Removing debug trait for CA cert and manually implementing debug trait for AuthMethod with sensitive fields removed 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Don't log sensitive fields via debug trait

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
