### PR TITLE
client: only set TCP socket buffer size on macOS

### DIFF
--- a/lightway-client/src/config.rs
+++ b/lightway-client/src/config.rs
@@ -170,14 +170,20 @@ pub struct Config {
     pub preferred_connection_wait_interval: Duration,
 
     #[patch(attribute(clap(long)))]
-    #[patch(attribute(doc = "Socket send buffer size"))]
+    #[patch(attribute(doc = r#"Socket send buffer size.
+    Always applied for UDP.
+    For TCP, only applied on macOS; skipped on Windows and Linux
+    to preserve kernel buffer autotuning."#))]
     #[schemars(extend("x-cfg" = "desktop"))]
     #[schemars(schema_with = "byte_size_schema")]
     /// ex: 1.5 MiB
     pub sndbuf: ByteSize,
 
     #[patch(attribute(clap(long)))]
-    #[patch(attribute(doc = "Socket receive buffer size"))]
+    #[patch(attribute(doc = r#"Socket receive buffer size.
+    Always applied for UDP.
+    For TCP, only applied on macOS; skipped on Windows and Linux
+    to preserve kernel buffer autotuning."#))]
     #[schemars(extend("x-cfg" = "desktop"))]
     #[schemars(schema_with = "byte_size_schema")]
     /// ex: 1.5 MiB

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -19,6 +19,7 @@ use bytes::BytesMut;
 use bytesize::ByteSize;
 use futures::{FutureExt, stream::FuturesUnordered};
 pub use io::inside::{InsideIO, InsideIORecv};
+use io::outside::OutsideIO;
 use keepalive::Keepalive;
 #[cfg(feature = "postquantum")]
 use lightway_app_utils::args::KeyShare;
@@ -835,6 +836,8 @@ pub async fn connect<
                     sock.enable_batch_receive();
                 }
 
+                sock.set_send_buffer_size(config.sndbuf.as_u64().try_into()?)?;
+                sock.set_recv_buffer_size(config.rcvbuf.as_u64().try_into()?)?;
                 (ConnectionType::Datagram, Arc::new(sock))
             }
             ClientConnectionMode::Stream(maybe_sock) => {
@@ -842,12 +845,20 @@ pub async fn connect<
                     .await
                     .inspect_err(|e| tracing::error!("Failed to create outside IO TCP socket: {e}"))
                     .context("Outside IO TCP")?;
+
+                // On Linux/Windows, setting SO_SNDBUF/SO_RCVBUF disables TCP buffer
+                // autotuning, capping the bandwidth-delay product and throttling
+                // high-RTT links to single-digit Mbps. UDP has no autotuning so it
+                // still needs explicit sizing above.
+                // macOS benefits from explicit buffers in real-world testing.
+                #[cfg(target_os = "macos")]
+                {
+                    sock.set_send_buffer_size(config.sndbuf.as_u64().try_into()?)?;
+                    sock.set_recv_buffer_size(config.rcvbuf.as_u64().try_into()?)?;
+                }
                 (ConnectionType::Stream, Arc::new(sock))
             }
         };
-
-    outside_io.set_send_buffer_size(config.sndbuf.as_u64().try_into()?)?;
-    outside_io.set_recv_buffer_size(config.rcvbuf.as_u64().try_into()?)?;
 
     let (event_cb, event_stream) = EventStreamCallback::new();
 


### PR DESCRIPTION
Setting SO_SNDBUF/SO_RCVBUF on TCP disables kernel buffer autotuning, capping the bandwidth-delay product and throttling high-RTT links. UDP still needs explicit sizing since it has no autotuning. 

However, macOS benefits from explicit buffers based on real-world testing.

<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CI tested and manually tested.

Performance difference on Lightway TCP when socket buffer is set/not set over a high RTT connection:

**Linux**

| Set Socket Buffer? | Idle Latency (ms) | Download (Mbps) | Download Latency (ms) | Upload (Mbps) | Upload Latency (ms) | Packet Loss (%) |
|---|---|---|---|---|---|---|
| Yes | 190.91 | 11.22 | 662.88 | 8.59 | 360.53 | 0.0 |
| No | 190.50 | 160.86 👑  | 845.22 | 59.29 👑  | 296.45 | 0.0 |

**macOS**

| Set Socket Buffer? | Idle Latency (ms) | Download (Mbps) | Download Latency (ms) | Upload (Mbps) | Upload Latency (ms) | Packet Loss (%) |
|---|---|---|---|---|---|---|
| Yes | 190.20 | 166.05 | 792.47 | 249.29 👑 | 285.27 | 0.97 |
| No | 188.85 | 167.37 | 730.95 | 101.17 | 278.61 | 0.0 |

**Windows**

| Set Socket Buffer? | Idle Latency (ms) | Download (Mbps) | Download Latency (ms) | Upload (Mbps) | Upload Latency (ms) | Packet Loss (%) |
|---|---|---|---|---|---|---|
| Yes | 192.89 | 326.50 | 680.44 | 256.90 | 316.64 | 0.0 |
| No | 190.36 | 457.56 👑 | 514.88 | 450.68 👑 | 379.42 | 0.0 |

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
