### PR TITLE
CVPN-2505: Network change monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,7 @@ dependencies = [
  "metrics",
  "pnet_packet",
  "regex",
+ "route_manager",
  "schemars 1.2.1",
  "serde",
  "serde_with",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ pnet_packet = { version = "0.35.0" }
 pnet = { version = "0.35.0", default-features = false}
 rand = "0.10.0"
 regex = "1"
+route_manager = { version = "0.2.6", features = ["async"] }
 schemars = "1.2.1"
 serde = "1.0.189"
 serde-env = "0.3"

--- a/lightway-app-utils/Cargo.toml
+++ b/lightway-app-utils/Cargo.toml
@@ -44,8 +44,18 @@ tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["json", "env-filter"] }
 tun-rs.workspace = true
 
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]
+route_manager.workspace = true
+
 [target.'cfg(windows)'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_Networking_WinSock"] }
+windows-sys = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_NetworkManagement",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_Networking_WinSock",
+    "Win32_System_IO",
+    "Win32_System_Threading",
+] }
 
 [build-dependencies]
 cfg_aliases.workspace = true

--- a/lightway-app-utils/src/lib.rs
+++ b/lightway-app-utils/src/lib.rs
@@ -14,6 +14,8 @@ mod dplpmtud_timer;
 mod event_stream;
 #[cfg(feature = "io-uring")]
 mod iouring;
+#[cfg(all(feature = "tokio", desktop))]
+mod network_change_monitor;
 mod tun;
 
 #[cfg(feature = "tokio")]
@@ -27,6 +29,9 @@ pub use event_stream::{EventStream, EventStreamCallback};
 
 #[cfg(feature = "io-uring")]
 pub use iouring::IOUring;
+
+#[cfg(all(feature = "tokio", desktop))]
+pub use network_change_monitor::NetworkChangeMonitor;
 
 #[cfg(feature = "io-uring")]
 pub use tun::TunIoUring;

--- a/lightway-app-utils/src/network_change_monitor.rs
+++ b/lightway-app-utils/src/network_change_monitor.rs
@@ -1,0 +1,116 @@
+//! Reusable network-change monitor.
+//!
+//! Spawns the platform route/address listeners and republishes their events as a coalescing
+//! [`tokio::sync::watch`] signal. Consumers can [`subscribe`](NetworkChangeMonitor::subscribe) to
+//! network changes
+
+#[cfg(windows)]
+mod addr_monitor;
+
+use anyhow::Result;
+use route_manager::{AsyncRouteListener, RouteChange};
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+#[cfg(windows)]
+use addr_monitor::AsyncAddrListener;
+
+/// Monitors network changes (route and, on Windows, address changes) and
+/// publishes a notification each time one is detected.
+pub struct NetworkChangeMonitor {
+    rx: watch::Receiver<()>,
+    task: JoinHandle<()>,
+}
+
+impl NetworkChangeMonitor {
+    /// Spawn the monitor. The route/address listeners are created inside the
+    /// spawned task.
+    pub fn spawn() -> Result<Self> {
+        let (tx, rx) = watch::channel(());
+
+        let task = tokio::spawn(async move {
+            let mut route_listener = match AsyncRouteListener::new() {
+                Ok(listener) => listener,
+                Err(e) => {
+                    tracing::error!("Failed to create AsyncRouteListener: {}", e);
+                    return;
+                }
+            };
+
+            // On Windows, also create address change listener as a fallback
+            // since Windows doesn't always publish route changes on network down
+            #[cfg(windows)]
+            let mut addr_listener = match AsyncAddrListener::new() {
+                Ok(listener) => {
+                    tracing::info!("Started address change monitoring (Windows)...");
+                    Some(listener)
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to create AsyncAddrListener: {}", e);
+                    None
+                }
+            };
+
+            #[cfg(not(windows))]
+            let (_sender, addr_listener) = tokio::sync::mpsc::unbounded_channel::<()>();
+            #[cfg(not(windows))]
+            let mut addr_listener = Some(addr_listener);
+
+            tracing::info!("Started monitoring route/intf...");
+            loop {
+                tokio::select! {
+                   route_result = route_listener.listen() => {
+                       match route_result {
+                           Ok(route_change) => {
+                               tracing::debug!("Route change detected: {:?}", route_change);
+                               let (RouteChange::Add(route)
+                               | RouteChange::Delete(route)
+                               | RouteChange::Change(route)) = &route_change;
+                               if route.prefix() == 0
+                                   && route.gateway().is_some_and(|gw| !gw.is_unspecified())
+                                   && tx.send(()).is_err() {
+                                   tracing::debug!("No network change receivers left, stopping monitor");
+                                   break;
+                               }
+                           }
+                           Err(e) => {
+                               // Continue monitoring even on transient errors
+                               tracing::debug!("Error listening for route changes: {}", e);
+                               tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                           }
+                       }
+                   }
+
+                   // On address/intf changes, notify too. This helps catch
+                   // network transitions that don't trigger route changes.
+                   _ = async {
+                       if let Some(listener) = &mut addr_listener {
+                           listener.recv().await
+                       } else {
+                           std::future::pending().await
+                       }
+                   } => {
+                       tracing::debug!("Address change detected");
+                       if tx.send(()).is_err() {
+                           tracing::debug!("No network change receivers left, stopping monitor");
+                           break;
+                       }
+                   }
+                }
+            }
+        });
+
+        Ok(Self { rx, task })
+    }
+
+    /// Get a receiver that fires whenever a network change is detected.
+    pub fn subscribe(&self) -> watch::Receiver<()> {
+        self.rx.clone()
+    }
+}
+
+impl Drop for NetworkChangeMonitor {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}

--- a/lightway-app-utils/src/network_change_monitor/addr_monitor.rs
+++ b/lightway-app-utils/src/network_change_monitor/addr_monitor.rs
@@ -1,10 +1,7 @@
 #![allow(unsafe_code)]
 use anyhow::Result;
-use futures::Stream;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::task::{Context, Poll};
 use tokio::sync::mpsc;
 use tracing::{debug, error};
 
@@ -15,17 +12,14 @@ use windows_sys::Win32::{
     System::Threading::{CreateEventW, ResetEvent, WaitForSingleObject},
 };
 
-/// Represents different types of address changes that can be monitored
+/// Represents an address change detected by the monitor.
+///
+/// The Windows `NotifyAddrChange` API does not report the specific kind of
+/// change, so a single generic event is emitted for any address change.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AddrChangeEvent {
-    /// An address was added to an interface
-    AddressAdded,
-    /// An address was removed from an interface
-    AddressRemoved,
     /// An address configuration changed
     AddressChanged,
-    /// Network interface state changed (up/down)
-    InterfaceStateChanged,
 }
 
 /// Async stream for monitoring Windows address changes
@@ -244,34 +238,14 @@ impl Drop for AsyncAddrListener {
     }
 }
 
-impl Stream for AsyncAddrListener {
-    type Item = AddrChangeEvent;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.receiver).poll_recv(cx)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio_stream::StreamExt;
 
     #[tokio::test]
     async fn test_addr_listener_creation() {
         // Test that we can create the listener without panic
         let result = AsyncAddrListener::new();
         assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_addr_listener_as_stream() {
-        let listener = AsyncAddrListener::new().unwrap();
-        let stream = listener.take(1); // Take only 1 event for test
-
-        // This test would hang waiting for actual address changes, so we just verify
-        // that we can create the stream without error
-        // To properly test, you'd need to trigger an address change during the test
-        drop(stream);
     }
 }

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -75,7 +75,7 @@ tracing-android = "0.2.0"
 cfg_aliases.workspace = true
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]
-route_manager = { version = "0.2.6", features = ["async"] }
+route_manager.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-core-foundation = "0.3.1"

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -744,6 +744,7 @@ impl<ExtAppState: Send + Sync> ClientConnection<ExtAppState> {
         route_mode: RouteMode,
         tun_peer_ip: IpAddr,
         tun_dns_ip: IpAddr,
+        network_change_rx: Option<watch::Receiver<()>>,
     ) -> Result<()> {
         let server_ip = self.outside_io.peer_addr().ip();
         let tun_index = self.inside_io.if_index()?;
@@ -758,7 +759,7 @@ impl<ExtAppState: Send + Sync> ClientConnection<ExtAppState> {
         );
         let mut route_manager =
             RouteManager::new(route_mode, server_ip, tun_index, tun_peer_ip, tun_dns_ip)?;
-        route_manager.start().await?;
+        route_manager.start(network_change_rx).await?;
 
         self.route_manager = Some(route_manager);
         info!("Routes configured");
@@ -1363,13 +1364,16 @@ pub async fn client<
     connection.set_connection_inside_io();
 
     #[cfg(desktop)]
-    connection
-        .initialize_routes(
-            config.route_mode,
-            config.tun_peer_ip.into(),
-            config.tun_dns_ip.into(),
-        )
-        .await?;
+    {
+        connection
+            .initialize_routes(
+                config.route_mode,
+                config.tun_peer_ip.into(),
+                config.tun_dns_ip.into(),
+                config.network_change_signal.clone(),
+            )
+            .await?;
+    }
 
     #[cfg(desktop)]
     connection.set_dns(config.dns_config_mode, config.tun_dns_ip.into())?;

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -64,7 +64,7 @@ use std::{
 };
 use tokio::{
     net::{TcpStream, UdpSocket},
-    sync::{mpsc, oneshot},
+    sync::{mpsc, oneshot, watch},
     task::{JoinHandle, JoinSet},
 };
 use tokio_stream::{StreamExt, StreamMap};
@@ -248,7 +248,7 @@ pub struct ClientConfig<ExtAppState: Send + Sync> {
     /// network change being defined as a change in
     /// wifi networks or a change of network interfaces
     #[educe(Debug(ignore))]
-    pub network_change_signal: Option<mpsc::Receiver<()>>,
+    pub network_change_signal: Option<watch::Receiver<()>>,
 
     /// Signal for triggering a runtime config reload.
     /// Each received value is applied to the running connection.
@@ -1325,10 +1325,10 @@ pub async fn client<
         let _ = conn.stop_signal.take().unwrap().send(());
     }
 
-    if let Some(mut network_change_signal) = config.network_change_signal.take() {
+    if let Some(mut network_change_signal) = config.network_change_signal.clone() {
         let connection_network_change_signal = connection.network_change_signal.clone();
         tokio::spawn(async move {
-            while network_change_signal.recv().await.is_some() {
+            while network_change_signal.changed().await.is_ok() {
                 if let Err(e) = connection_network_change_signal.send(()).await {
                     tracing::error!("Failed to send network_change_signal: {e}");
                 }

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -21,6 +21,8 @@ use futures::{FutureExt, stream::FuturesUnordered};
 pub use io::inside::{InsideIO, InsideIORecv};
 use io::outside::OutsideIO;
 use keepalive::Keepalive;
+#[cfg(desktop)]
+use lightway_app_utils::NetworkChangeMonitor;
 #[cfg(feature = "postquantum")]
 use lightway_app_utils::args::KeyShare;
 use lightway_app_utils::{
@@ -1364,13 +1366,24 @@ pub async fn client<
     connection.set_connection_inside_io();
 
     #[cfg(desktop)]
+    let mut network_change_monitor: Option<NetworkChangeMonitor> = None;
+    #[cfg(desktop)]
     {
+        let rx = if let Some(ref rx) = config.network_change_signal {
+            rx.clone()
+        } else {
+            let monitor = NetworkChangeMonitor::spawn()?;
+            let rx = monitor.subscribe();
+            network_change_monitor = Some(monitor);
+            rx
+        };
+
         connection
             .initialize_routes(
                 config.route_mode,
                 config.tun_peer_ip.into(),
                 config.tun_dns_ip.into(),
-                config.network_change_signal.clone(),
+                Some(rx),
             )
             .await?;
     }
@@ -1384,6 +1397,10 @@ pub async fn client<
     if let Some(mut route_manager) = connection.route_manager {
         let _ = route_manager.stop().await;
     }
+
+    // Dropping the monitor aborts its background task.
+    #[cfg(desktop)]
+    drop(network_change_monitor);
 
     result
 }

--- a/lightway-client/src/platform/windows.rs
+++ b/lightway-client/src/platform/windows.rs
@@ -1,4 +1,3 @@
-pub mod addr_monitor;
 pub mod crypto;
 pub mod dns_manager;
 pub mod utils;

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -1,19 +1,16 @@
 use anyhow::Result;
-use route_manager::{
-    AsyncRouteListener, AsyncRouteManager, Route, RouteManager as SyncRouteManager,
-};
+use route_manager::{AsyncRouteManager, Route, RouteManager as SyncRouteManager};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use thiserror::Error;
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tracing::{trace, warn};
 
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::ERROR_OBJECT_ALREADY_EXISTS;
 
-#[cfg(windows)]
-use crate::platform::windows::addr_monitor::AsyncAddrListener;
 #[cfg(windows)]
 use crate::platform::windows::utils;
 
@@ -150,12 +147,15 @@ impl RouteManager {
         Ok(Self { inner, task: None })
     }
 
-    pub async fn start(&mut self) -> Result<(), RoutingTableError> {
+    pub async fn start(
+        &mut self,
+        network_change_rx: Option<watch::Receiver<()>>,
+    ) -> Result<(), RoutingTableError> {
         let Some(inner) = self.inner.take() else {
             return Err(RoutingTableError::InsufficientPermissions);
         };
 
-        self.task = inner.start().await?;
+        self.task = inner.start(network_change_rx).await?;
         Ok(())
     }
 
@@ -476,103 +476,36 @@ impl RouteManagerInner {
 
     /// Install routes required to use tunnel and start monitoring route changes
     /// to update the routes if needed (mostly during connection floating)
-    async fn start(mut self) -> Result<Option<JoinHandle<()>>, RoutingTableError> {
+    async fn start(
+        mut self,
+        network_change_rx: Option<watch::Receiver<()>>,
+    ) -> Result<Option<JoinHandle<()>>, RoutingTableError> {
         if self.routing_mode == RouteMode::NoExec {
             return Ok(None);
         }
 
-        // Install all th required routes
+        // Install all the required routes
         self.install_routes().await?;
 
-        // Spawn async task to monitor route changes using AsyncRouteListener
-        let monitor_task = tokio::spawn(async move {
-            // Create AsyncRouteListener
-            let mut route_listener = match AsyncRouteListener::new() {
-                Ok(listener) => listener,
-                Err(e) => {
-                    tracing::error!("Failed to create AsyncRouteListener: {}", e);
-                    return;
+        let task = tokio::spawn(async move {
+            let mut inner = self;
+            match network_change_rx {
+                Some(mut rx) => {
+                    tracing::info!("Reacting to network changes for route updates...");
+                    while rx.changed().await.is_ok() {
+                        if let Err(e) = inner.check_and_update_server_route().await {
+                            tracing::warn!("Updating server route failed: {:?}", e);
+                        }
+                    }
                 }
-            };
-
-            // On Windows, also create address change listener as a fallback
-            // since Windows doesn't always publish route changes on network down
-            #[cfg(windows)]
-            let mut addr_listener = match AsyncAddrListener::new() {
-                Ok(listener) => {
-                    tracing::info!("Started address change monitoring (Windows)...");
-                    Some(listener)
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to create AsyncAddrListener: {}", e);
-                    None
-                }
-            };
-
-            #[cfg(not(windows))]
-            let (_sender, addr_listener) = tokio::sync::mpsc::unbounded_channel::<()>();
-            #[cfg(not(windows))]
-            let mut addr_listener = Some(addr_listener);
-
-            tracing::info!("Started monitoring route/intf...");
-            // Listen for changes in a loop
-            loop {
-                tokio::select! {
-                   // Handle route changes
-                   route_result = route_listener.listen() => {
-                       match route_result {
-                           Ok(route_change) => {
-                               tracing::debug!("Route change detected: {:?}", route_change);
-                               match route_change {
-                                   route_manager::RouteChange::Add(route)
-                                   | route_manager::RouteChange::Delete(route)
-                                   | route_manager::RouteChange::Change(route) => {
-                                       // Only process route updates that match server IP family
-                                       // If server is IPv4, only monitor IPv4 routes; if IPv6, only IPv6
-                                       if !same_ip_family(&self.server_ip, &route.destination()) {
-                                           // Different IP families - skip
-                                           continue;
-                                       }
-
-                                       // Update only the /0 prefix route i.e default route
-                                       if route.prefix() != 0 {
-                                           continue;
-                                       }
-                                       if route.gateway().is_none_or(|a| a.is_unspecified()) {
-                                           continue;
-                                       }
-                                       if let Err(e) = self.check_and_update_server_route().await {
-                                           tracing::warn!("Updating server route failed: {:?}", e);
-                                       }
-                                   }
-                               }
-                           }
-                       Err(e) => {
-                           // Continue monitoring even on transient errors
-                           tracing::debug!("Error listening for route changes: {}", e);
-                           tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                       }
-                   }}
-
-                   // On address/intf changes, check and update server route
-                   // This helps catch network transitions that don't trigger route changes
-                   _ = async {
-                       if let Some(listener) = &mut addr_listener {
-                           listener.recv().await
-                       } else {
-                           std::future::pending().await
-                       }
-                   } => {
-                       tracing::debug!("Address change detected");
-                       if let Err(e) = self.check_and_update_server_route().await {
-                           tracing::warn!("Updating server route after address change failed: {:?}", e);
-                       }
-                   }
+                None => {
+                    // No monitor: keep routes installed until stop()/abort.
+                    std::future::pending::<()>().await;
                 }
             }
         });
 
-        Ok(Some(monitor_task))
+        Ok(Some(task))
     }
 
     /// Check if server route needs updating due to network changes
@@ -1046,7 +979,7 @@ mod tests {
             RouteManager::new(route_mode, EXTERNAL_IP_V4, 0, TUN_PEER_IP, TUN_DNS_IP).unwrap();
 
         // Test that we can start the route manager
-        let start_result = route_manager.start().await;
+        let start_result = route_manager.start(None).await;
         if route_mode == RouteMode::NoExec {
             // NoExec mode should succeed but not actually do anything
             assert!(start_result.is_ok());
@@ -1096,10 +1029,10 @@ mod tests {
         .unwrap();
 
         // First start should succeed
-        assert!(route_manager.start().await.is_ok());
+        assert!(route_manager.start(None).await.is_ok());
 
         // Second start should fail since inner is already taken
-        let second_start_result = route_manager.start().await;
+        let second_start_result = route_manager.start(None).await;
         assert!(second_start_result.is_err());
         assert!(matches!(
             second_start_result.unwrap_err(),
@@ -1150,7 +1083,7 @@ mod tests {
         .unwrap();
 
         // NoExec mode should return None (no monitoring task)
-        let monitor_task = inner.start().await;
+        let monitor_task = inner.start(None).await;
         assert!(monitor_task.is_ok());
         assert!(monitor_task.unwrap().is_none());
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Exposes the network change detection logic within route_manager in app_utils. Multiple consumers can now subscribe to the change notification. route_manager is changed to subscribe to this monitor task instead.

Users will pass a network_change_signal (from `NetworkChangeManager::subscribe()`, or their own implementation) if they wish to own their own NetworkChangeManager. If none is provided, the client will create its own and use it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, the network change detection was done only within route_manager. To allow consumers to also reuse this logic, this is exposed in app_utils instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change is broadcasted

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
