### PR TITLE
[CVPN-2539] remove IP addresses on TUN interface drop

### DIFF
--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -251,6 +251,9 @@ impl TunConfig {
                         // Windows if destination provided create a default route with
                         // high priority
                         if cfg!(windows) {
+                            // remove address before adding it to prevent error
+                            // when address is already present
+                            let _ = device.remove_address(address);
                             device.add_address_v4(ipv4_addr, netmask)?;
                         } else {
                             device.set_network_address(ipv4_addr, netmask, self.destination)?;
@@ -587,6 +590,16 @@ impl Drop for TunDirect {
         if !self.close_fd_on_drop {
             let tun = self.tun.take().unwrap();
             let _ = tun.into_raw_fd();
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for TunDirect {
+    fn drop(&mut self) {
+        let tun = self.tun.as_ref().unwrap();
+        for address in tun.addresses().unwrap() {
+            let _ = tun.remove_address(address);
         }
     }
 }


### PR DESCRIPTION
## Description
Tun-rs tries to open existing TUN interface with specified name if it already exists. But when adding IP address to it an error may occur if that address is already assigned to the interface. To allow lightway to re-use existing TUN interface remove all addresses on close, so when restarted lightway can assign them successfully again.
The error only occurs on windows.

## Motivation and Context
We want to be able to control TUN interface life cycle outside of lightway.

## How Has This Been Tested?
Created WinTUN interface in external program and started lightway to verify interface is used and usable.
Tested repeated use of the same interface by new lightway instances.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
