### PR TITLE
nix: backport importCargoLock static.crates.io fix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,44 @@
         {
           _module.args.pkgs = import inputs.nixpkgs {
             inherit system;
-            overlays = [ inputs.rust-overlay.overlays.default ];
+            overlays = [
+              inputs.rust-overlay.overlays.default
+              # Backport NixOS/nixpkgs#524985 (merged 2026-05-27): switch
+              # `importCargoLock` to download crates from
+              # `https://static.crates.io/crates` instead of the API endpoint
+              # `https://crates.io/api/v1/crates/...`, which now returns HTTP 403
+              # for `curl/*` User-Agents. See rust-lang/crates.io#13482 and
+              # NixOS/nixpkgs#524979. Drop this overlay once `flake.lock` is
+              # bumped to a `nixpkgs-unstable` revision containing the upstream
+              # fix.
+              #
+              # Override `makeRustPlatform` (not `rustPlatform.importCargoLock`):
+              # nixpkgs' `pkgs/development/compilers/rust/make-rust-platform.nix`
+              # constructs a fresh `importCargoLock` from a hardcoded file path
+              # via `buildPackages.callPackage`, so the top-level
+              # `rustPlatform.importCargoLock` is ignored by both native.nix and
+              # cross.nix (which both call `(pkgsCross.)makeRustPlatform`).
+              (
+                final: prev:
+                let
+                  patchedImportCargoLockFile = builtins.toFile "import-cargo-lock-static-crates-io.nix" (
+                    builtins.replaceStrings [ "https://crates.io/api/v1/crates" ] [ "https://static.crates.io/crates" ]
+                      (builtins.readFile (prev.path + "/pkgs/build-support/rust/import-cargo-lock.nix"))
+                  );
+                in
+                {
+                  makeRustPlatform =
+                    args:
+                    (prev.makeRustPlatform args).overrideScope (
+                      _: _: {
+                        importCargoLock = prev.buildPackages.callPackage patchedImportCargoLockFile {
+                          inherit (args) cargo;
+                        };
+                      }
+                    );
+                }
+              )
+            ];
             config.allowUnfree = true;
             config.android_sdk.accept_license = true;
           };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
crates.io now rejects requests with curl/* User-Agent, returning HTTP 403 on `[https://crates.io/api/v1/crates/<name>/<ver>/download]`. 
nixpkgs `fetchurl` calls curl with its default UA, so `rustPlatform.buildRustPackage` with `cargoLock.lockFile` (which routes through `importCargoLock` and fetches each crate tarball via `fetchurl`) fails on the first uncached crate, e.g.:

```
  trying https://crates.io/api/v1/crates/autocfg/1.5.1/download
  curl: (22) The requested URL returned error: 403
```

Override `rustPlatform.importCargoLock` with a copy of the upstream file patched to use [https://static.crates.io/crates](https://static.crates.io/crates%60) instead of the API host.
This mirrors https://github.com/NixOS/nixpkgs/pull/524985.

**Upstream references:**

  - https://github.com/rust-lang/crates.io/issues/13482: original ticket (closed). Initially flagged python-requests/2.32.5+ UA; crates.io has since extended the blocklist to include curl/*.
  - https://github.com/NixOS/nixpkgs/pull/512735 (merged 2026-04-26): sets  `nixpkgs-fetchCargoVendor/2 (...)` UA and switches to  `static.crates.io`. Only patches `fetchCargoVendor`.
  - https://github.com/NixOS/nixpkgs/issues/524979 (closed 2026-05-27): tracking issue for the same 403 hitting `importCargoLock` (the path lightway uses).
  - https://github.com/NixOS/nixpkgs/pull/524985 (merged 2026-05-27 to master): fix for `importCargoLock` - switches crate downloads to `[https://static.crates.io/crates/<name>/<ver>/download`](), which has no UA gate. As of this commit the fix is on master only; `nixpkgs-unstable` (the channel this flake tracks at f9d8b65, 2026-05-25) does not yet contain it.

Drop this overlay once `flake.lock` is bumped to a `nixpkgs-unstable` revision that includes https://github.com/NixOS/nixpkgs/pull/524985.

## Motivation and Context
nix builds are failing in PRs

## How Has This Been Tested?
nix builds are passing with this overlay

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
