### PR TITLE
CVPN-109: client default token auth to VersionedToken

### DIFF
--- a/lightway-client/src/config.rs
+++ b/lightway-client/src/config.rs
@@ -9,7 +9,7 @@ use lightway_app_utils::args::KeyShare;
 use lightway_app_utils::args::{
     Cipher, ConfigFormat, ConnectionType, Duration, LogLevel, NonZeroDuration,
 };
-use lightway_core::{AuthMethod, MAX_OUTSIDE_MTU};
+use lightway_core::{AuthMethod, MAX_OUTSIDE_MTU, Version};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::time::Duration as StdDuration;
@@ -560,7 +560,10 @@ fn take_auth(
     password: Option<String>,
 ) -> Result<AuthMethod, Error> {
     match (token, user, password) {
-        (Some(token), _, _) => Ok(AuthMethod::Token { token }),
+        (Some(token), _, _) => Ok(AuthMethod::VersionedToken {
+            version: Version::MAXIMUM,
+            token,
+        }),
         (_, Some(user), Some(password)) => Ok(AuthMethod::UserPass { user, password }),
         _ => Err(Error::InsufficientAuth),
     }

--- a/lightway-core/src/connection/builders.rs
+++ b/lightway-core/src/connection/builders.rs
@@ -128,18 +128,18 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
         self.with_auth(auth_method)
     }
 
-    /// Setup authentication using a token
+    /// Setup authentication using a token. The client's maximum
+    /// supported lightway protocol [`Version`] is sent alongside the
+    /// token via [`AuthMethod::VersionedToken`] so the server can
+    /// determine the client's version even on transports without a
+    /// wire header (e.g. TCP).
     pub fn with_auth_token(self, token: &str) -> Self {
-        let auth_method = AuthMethod::Token {
-            token: token.to_string(),
-        };
-
-        self.with_auth(auth_method)
+        self.with_auth_versioned_token(token, Version::MAXIMUM)
     }
 
-    /// Setup authentication using a token plus the client's lightway
-    /// protocol [`Version`]. The server learns the client's version
-    /// even on transports without a wire header (e.g. TCP).
+    /// Setup authentication using a token plus an explicit lightway
+    /// protocol [`Version`]. Prefer [`Self::with_auth_token`] which
+    /// auto-fills the client's maximum supported version.
     pub fn with_auth_versioned_token(self, token: &str, version: Version) -> Self {
         let auth_method = AuthMethod::VersionedToken {
             version,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Flip the default token-auth path so both
`ClientConnectionBuilder::with_auth_token` and the client config `take_auth` helper emit `AuthMethod::VersionedToken` carrying `Version::MAXIMUM`.

## Motivation and Context

CVPN-109
Make clients send the lightway version in TCP connections

## How Has This Been Tested?

Unit tests will cover the versionedtoken auth
And all servers are updated to handle versionedtoken auth in PR 
https://github.com/expressvpn/lightway/pull/432
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
