### PR TITLE
CVPN-2505: core: add RTT to KeepaliveReply event

### DIFF
--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -413,7 +413,7 @@ async fn handle_events<A: 'static + Send + EventCallback, ExtAppState: Send + Sy
                     let _ = disconnected_tx.send(());
                 }
             }
-            Event::KeepaliveReply => keepalive.reply_received().await,
+            Event::KeepaliveReply { .. } => keepalive.reply_received().await,
             Event::FirstPacketReceived => {
                 info!("First outside packet received");
             }

--- a/lightway-client/src/mobile/lightway.rs
+++ b/lightway-client/src/mobile/lightway.rs
@@ -793,7 +793,7 @@ async fn handle_events<A: 'static + Send + EventCallback>(
                     };
                 }
             }
-            Event::KeepaliveReply => {
+            Event::KeepaliveReply { .. } => {
                 notify_keepalive_reply.notify_waiters();
                 keepalive.reply_received().await
             }

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -416,6 +416,11 @@ pub struct Connection<AppState: Send = ()> {
     /// PMTU discovery state ([`ConnectionType::Datagram`] only)
     pmtud: Option<dplpmtud::Dplpmtud<AppState>>,
 
+    /// Timestamp of the most recent keepalive send awaiting a reply. If a packet is dropped, the
+    /// next keepalive will overwrite this field so we don't measure against a stale entry.
+    /// Consumed on reply to attach RTT to [`Event::KeepaliveReply`].
+    last_keepalive_sent: Option<Instant>,
+
     /// Counter to use for `wire::DataFrag`
     fragment_counter: std::num::Wrapping<u16>,
 
@@ -515,6 +520,7 @@ impl<AppState: Send> Connection<AppState> {
                     )
                 }),
             },
+            last_keepalive_sent: None,
             fragment_counter: Wrapping(0),
             is_first_packet_received: false,
             inside_pkt_encoder,
@@ -1092,7 +1098,11 @@ impl<AppState: Send> Connection<AppState> {
 
         let msg = wire::Frame::Ping(ping);
 
-        self.send_frame_or_drop(msg)
+        let result = self.send_frame_or_drop(msg);
+        if result.is_ok() {
+            self.last_keepalive_sent = Some(Instant::now());
+        }
+        result
     }
 
     /// Disconnect this connection
@@ -1489,7 +1499,8 @@ impl<AppState: Send> Connection<AppState> {
         );
 
         if pong.id == wire::Ping::KEEPALIVE_ID {
-            self.event(Event::KeepaliveReply);
+            let rtt = self.last_keepalive_sent.take().map(|sent| sent.elapsed());
+            self.event(Event::KeepaliveReply { rtt });
             self.check_expresslane_health(&pong.payload)?;
         }
 

--- a/lightway-core/src/connection/event.rs
+++ b/lightway-core/src/connection/event.rs
@@ -1,13 +1,19 @@
 use crate::connection::ExpresslaneState;
 use crate::{SessionId, State};
+use std::time::Duration;
 
 /// A lightway event
 #[derive(Debug)]
 pub enum Event {
     /// The connection state has changed
     StateChanged(State),
-    /// A reply was received after a [`crate::Connection::keepalive()`]
-    KeepaliveReply,
+    /// A reply was received after a [`crate::Connection::keepalive()`].
+    KeepaliveReply {
+        /// Measured round-trip time for the matched keepalive packet.
+        /// The connection retains at most one outstanding send timestamp,
+        /// which avoids stale-timestamp drift if pings are dropped.
+        rtt: Option<Duration>,
+    },
     /// A new session id has been generated and will be used in
     /// outgoing packets. The old session id is still active until
     /// the peer acknowledges the new one.

--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -498,7 +498,7 @@ async fn client<S: TestSock>(
                     );
                 }
                 Event::StateChanged(state) => eprintln!("Connection change to {state:?}"),
-                Event::KeepaliveReply => eprintln!("Got keepalive reply"),
+                Event::KeepaliveReply { .. } => eprintln!("Got keepalive reply"),
                 Event::SessionIdRotationStarted { .. } => {
                     eprintln!("Got SessionIdRotationStarted")
                 }

--- a/lightway-server/src/connection_manager.rs
+++ b/lightway-server/src/connection_manager.rs
@@ -188,7 +188,7 @@ async fn handle_events(
 
         match event {
             Event::StateChanged(state) => handle_state_change(state, &conn).await,
-            Event::KeepaliveReply => {}
+            Event::KeepaliveReply { .. } => {}
             Event::SessionIdRotationStarted { .. } => {}
             Event::SessionIdRotationAcknowledged { old, new } => {
                 handle_finalize_session_rotation(&conn, old, new);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
An Instant is measured when keepalive is first sent, and the RTT is measured against it when the keepalive reply is received. When RTT > keepalive interval, this will cause an lower reading than expected. But since our keepalive interval is relatively long, it should be fine.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows consumers to gauge RTT using keepalive packets

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
