### PR TITLE
server: config: expose Config as Substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3063,22 +3063,23 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "struct-patch"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6647f17706475257679fb9a4a71d85b222633d398d685010d7cc2f4c99de375"
+checksum = "7d0dafd40527e4b2dd640c4272d51d0e2e838e9345db4fab06c86c501fe8bc5e"
 dependencies = [
  "struct-patch-derive",
 ]
 
 [[package]]
 name = "struct-patch-derive"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203b436d4379c929ff3e7340b89c3a57ca3be8a76b3376448176575e8ca3f258"
+checksum = "970378c47245454d5899f4aae1ed2ad9698f756ebbfc8589bd63b54f56af86ff"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+ "syn-serde",
 ]
 
 [[package]]
@@ -3128,6 +3129,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-serde"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bac52f98dc6afb9d7d51d325cf6611cab08f283b6b6c20ba57298fd9db509ef"
+dependencies = [
+ "proc-macro2",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ serde = "1.0.189"
 serde-env = "0.3"
 serde-saphyr = "0.0.22"
 socket2 = "0.6.0"
-struct-patch = "0.11.0"
+struct-patch = { version =  "0.12.2", features= ["catalyst"] }
 test-case = "3.1.0"
 thiserror = "2.0.3"
 tokio = { version = "1.33.0", features = ["rt-multi-thread", "macros", "net", "time", "sync", "io-util", "fs", "signal"] }

--- a/lightway-server/src/config.rs
+++ b/lightway-server/src/config.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use ipnet::Ipv4Net;
 use serde::Deserialize;
 use std::time::Duration as StdDuration;
-use struct_patch::Patch;
+use struct_patch::{Patch, Substrate};
 
 use lightway_app_utils::args::{
     ConnectionType, Duration, IpMap, LogFormat, LogLevel, NonZeroDuration,
@@ -19,7 +19,7 @@ use lightway_app_utils::args::{
 // Patch derive, do NOT set defualts in the clap macros, and let all default
 // values follow the Rust convention in default trait, such that we are able
 // to serialized out any kind of configure from the Config::default()
-#[derive(Debug, Deserialize, Patch)]
+#[derive(Debug, Deserialize, Patch, Substrate)]
 #[patch(attribute(derive(Deserialize, Parser)))]
 #[patch(attribute(clap(about = "A lightway server")))]
 pub struct Config {
@@ -183,13 +183,13 @@ impl Default for Config {
             lightway_dns_ip: Ipv4Addr::new(10, 125, 0, 1),
             enable_expresslane: false,
             expresslane_keys_rotation_interval: Duration::from_std_duration(
-                lightway_server::DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL,
+                crate::DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL,
             ),
             connection_age_expiration_interval: Duration::from_std_duration(
-                lightway_server::DEFAULT_CONNECTION_AGE_EXPIRATION_INTERVAL,
+                crate::DEFAULT_CONNECTION_AGE_EXPIRATION_INTERVAL,
             ),
             statistics_reporting_interval: Duration::from_std_duration(
-                lightway_server::DEFAULT_STATISTICS_REPORTING_INTERVAL,
+                crate::DEFAULT_STATISTICS_REPORTING_INTERVAL,
             ),
             enable_pqc: false,
             enable_tun_iouring: false,

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod config;
 mod connection;
 mod connection_manager;
 mod io;


### PR DESCRIPTION
## Description
In order to easier integration from downstream, the config of server is exposed as substrate
Please take a look at down stream PR.

## Motivation and Context
When working on a repo with lightway, this feature will easy to let the repo align to each others

## How Has This Been Tested?
Tested by downstream 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
