### PR TITLE
CVPN-2609: Bound UDP batch receive iovecs by buffer capacity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,6 +1639,7 @@ dependencies = [
  "tracing-core",
  "tracing-panic",
  "tracing-subscriber",
+ "tracing-test",
  "tun-rs",
  "uniffi",
  "uuid",
@@ -3499,6 +3500,27 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -66,6 +66,7 @@ mockall = "0.14.0"
 regex.workspace = true
 serial_test.workspace = true
 tempfile = "3.24.0"
+tracing-test = "0.2.6"
 tun-rs.workspace = true
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/lightway-client/src/io/outside/udp/batch_receive.rs
+++ b/lightway-client/src/io/outside/udp/batch_receive.rs
@@ -34,7 +34,7 @@ pub(crate) fn recv_multiple(
 mod apple {
     use bytes::BytesMut;
     use lightway_app_utils::recvmsg_x::{msghdr_x, recvmsg_x};
-    use lightway_core::{MAX_IO_BATCH_SIZE, MAX_OUTSIDE_MTU};
+    use lightway_core::MAX_IO_BATCH_SIZE;
     use std::{io, mem};
 
     pub(crate) struct RecvmsgX;
@@ -53,11 +53,16 @@ mod apple {
             // SAFETY: zeroed msghdr_x is valid (null pointers + zero lengths).
             let mut hdrs = unsafe { mem::zeroed::<[msghdr_x; MAX_IO_BATCH_SIZE]>() };
             for i in 0..msg_count {
-                iovecs[i].iov_base =
-                    recv_bufs[i].spare_capacity_mut().as_mut_ptr() as *mut libc::c_void;
-                iovecs[i].iov_len = MAX_OUTSIDE_MTU;
-                hdrs[i].msg_iov = &mut iovecs[i];
-                hdrs[i].msg_iovlen = 1;
+                // Advertise only the buffer's spare capacity to the kernel so
+                // it can never write past the allocation; oversized datagrams
+                // are truncated, matching the non-batch recv path.
+                let spare = recv_bufs[i].spare_capacity_mut();
+                let iovec = &mut iovecs[i];
+                let hdr = &mut hdrs[i];
+                iovec.iov_base = spare.as_mut_ptr() as *mut libc::c_void;
+                iovec.iov_len = spare.len();
+                hdr.msg_iov = iovec;
+                hdr.msg_iovlen = 1;
             }
 
             // SAFETY: hdrs and iovecs are valid for msg_count entries, fd is a valid and borrowed socket.
@@ -75,11 +80,17 @@ mod apple {
                 ));
             }
             for i in 0..count {
-                let len = hdrs[i].msg_datalen;
-                // SAFETY: For recvmsg_x(), the size of the data received is given by the field msg_datalen,
-                // and we have early returned already if we have received no packets from the kernel.
+                let hdr = &hdrs[i];
+                // For recvmsg_x(), the size of the data received is given by the field msg_datalen.
+                let len = hdr.msg_datalen;
+                let recv_buf = &mut recv_bufs[i];
+                let new_len = recv_buf.len() + len;
+                // SAFETY: the kernel wrote `len` bytes into the spare capacity
+                // advertised via the iovec, which was bounded by that spare
+                // capacity, so `new_len <= capacity()`.
                 unsafe {
-                    recv_bufs[i].set_len(len);
+                    recv_buf.set_len(new_len);
+                }
                 }
             }
 
@@ -91,7 +102,7 @@ mod apple {
 #[cfg(any(linux, android))]
 mod linux {
     use bytes::BytesMut;
-    use lightway_core::{MAX_IO_BATCH_SIZE, MAX_OUTSIDE_MTU};
+    use lightway_core::MAX_IO_BATCH_SIZE;
     use std::{io, mem};
 
     pub(crate) struct Recvmmsg;
@@ -110,11 +121,16 @@ mod linux {
             // SAFETY: zeroed mmsghdr is valid (null pointers + zero lengths).
             let mut hdrs = unsafe { mem::zeroed::<[libc::mmsghdr; MAX_IO_BATCH_SIZE]>() };
             for i in 0..msg_count {
-                iovecs[i].iov_base =
-                    recv_bufs[i].spare_capacity_mut().as_mut_ptr() as *mut libc::c_void;
-                iovecs[i].iov_len = MAX_OUTSIDE_MTU;
-                hdrs[i].msg_hdr.msg_iov = &mut iovecs[i];
-                hdrs[i].msg_hdr.msg_iovlen = 1;
+                // Advertise only the buffer's spare capacity to the kernel so
+                // it can never write past the allocation; oversized datagrams
+                // are truncated, matching the non-batch recv path.
+                let spare = recv_bufs[i].spare_capacity_mut();
+                let iovec = &mut iovecs[i];
+                let hdr = &mut hdrs[i];
+                iovec.iov_base = spare.as_mut_ptr() as *mut libc::c_void;
+                iovec.iov_len = spare.len();
+                hdr.msg_hdr.msg_iov = iovec;
+                hdr.msg_hdr.msg_iovlen = 1;
             }
 
             // SAFETY: hdrs and iovecs are valid for msg_count entries, fd is a valid and borrowed socket.
@@ -140,11 +156,17 @@ mod linux {
                 ));
             }
             for i in 0..count {
-                let len = hdrs[i].msg_len as usize;
-                // SAFETY: recvmmsg sets msg_len to the number of bytes received per message,
-                // and we have early returned already if we have received no packets from the kernel.
+                let hdr = &hdrs[i];
+                // recvmmsg sets msg_len to the number of bytes received per message.
+                let len = hdr.msg_len as usize;
+                let recv_buf = &mut recv_bufs[i];
+                let new_len = recv_buf.len() + len;
+                // SAFETY: the kernel wrote `len` bytes into the spare capacity
+                // advertised via the iovec, which was bounded by that spare
+                // capacity, so `new_len <= capacity()`.
                 unsafe {
-                    recv_bufs[i].set_len(len);
+                    recv_buf.set_len(new_len);
+                }
                 }
             }
 
@@ -190,6 +212,34 @@ mod tests {
         assert!(count >= 1);
         assert_eq!(&bufs[0][..], b"hello");
     }
+
+    #[tokio::test]
+    async fn recv_multiple_truncates_datagram_larger_than_buffer_capacity() {
+        let (sender, receiver) = make_socket_pair().await;
+
+        // A datagram larger than the buffer's capacity (e.g. a configured
+        // outside_mtu smaller than the received packet) must be truncated by
+        // the kernel rather than written past the allocation
+        const SMALL_CAPACITY: usize = 16;
+        let payload = [0xa5u8; SMALL_CAPACITY * 4];
+        sender.send(&payload).await.unwrap();
+
+        let mut bufs: [BytesMut; MAX_IO_BATCH_SIZE] =
+            std::array::from_fn(|_| BytesMut::with_capacity(SMALL_CAPACITY));
+        let capacity = bufs[0].capacity();
+
+        tokio::time::timeout(Duration::from_secs(2), receiver.readable())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let fd = std::os::fd::AsRawFd::as_raw_fd(&receiver);
+        let count = PlatformBatchRecv::recv_multiple(fd, &mut bufs, MAX_IO_BATCH_SIZE).unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(bufs[0].len(), capacity);
+        assert_eq!(&bufs[0][..], &payload[..capacity]);
+    }
+
 
     #[tokio::test]
     async fn recv_multiple_multiple_packets() {

--- a/lightway-client/src/io/outside/udp/batch_receive.rs
+++ b/lightway-client/src/io/outside/udp/batch_receive.rs
@@ -79,6 +79,11 @@ mod apple {
                     "recvmsg_x returned more packets than requested",
                 ));
             }
+            // Note: current XNU does not set MSG_TRUNC in the per-message
+            // msg_flags of recvmsg_x (only MSG_CTRUNC is reported there), so
+            // this count stays zero on Apple platforms today. The check is
+            // kept in case the kernel gains support.
+            let mut truncated = 0usize;
             for i in 0..count {
                 let hdr = &hdrs[i];
                 // For recvmsg_x(), the size of the data received is given by the field msg_datalen.
@@ -91,7 +96,15 @@ mod apple {
                 unsafe {
                     recv_buf.set_len(new_len);
                 }
+                if hdr.msg_flags & libc::MSG_TRUNC != 0 {
+                    truncated += 1;
                 }
+            }
+            if truncated > 0 {
+                tracing::warn!(
+                    "{truncated} datagram(s) truncated to receive buffer capacity; \
+                     the configured outside_mtu may be too small"
+                );
             }
 
             Ok(count)
@@ -155,6 +168,7 @@ mod linux {
                     "recvmmsg returned more packets than requested",
                 ));
             }
+            let mut truncated = 0usize;
             for i in 0..count {
                 let hdr = &hdrs[i];
                 // recvmmsg sets msg_len to the number of bytes received per message.
@@ -167,7 +181,15 @@ mod linux {
                 unsafe {
                     recv_buf.set_len(new_len);
                 }
+                if hdr.msg_hdr.msg_flags & libc::MSG_TRUNC != 0 {
+                    truncated += 1;
                 }
+            }
+            if truncated > 0 {
+                tracing::warn!(
+                    "{truncated} datagram(s) truncated to receive buffer capacity; \
+                     the configured outside_mtu may be too small"
+                );
             }
 
             Ok(count)
@@ -240,6 +262,65 @@ mod tests {
         assert_eq!(&bufs[0][..], &payload[..capacity]);
     }
 
+    /// Linux/Android only: current XNU never copies MSG_TRUNC into
+    /// recvmsg_x's per-message msg_flags, so the warning cannot fire on
+    /// Apple platforms.
+    #[cfg(any(linux, android))]
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn recv_multiple_warns_when_datagrams_are_truncated() {
+        let (sender, receiver) = make_socket_pair().await;
+
+        const SMALL_CAPACITY: usize = 16;
+        let mut bufs: [BytesMut; MAX_IO_BATCH_SIZE] =
+            std::array::from_fn(|_| BytesMut::with_capacity(SMALL_CAPACITY));
+        let capacity = bufs[0].capacity();
+
+        let fd = std::os::fd::AsRawFd::as_raw_fd(&receiver);
+
+        // A datagram that fits must not produce a truncation warning.
+        sender.send(&vec![0u8; capacity / 2]).await.unwrap();
+        tokio::time::timeout(Duration::from_secs(2), receiver.readable())
+            .await
+            .unwrap()
+            .unwrap();
+        let count = PlatformBatchRecv::recv_multiple(fd, &mut bufs, MAX_IO_BATCH_SIZE).unwrap();
+        assert_eq!(count, 1);
+        assert!(
+            !logs_contain("truncated"),
+            "no warning expected for a datagram that fits",
+        );
+
+        for buf in &mut bufs {
+            buf.clear();
+        }
+
+        // A datagram larger than the buffer capacity must produce a single
+        // truncation warning for the batch. Use a fresh socket pair: the raw
+        // recv above bypassed tokio, leaving the first receiver's readiness
+        // cached, so another readable().await on it would not actually wait
+        // for this datagram to arrive.
+        let (sender, receiver) = make_socket_pair().await;
+        let fd = std::os::fd::AsRawFd::as_raw_fd(&receiver);
+        sender.send(&vec![0xa5u8; capacity * 4]).await.unwrap();
+        tokio::time::timeout(Duration::from_secs(2), receiver.readable())
+            .await
+            .unwrap()
+            .unwrap();
+        let count = PlatformBatchRecv::recv_multiple(fd, &mut bufs, MAX_IO_BATCH_SIZE).unwrap();
+        assert_eq!(count, 1);
+        logs_assert(|lines: &[&str]| {
+            match lines
+                .iter()
+                .inspect(|f| eprintln!("{}", f))
+                .filter(|line| line.contains("WARN") && line.contains("truncated"))
+                .count()
+            {
+                1 => Ok(()),
+                n => Err(format!("expected exactly one truncation warning, got {n}")),
+            }
+        });
+    }
 
     #[tokio::test]
     async fn recv_multiple_multiple_packets() {

--- a/lightway-server/src/io/outside/udp/batch_receive.rs
+++ b/lightway-server/src/io/outside/udp/batch_receive.rs
@@ -33,9 +33,11 @@ trait ServerBatchRecvSyscall {
 pub struct BatchRecvSlot<const CONTROL_SIZE: usize> {
     /// Data buffer for the packet payload.
     ///
-    /// Spare capacity must be at least [`lightway_core::MAX_OUTSIDE_MTU`]
-    /// before each batch call; the syscall sets the length to the number of
-    /// bytes actually received.
+    /// Spare capacity should be at least [`lightway_core::MAX_OUTSIDE_MTU`]
+    /// before each batch call. The syscall advertises at most the spare capacity
+    /// to the kernel, so an undersized buffer results in truncated datagrams
+    /// rather than an out-of-bounds write. The syscall sets the length to the
+    /// number of bytes actually received.
     pub buf: BytesMut,
     /// Control message buffer.
     ///
@@ -59,6 +61,10 @@ pub struct BatchRecvSlot<const CONTROL_SIZE: usize> {
     /// Out: `true` if the kernel set `MSG_TRUNC` in `msg_flags` for this
     /// packet, meaning the datagram was larger than the buffer we supplied and
     /// the tail was discarded. Callers should treat the payload as incomplete.
+    ///
+    /// Note: on Apple platforms this stays `false` — current XNU does not set
+    /// `MSG_TRUNC` in the per-message `msg_flags` of `recvmsg_x` (only
+    /// `MSG_CTRUNC` is reported there).
     pub truncated: bool,
 }
 
@@ -173,25 +179,30 @@ mod apple {
             // SAFETY: zeroed msghdr_x is valid (null pointers + zero lengths).
             let mut hdrs = unsafe { mem::zeroed::<[msghdr_x; MAX_IO_BATCH_SIZE]>() };
             for (i, slot) in slots.iter_mut().take(msg_count).enumerate() {
+                let spare = slot.buf.spare_capacity_mut();
                 debug_assert!(
-                    slot.buf.capacity() - slot.buf.len() >= MAX_OUTSIDE_MTU,
+                    spare.len() >= MAX_OUTSIDE_MTU,
                     "slot {i}: buf spare capacity ({}) < MAX_OUTSIDE_MTU ({MAX_OUTSIDE_MTU})",
-                    slot.buf.capacity() - slot.buf.len(),
+                    spare.len(),
                 );
 
-                iovecs[i].iov_base =
-                    slot.buf.spare_capacity_mut().as_mut_ptr() as *mut libc::c_void;
-                iovecs[i].iov_len = MAX_OUTSIDE_MTU;
-                hdrs[i].msg_iov = &mut iovecs[i];
-                hdrs[i].msg_iovlen = 1;
+                let iovec = &mut iovecs[i];
+                let hdr = &mut hdrs[i];
+                // Bound the iovec by the spare capacity actually available so
+                // the kernel can never write past the allocation, even if a
+                // caller violates the spare-capacity contract above.
+                iovec.iov_base = spare.as_mut_ptr() as *mut libc::c_void;
+                iovec.iov_len = spare.len().min(MAX_OUTSIDE_MTU);
+                hdr.msg_iov = iovec;
+                hdr.msg_iovlen = 1;
 
-                hdrs[i].msg_name = &mut slot.peer_addr_storage as *mut socket2::SockAddrStorage
+                hdr.msg_name = &mut slot.peer_addr_storage as *mut socket2::SockAddrStorage
                     as *mut libc::c_void;
-                hdrs[i].msg_namelen = slot.peer_addr_len;
+                hdr.msg_namelen = slot.peer_addr_len;
 
                 if let Some(control) = &mut slot.control {
-                    hdrs[i].msg_control = control.as_mut().as_mut_ptr() as *mut libc::c_void;
-                    hdrs[i].msg_controllen = control.capacity() as LibcControlLen;
+                    hdr.msg_control = control.as_mut().as_mut_ptr() as *mut libc::c_void;
+                    hdr.msg_controllen = control.capacity() as LibcControlLen;
                 }
             }
 
@@ -211,16 +222,23 @@ mod apple {
                 ));
             }
             for (slot, hdr) in slots.iter_mut().take(count).zip(hdrs) {
+                // For recvmsg_x(), the size of the data received is given by the field msg_datalen.
                 let len = hdr.msg_datalen;
-                // SAFETY: For recvmsg_x(), the size of the data received is given by the field msg_datalen,
-                // and we have early returned already if we have received no packets from the kernel.
+                let new_len = slot.buf.len() + len;
+                // SAFETY: the kernel wrote `len` bytes into the spare capacity
+                // advertised via the iovec, which was bounded by that spare
+                // capacity, so `new_len <= capacity()`.
                 unsafe {
-                    slot.buf.set_len(len);
+                    slot.buf.set_len(new_len);
                 }
                 slot.peer_addr_len = hdr.msg_namelen;
                 if slot.control.is_some() {
                     slot.control_length = Some(hdr.msg_controllen);
                 }
+                // Note: current XNU does not set MSG_TRUNC in the per-message
+                // msg_flags of recvmsg_x (only MSG_CTRUNC is reported there),
+                // so this stays false today. The check is kept in case the
+                // kernel gains support.
                 slot.truncated = hdr.msg_flags & libc::MSG_TRUNC != 0;
             }
 
@@ -251,21 +269,30 @@ mod linux {
             // SAFETY: zeroed hdrs are valid (null pointers + zero lengths).
             let mut hdrs = unsafe { mem::zeroed::<[libc::mmsghdr; MAX_IO_BATCH_SIZE]>() };
             for (i, slot) in slots.iter_mut().take(msg_count).enumerate() {
-                iovecs[i].iov_base =
-                    slot.buf.spare_capacity_mut().as_mut_ptr() as *mut libc::c_void;
-                iovecs[i].iov_len = MAX_OUTSIDE_MTU;
-                hdrs[i].msg_hdr.msg_iov = &mut iovecs[i];
-                hdrs[i].msg_hdr.msg_iovlen = 1;
+                let spare = slot.buf.spare_capacity_mut();
+                debug_assert!(
+                    spare.len() >= MAX_OUTSIDE_MTU,
+                    "slot {i}: buf spare capacity ({}) < MAX_OUTSIDE_MTU ({MAX_OUTSIDE_MTU})",
+                    spare.len(),
+                );
 
-                hdrs[i].msg_hdr.msg_name = &mut slot.peer_addr_storage
-                    as *mut socket2::SockAddrStorage
+                let iovec = &mut iovecs[i];
+                let hdr = &mut hdrs[i];
+                // Bound the iovec by the spare capacity actually available so
+                // the kernel can never write past the allocation, even if a
+                // caller violates the spare-capacity contract above.
+                iovec.iov_base = spare.as_mut_ptr() as *mut libc::c_void;
+                iovec.iov_len = spare.len().min(MAX_OUTSIDE_MTU);
+                hdr.msg_hdr.msg_iov = iovec;
+                hdr.msg_hdr.msg_iovlen = 1;
+
+                hdr.msg_hdr.msg_name = &mut slot.peer_addr_storage as *mut socket2::SockAddrStorage
                     as *mut libc::c_void;
-                hdrs[i].msg_hdr.msg_namelen = slot.peer_addr_len;
+                hdr.msg_hdr.msg_namelen = slot.peer_addr_len;
 
                 if let Some(control) = &mut slot.control {
-                    hdrs[i].msg_hdr.msg_control =
-                        control.as_mut().as_mut_ptr() as *mut libc::c_void;
-                    hdrs[i].msg_hdr.msg_controllen = control.capacity() as LibcControlLen;
+                    hdr.msg_hdr.msg_control = control.as_mut().as_mut_ptr() as *mut libc::c_void;
+                    hdr.msg_hdr.msg_controllen = control.capacity() as LibcControlLen;
                 }
             }
 
@@ -293,11 +320,14 @@ mod linux {
                 ));
             }
             for (slot, hdr) in slots.iter_mut().take(count).zip(hdrs) {
+                // recvmmsg sets msg_len to the number of bytes received per message.
                 let len = hdr.msg_len as usize;
-
-                // SAFETY: kernel wrote `len` bytes of payload into the spare capacity.
+                let new_len = slot.buf.len() + len;
+                // SAFETY: the kernel wrote `len` bytes into the spare capacity
+                // advertised via the iovec, which was bounded by that spare
+                // capacity, so `new_len <= capacity()`.
                 unsafe {
-                    slot.buf.set_len(len);
+                    slot.buf.set_len(new_len);
                 }
                 slot.peer_addr_len = hdr.msg_hdr.msg_namelen;
                 if slot.control.is_some() {
@@ -446,6 +476,48 @@ mod tests {
                 .unwrap();
         assert!(count >= 1);
         assert_eq!(&slots[0].buf[..], b"hello");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    #[cfg_attr(
+        miri,
+        ignore = "binds a real UDP socket, unsupported under miri isolation"
+    )]
+    async fn recv_multiple_with_metadata_truncates_oversized_datagram() {
+        let (sender, receiver) = make_socket_pair().await;
+
+        // A datagram larger than MAX_OUTSIDE_MTU must be truncated to the
+        // iovec we advertised and never written past the buffer's allocation.
+        // On Linux it is additionally reported via the truncated flag.
+        let payload = vec![0xa5u8; lightway_core::MAX_OUTSIDE_MTU + 500];
+        sender.send(&payload).await.unwrap();
+
+        let mut slots: [BatchRecvSlot<0>; MAX_IO_BATCH_SIZE] =
+            std::array::from_fn(|_| BatchRecvSlot::new());
+
+        tokio::time::timeout(Duration::from_secs(2), receiver.readable())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let fd = std::os::fd::AsRawFd::as_raw_fd(&receiver);
+        let count =
+            PlatformBatchRecv::recv_multiple_with_metadata(fd, &mut slots, MAX_IO_BATCH_SIZE)
+                .unwrap();
+        assert_eq!(count, 1);
+
+        let slot = &slots[0];
+        assert_eq!(slot.buf.len(), lightway_core::MAX_OUTSIDE_MTU);
+        assert_eq!(&slot.buf[..], &payload[..lightway_core::MAX_OUTSIDE_MTU]);
+        // recvmsg_x on Apple platforms does not report MSG_TRUNC in the
+        // per-message msg_flags, so the truncated flag can only be asserted
+        // where recvmmsg provides it.
+        #[cfg(linux)]
+        assert!(
+            slot.truncated,
+            "MSG_TRUNC must be reported for oversized datagrams",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The UDP batch receive paths (client and server) advertised a fixed `MAX_OUTSIDE_MTU` iovec length to the kernel regardless of the destination buffer's actual spare capacity. Each iovec is now bounded by the buffer's spare capacity, so undersized buffers result in kernel-side truncation —matching the non-batch receive path — rather than writes past the buffer.

- **client**: iovecs bounded by spare capacity (buffers are sized from the configured `outside_mtu`, which can be below `MAX_OUTSIDE_MTU`); logs one warning per batch when `recvmmsg` reports `MSG_TRUNC`.
- **server**: same bounding, capped at `MAX_OUTSIDE_MTU`, with a `debug_assert` documenting the spare-capacity contract.

Note: current XNU doesn't report per-message `MSG_TRUNC` via `recvmsg_x` (despite its header docs), so truncation isn't observable on Apple platforms; this is documented in code and the related test assertions are Linux-gated.

## Motivation and Context
The fixed iovec length didn't always reflect the real buffer size on the client. Bounding by spare capacity makes the batch path safer for any buffer size, and the warning makes MTU misconfiguration diagnosable instead of silent packet loss.

## How Has This Been Tested?
New unit tests: truncation of oversized datagrams on client and server, and the client truncation warning (via `tracing-test`, Linux/Android only)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
