### PR TITLE
server: config: expose ServerConfig::try_from method

### DIFF
--- a/lightway-app-utils/src/args/connection_type.rs
+++ b/lightway-app-utils/src/args/connection_type.rs
@@ -19,7 +19,7 @@ pub enum ConnectionType {
 }
 
 impl ConnectionType {
-    /// A helper function easier to use especially in mobile
+    #[allow(missing_docs)]
     pub fn is_tcp(&self) -> bool {
         *self == ConnectionType::Tcp
     }

--- a/lightway-app-utils/src/args/connection_type.rs
+++ b/lightway-app-utils/src/args/connection_type.rs
@@ -23,6 +23,11 @@ impl ConnectionType {
     pub fn is_tcp(&self) -> bool {
         *self == ConnectionType::Tcp
     }
+
+    #[allow(missing_docs)]
+    pub fn is_udp(&self) -> bool {
+        *self == ConnectionType::Udp
+    }
 }
 
 impl From<ConnectionType> for LWConnectionType {

--- a/lightway-server/src/config.rs
+++ b/lightway-server/src/config.rs
@@ -233,6 +233,13 @@ impl Config {
             anyhow::ensure!(self.mode.is_udp(), "Expresslane only work in udp mode")
         }
 
+        if self.proxy_protocol {
+            anyhow::ensure!(
+                self.mode.is_tcp(),
+                "Proxy protocol only support with tcp mode"
+            )
+        }
+
         Ok(())
     }
 }
@@ -254,6 +261,14 @@ mod tests {
         let mut config = Config::default();
         config.mode = ConnectionType::Tcp;
         config.enable_expresslane = true;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_proxy_protocol() {
+        let mut config = Config::default();
+        config.mode = ConnectionType::Udp;
+        config.proxy_protocol = true;
         assert!(config.validate().is_err());
     }
 }

--- a/lightway-server/src/config.rs
+++ b/lightway-server/src/config.rs
@@ -229,6 +229,10 @@ impl Default for Config {
 impl Config {
     /// Ensure the config is validated, and alerted when there's a conflict in the settings.
     pub fn validate(&self) -> anyhow::Result<()> {
+        if self.enable_expresslane {
+            anyhow::ensure!(self.mode.is_udp(), "Expresslane only work in udp mode")
+        }
+
         Ok(())
     }
 }
@@ -243,5 +247,13 @@ mod tests {
     fn validate_default_config() {
         let config = Config::default();
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_enable_expresslane() {
+        let mut config = Config::default();
+        config.mode = ConnectionType::Tcp;
+        config.enable_expresslane = true;
+        assert!(config.validate().is_err());
     }
 }

--- a/lightway-server/src/config.rs
+++ b/lightway-server/src/config.rs
@@ -225,3 +225,23 @@ impl Default for Config {
         }
     }
 }
+
+impl Config {
+    /// Ensure the config is validated, and alerted when there's a conflict in the settings.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+// Note it easier to see what is different from default in each testcase
+#[allow(clippy::field_reassign_with_default)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_default_config() {
+        let config = Config::default();
+        assert!(config.validate().is_ok());
+    }
+}

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -262,6 +262,65 @@ pub struct ServerConfig<SA: for<'a> ServerAuth<AuthState<'a>>> {
     pub randomize_ippool: bool,
 }
 
+impl<SA: for<'a> ServerAuth<AuthState<'a>>> ServerConfig<SA> {
+    pub fn try_from_auth_and_config(auth: SA, config: config::Config) -> Result<Self> {
+        let mut tun_config = lightway_app_utils::TunConfig::default();
+        if let Some(tun_name) = config.tun_name {
+            tun_config.tun_name(tun_name);
+        }
+        tun_config.up();
+
+        Ok(crate::ServerConfig {
+            mode: match config.mode {
+                lightway_app_utils::args::ConnectionType::Udp => {
+                    crate::ServerConnectionMode::Datagram(None)
+                }
+                lightway_app_utils::args::ConnectionType::Tcp => {
+                    crate::ServerConnectionMode::Stream(None)
+                }
+            },
+            auth,
+            server_cert: config.server_cert,
+            server_key: config.server_key,
+            tun_config,
+            ip_pool: config.ip_pool,
+            ip_map: config.ip_map.unwrap_or_default().try_into()?,
+            inside_io: None,
+            tun_ip: config.tun_ip,
+            lightway_server_ip: config.lightway_server_ip,
+            lightway_client_ip: config.lightway_client_ip,
+            lightway_dns_ip: config.lightway_dns_ip,
+            use_dynamic_client_ip: false,
+            enable_expresslane: config.enable_expresslane,
+            expresslane_keys_rotation_interval: config.expresslane_keys_rotation_interval.into(),
+            expresslane_cb: None,
+            expresslane_metrics: None,
+            event_cb: None,
+            enable_pqc: config.enable_pqc,
+            #[cfg(target_os = "linux")]
+            enable_tun_offload: config.enable_tun_offload,
+            #[cfg(feature = "io-uring")]
+            enable_tun_iouring: config.enable_tun_iouring,
+            #[cfg(feature = "io-uring")]
+            iouring_entry_count: config.iouring_entry_count,
+            #[cfg(feature = "io-uring")]
+            iouring_sqpoll_idle_time: config.iouring_sqpoll_idle_time.into(),
+            key_update_interval: config.key_update_interval.into(),
+            connection_age_expiration_interval: config.connection_age_expiration_interval.into(),
+            statistics_reporting_interval: config.statistics_reporting_interval.into(),
+            inside_plugins: Default::default(),
+            outside_plugins: Default::default(),
+            inside_pkt_codec: None,
+            bind_address: config.bind_address,
+            proxy_protocol: config.proxy_protocol,
+            udp_buffer_size: config.udp_buffer_size,
+            enable_batch_receive: config.enable_batch_receive,
+            #[cfg(feature = "debug")]
+            randomize_ippool: config.randomize_ippool,
+        })
+    }
+}
+
 pub(crate) fn handle_inside_io_error(conn: Arc<Connection>, result: ConnectionResult<()>) {
     match result {
         Ok(()) => {}

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -264,6 +264,8 @@ pub struct ServerConfig<SA: for<'a> ServerAuth<AuthState<'a>>> {
 
 impl<SA: for<'a> ServerAuth<AuthState<'a>>> ServerConfig<SA> {
     pub fn try_from_auth_and_config(auth: SA, config: config::Config) -> Result<Self> {
+        config.validate()?;
+
         let mut tun_config = lightway_app_utils::TunConfig::default();
         if let Some(tun_name) = config.tun_name {
             tun_config.tun_name(tun_name);

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -1,5 +1,4 @@
 mod auth;
-mod config;
 
 use anyhow::{Context, Result, anyhow};
 use clap::Parser;
@@ -10,10 +9,10 @@ use tokio::fs::read_to_string;
 use tokio_stream::StreamExt;
 use tracing::{error, trace};
 
-use config::{Config, ConfigPatch};
-use lightway_app_utils::{TunConfig, Validate, validate_configuration_file_path};
+use lightway_app_utils::{Validate, validate_configuration_file_path};
 #[cfg(feature = "debug")]
 use lightway_core::set_logging_callback;
+use lightway_server::config::{Config, ConfigPatch};
 use lightway_server::*;
 
 async fn metrics_debug() {
@@ -140,62 +139,12 @@ async fn main() -> Result<()> {
         }
     });
 
-    let auth = auth::Auth::new(
-        config.user_db.as_ref().map(AsRef::as_ref),
-        config.token_rsa_pub_key_pem.as_ref().map(AsRef::as_ref),
-    )?;
-
-    let mut tun_config = TunConfig::default();
-    if let Some(tun_name) = config.tun_name {
-        tun_config.tun_name(tun_name);
-    }
-    tun_config.up();
-    let mode = match config.mode {
-        lightway_app_utils::args::ConnectionType::Udp => ServerConnectionMode::Datagram(None),
-        lightway_app_utils::args::ConnectionType::Tcp => ServerConnectionMode::Stream(None),
-    };
-
-    let config = ServerConfig {
-        mode,
-        auth,
-        server_cert: config.server_cert,
-        server_key: config.server_key,
-        tun_config,
-        ip_pool: config.ip_pool,
-        ip_map: config.ip_map.unwrap_or_default().try_into()?,
-        inside_io: None,
-        tun_ip: config.tun_ip,
-        lightway_server_ip: config.lightway_server_ip,
-        lightway_client_ip: config.lightway_client_ip,
-        lightway_dns_ip: config.lightway_dns_ip,
-        use_dynamic_client_ip: false,
-        enable_expresslane: config.enable_expresslane,
-        expresslane_keys_rotation_interval: config.expresslane_keys_rotation_interval.into(),
-        expresslane_cb: None,
-        expresslane_metrics: None,
-        event_cb: None,
-        enable_pqc: config.enable_pqc,
-        #[cfg(target_os = "linux")]
-        enable_tun_offload: config.enable_tun_offload,
-        #[cfg(feature = "io-uring")]
-        enable_tun_iouring: config.enable_tun_iouring,
-        #[cfg(feature = "io-uring")]
-        iouring_entry_count: config.iouring_entry_count,
-        #[cfg(feature = "io-uring")]
-        iouring_sqpoll_idle_time: config.iouring_sqpoll_idle_time.into(),
-        key_update_interval: config.key_update_interval.into(),
-        connection_age_expiration_interval: config.connection_age_expiration_interval.into(),
-        statistics_reporting_interval: config.statistics_reporting_interval.into(),
-        inside_plugins: Default::default(),
-        outside_plugins: Default::default(),
-        inside_pkt_codec: None,
-        bind_address: config.bind_address,
-        proxy_protocol: config.proxy_protocol,
-        udp_buffer_size: config.udp_buffer_size,
-        enable_batch_receive: config.enable_batch_receive,
-        #[cfg(feature = "debug")]
-        randomize_ippool: config.randomize_ippool,
-    };
-
-    server(config).await
+    server(crate::ServerConfig::try_from_auth_and_config(
+        crate::auth::Auth::new(
+            config.user_db.as_ref().map(AsRef::as_ref),
+            config.token_rsa_pub_key_pem.as_ref().map(AsRef::as_ref),
+        )?,
+        config,
+    )?)
+    .await
 }

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -97,7 +97,6 @@ async fn main() -> Result<()> {
         validate_configuration_file_path(user_db, Validate::OwnerOnly)
             .with_context(|| format!("Invalid user db file {}", user_db.display()))?;
     }
-    config.validate()?;
 
     #[cfg(feature = "debug")]
     if config.tls_debug {
@@ -115,6 +114,13 @@ async fn main() -> Result<()> {
     let fmt = tracing_subscriber::fmt().with_env_filter(filter);
 
     config.log_format.init_with_env_filter(fmt);
+    let server_config = crate::ServerConfig::try_from_auth_and_config(
+        crate::auth::Auth::new(
+            config.user_db.as_ref().map(AsRef::as_ref),
+            config.token_rsa_pub_key_pem.as_ref().map(AsRef::as_ref),
+        )?,
+        config,
+    )?;
 
     tokio::spawn(metrics_debug());
 
@@ -140,12 +146,5 @@ async fn main() -> Result<()> {
         }
     });
 
-    server(crate::ServerConfig::try_from_auth_and_config(
-        crate::auth::Auth::new(
-            config.user_db.as_ref().map(AsRef::as_ref),
-            config.token_rsa_pub_key_pem.as_ref().map(AsRef::as_ref),
-        )?,
-        config,
-    )?)
-    .await
+    server(server_config).await
 }

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -97,6 +97,7 @@ async fn main() -> Result<()> {
         validate_configuration_file_path(user_db, Validate::OwnerOnly)
             .with_context(|| format!("Invalid user db file {}", user_db.display()))?;
     }
+    config.validate()?;
 
     #[cfg(feature = "debug")]
     if config.tls_debug {


### PR DESCRIPTION
## Description
- [X] collect `ServerConfig::try_from_auth_and_config`
- [X] add `validate` method of `Config` 
- [X] adding validation for `enable_expresslane`, `proxy_protocol`
- [X] validate config when building `ServerConfig`

## Motivation and Context
Provide reusable methods, including validations and casting, for `Config`, such that these method can easier to reused by any downstream projects.  Track with ticket CVPN-2602.

## How Has This Been Tested?
- [X] testcases for new validation functions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
