### PR TITLE
Fix nix ci failure

### DIFF
--- a/.github/workflows/nix-build.yaml
+++ b/.github/workflows/nix-build.yaml
@@ -208,6 +208,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v21
 

--- a/flake.nix
+++ b/flake.nix
@@ -41,41 +41,6 @@
             inherit system;
             overlays = [
               inputs.rust-overlay.overlays.default
-              # Backport NixOS/nixpkgs#524985 (merged 2026-05-27): switch
-              # `importCargoLock` to download crates from
-              # `https://static.crates.io/crates` instead of the API endpoint
-              # `https://crates.io/api/v1/crates/...`, which now returns HTTP 403
-              # for `curl/*` User-Agents. See rust-lang/crates.io#13482 and
-              # NixOS/nixpkgs#524979. Drop this overlay once `flake.lock` is
-              # bumped to a `nixpkgs-unstable` revision containing the upstream
-              # fix.
-              #
-              # Override `makeRustPlatform` (not `rustPlatform.importCargoLock`):
-              # nixpkgs' `pkgs/development/compilers/rust/make-rust-platform.nix`
-              # constructs a fresh `importCargoLock` from a hardcoded file path
-              # via `buildPackages.callPackage`, so the top-level
-              # `rustPlatform.importCargoLock` is ignored by both native.nix and
-              # cross.nix (which both call `(pkgsCross.)makeRustPlatform`).
-              (
-                final: prev:
-                let
-                  patchedImportCargoLockFile = builtins.toFile "import-cargo-lock-static-crates-io.nix" (
-                    builtins.replaceStrings [ "https://crates.io/api/v1/crates" ] [ "https://static.crates.io/crates" ]
-                      (builtins.readFile (prev.path + "/pkgs/build-support/rust/import-cargo-lock.nix"))
-                  );
-                in
-                {
-                  makeRustPlatform =
-                    args:
-                    (prev.makeRustPlatform args).overrideScope (
-                      _: _: {
-                        importCargoLock = prev.buildPackages.callPackage patchedImportCargoLockFile {
-                          inherit (args) cargo;
-                        };
-                      }
-                    );
-                }
-              )
             ];
             config.allowUnfree = true;
             config.android_sdk.accept_license = true;

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -23,6 +23,9 @@ setup_ns() {
     ip netns exec "${ns}" ip link set lo up
     mkdir /etc/netns/"${ns}" -p
 
+    ip netns exec "${ns}" sysctl -q net.ipv4.conf.all.arp_ignore=0
+    ip netns exec "${ns}" sysctl -q net.ipv4.conf.all.arp_announce=0
+
     # Setup TUN interface
     if [[ -n $tunname ]]; then
         ip netns exec "${ns}" ip tuntap add mode tun dev "${tunname}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes
- Use `ci-free-disk-space` for making more free space
- Remove now unnecessary nix patch for cargo build
- Fix minor issue in dev test environment where the host has strictArp enabled

## Motivation and Context

Daily nix builds are failings in musl target due to storage full.
https://github.com/xvpn/lightway-mirror/actions/runs/27101282087

## How Has This Been Tested?

Will verify with todays build

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
