### PR TITLE
[CVPN-2251] client: dns_manager for Windows

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,3 +23,7 @@
 
 * [Wireshark lightway plugin](wireshark.md)
 
+# Platform specific info
+
+* [Windows](./windows.md)
+

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,0 +1,13 @@
+# Windows specific info
+
+## DNS name resolution
+
+To prevent DNS leaks lightway client uses [NRTP](https://www.island.io/blog/man-7-windows-nrpt) (Name Resolution Policy Table)
+rule to try and route all DNS queries via tunnel.
+
+Unfortunately some programs (ex. nslookup) do not obey this which might still lead to DNS leaks.
+
+Another issue is that when lightway client crashes the NRPT rule might be left leading to name resolution problems.
+The old rule will be deleted on next client connection.
+In order to remove the rule manually following PowerShell (run as Administrator) command might be used:
+`Get-DnsClientNrptRule | Where-Object -Property Comment -eq 'lightway-dns' | Remove-DnsClientNrptRule -Force`

--- a/lightway-client/src/dns_manager.rs
+++ b/lightway-client/src/dns_manager.rs
@@ -24,9 +24,9 @@ pub enum DnsManagerError {
     #[error("Failed to set DNS configuration: {0}")]
     #[cfg(desktop)]
     FailedToSetDnsConfig(String),
-    #[error("Failed to remove DNS configuration")]
-    #[cfg(macos)]
-    FailedToRemoveDnsConfig,
+    #[error("Failed to remove DNS configuration: {0}")]
+    #[cfg(any(macos, windows))]
+    FailedToRemoveDnsConfig(String),
     #[error("DNS cache flush failed: {0}")]
     #[cfg(macos)]
     CacheFlushFailed(String),
@@ -43,7 +43,7 @@ pub enum DnsManagerError {
     #[cfg(linux)]
     FailedToRestoreDnsConfig(String),
     #[error("DNS has already been configured")]
-    #[cfg(linux)]
+    #[cfg(any(linux, windows))]
     DnsAlreadyConfigured,
 }
 

--- a/lightway-client/src/platform/macos/dns_manager.rs
+++ b/lightway-client/src/platform/macos/dns_manager.rs
@@ -186,7 +186,7 @@ impl DnsSetup for DnsManager {
             let primary_service_path = Self::get_primary_service_path(service_id);
 
             if !SCDynamicStore::remove_value(Some(&self.store), &primary_service_path) {
-                return Err(DnsManagerError::FailedToRemoveDnsConfig);
+                return Err(DnsManagerError::FailedToRemoveDnsConfig("".to_string()));
             }
             self.service_id = None;
         }

--- a/lightway-client/src/platform/windows/dns_manager.rs
+++ b/lightway-client/src/platform/windows/dns_manager.rs
@@ -1,14 +1,125 @@
 use crate::dns_manager::{DnsManagerError, DnsSetup};
 use std::net::IpAddr;
+use std::process::Command;
 
 #[derive(Default)]
-pub struct DnsManager {}
+pub struct DnsManager {
+    setup: bool,
+}
+
+/// Windows implementation of DnsManeger is based on
+/// NRPT (Name Resolution Policy Table) rules that force all DNS
+/// queries through configured resolver.
+/// This overrides Windows Smart Multi-Homed Name Resolution which otherwise
+/// queries all interfaces in parallel, allowing ISP DNS poisoning to win.
+impl DnsManager {
+    fn flush_dns_cache() {
+        let _ = Command::new("ipconfig").arg("/flushdns").output();
+    }
+
+    fn add_nrpt_rule(dns_server: IpAddr) -> Result<(), DnsManagerError> {
+        let server = format!("'{dns_server}'");
+        let cmd = format!(
+            "Add-DnsClientNrptRule -Comment 'lightway-dns' -Namespace '.' -NameServers {server}"
+        );
+
+        let output = Command::new("powershell")
+            .args(["-NoProfile", "-Command", &cmd])
+            .output()
+            .map_err(|e| DnsManagerError::FailedToSetDnsConfig(e.to_string()))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(DnsManagerError::FailedToSetDnsConfig(format!(
+                "NRPT rule creation failed: {stderr}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn remove_nrpt_rule() -> Result<(), DnsManagerError> {
+        let cmd = "Get-DnsClientNrptRule | Where-Object -Property Comment -eq 'lightway-dns' | Remove-DnsClientNrptRule -Force";
+
+        let output = Command::new("powershell")
+            .args(["-NoProfile", "-Command", cmd])
+            .output()
+            .map_err(|e| DnsManagerError::FailedToRemoveDnsConfig(e.to_string()))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(DnsManagerError::FailedToRemoveDnsConfig(format!(
+                "NRPT rule removal failed: {stderr}"
+            )));
+        }
+        Ok(())
+    }
+}
 
 impl DnsSetup for DnsManager {
-    fn set_dns(&mut self, _dns_server: IpAddr) -> Result<(), DnsManagerError> {
+    fn set_dns(&mut self, dns_server: IpAddr) -> Result<(), DnsManagerError> {
+        if self.setup {
+            return Err(DnsManagerError::DnsAlreadyConfigured);
+        }
+        // always remove it first in case the rule is hanging after client crash
+        Self::remove_nrpt_rule()?;
+        Self::add_nrpt_rule(dns_server)?;
+        Self::flush_dns_cache();
+        self.setup = true;
         Ok(())
     }
     fn reset_dns(&mut self) -> Result<(), DnsManagerError> {
+        Self::remove_nrpt_rule()?;
+        Self::flush_dns_cache();
+        self.setup = false;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    fn get_configured_nrpt_server() -> Option<String> {
+        let cmd = "Get-DnsClientNrptRule | Where-Object -Property Comment -eq 'lightway-dns' | Format-List -Property 'NameServers'";
+        let output = Command::new("powershell")
+            .args(["-NoProfile", "-Command", cmd])
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        let server = stdout.splitn(2, ':').nth(1).map(|s| s.trim().to_string());
+
+        return server;
+    }
+
+    fn has_configured_nrpt() -> bool {
+        let cmd = "Get-DnsClientNrptRule | Where-Object -Property Comment -eq 'lightway-dns'";
+        let output = Command::new("powershell")
+            .args(["-NoProfile", "-Command", cmd])
+            .output()
+            .unwrap();
+
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        !stdout.is_empty()
+    }
+
+    #[test]
+    fn test_dns_set_and_cleanup() {
+        const TEST_ADDRESS: &str = "192.0.2.1";
+
+        // Verify NRPT is not initially present
+        assert!(!has_configured_nrpt(), "NRPT already configured");
+
+        // Set DNS and verify it's applied
+        let mut dns_manager = crate::dns_manager::DnsManager::default();
+        dns_manager.set_dns(TEST_ADDRESS.parse().unwrap()).unwrap();
+
+        assert!(has_configured_nrpt(), "NRPT not configured");
+        let server = get_configured_nrpt_server();
+        assert!(server.is_some());
+        assert!(server.unwrap() == TEST_ADDRESS);
+
+        // Reset NRPT and verify it is removed
+        dns_manager.reset_dns().unwrap();
+        assert!(!has_configured_nrpt(), "NRPT still configured");
     }
 }


### PR DESCRIPTION
## Description
Add implementation of dns_manager for Windows platform.
Using NRPT (Name Resolution Policy Table) to always use configured DNS resolver.

Based on work of geekjy
[https://github.com/geekjy/lightway/blob/ef21c1567548e1608ef2b99e1acffd84310e30ee/lightway-client/src/platform/windows/dns_manager.rs]
## Motivation and Context
We want to prevent DNS leaks on Windows.
For that we need to be sure Windows uses a DNS resolver over VPN tunnel.

## How Has This Been Tested?
Unit tests.
End-to-end test with Windows client and Linux server.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
