### PR TITLE
CVPN-2505: Ignore tunnel's own address in Windows network-change monitor

### DIFF
--- a/lightway-app-utils/Cargo.toml
+++ b/lightway-app-utils/Cargo.toml
@@ -52,6 +52,7 @@ windows-sys = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_NetworkManagement",
     "Win32_NetworkManagement_IpHelper",
+    "Win32_NetworkManagement_Ndis",
     "Win32_Networking_WinSock",
     "Win32_System_IO",
     "Win32_System_Threading",

--- a/lightway-app-utils/src/network_change_monitor.rs
+++ b/lightway-app-utils/src/network_change_monitor.rs
@@ -25,10 +25,18 @@ pub struct NetworkChangeMonitor {
 impl NetworkChangeMonitor {
     /// Spawn the monitor. The route/address listeners are created inside the
     /// spawned task.
-    pub fn spawn() -> Result<Self> {
+    ///
+    /// `ignore_ips` lists local addresses (the tunnel's own address) that must
+    /// not be treated as network changes. On Windows the address listener uses
+    /// it to filter out the client's own TUN interface coming up; on other
+    /// platforms it is unused.
+    pub fn spawn(ignore_ips: Vec<std::net::IpAddr>) -> Result<Self> {
         let (tx, rx) = watch::channel(());
 
         let task = tokio::spawn(async move {
+            #[cfg(not(windows))]
+            let _ = ignore_ips;
+
             let mut route_listener = match AsyncRouteListener::new() {
                 Ok(listener) => listener,
                 Err(e) => {
@@ -40,7 +48,7 @@ impl NetworkChangeMonitor {
             // On Windows, also create address change listener as a fallback
             // since Windows doesn't always publish route changes on network down
             #[cfg(windows)]
-            let mut addr_listener = match AsyncAddrListener::new() {
+            let mut addr_listener = match AsyncAddrListener::new(ignore_ips) {
                 Ok(listener) => {
                     tracing::info!("Started address change monitoring (Windows)...");
                     Some(listener)
@@ -112,5 +120,82 @@ impl NetworkChangeMonitor {
 impl Drop for NetworkChangeMonitor {
     fn drop(&mut self) {
         self.task.abort();
+    }
+}
+
+/// Reduce the system's unicast addresses to those whose appearance or
+/// disappearance constitutes a real network change.
+///
+/// Loopback, link-local and unspecified addresses are configuration noise.
+/// `ignore` carries the local tunnel address(es) so the VPN's own interface
+/// coming up — which the Windows `NotifyAddrChange` API reports just like any
+/// other address change — is not mistaken for a path change. Comparing
+/// successive snapshots of this set lets the monitor signal only on genuine
+/// changes.
+#[cfg(any(windows, test))]
+pub(crate) fn relevant_addrs(
+    addrs: impl IntoIterator<Item = std::net::IpAddr>,
+    ignore: &[std::net::IpAddr],
+) -> std::collections::BTreeSet<std::net::IpAddr> {
+    addrs
+        .into_iter()
+        .filter(|ip| {
+            !ip.is_loopback() && !ip.is_unspecified() && !is_link_local(ip) && !ignore.contains(ip)
+        })
+        .collect()
+}
+
+#[cfg(any(windows, test))]
+fn is_link_local(ip: &std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => v4.is_link_local(),
+        // Ipv6Addr::is_unicast_link_local is unstable; match fe80::/10 directly.
+        std::net::IpAddr::V6(v6) => (v6.segments()[0] & 0xffc0) == 0xfe80,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+    use std::net::IpAddr;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn tunnel_bringup_is_not_a_network_change() {
+        let tun = ip("100.64.0.6");
+        let nic = ip("192.168.1.5");
+        // Before the tunnel comes up only the physical NIC is present; after
+        // bring-up the system also reports the tunnel's own address. With the
+        // tunnel address ignored, both snapshots must be identical so the
+        // monitor does not mistake its own interface for a path change.
+        let before = relevant_addrs([nic], &[tun]);
+        let after = relevant_addrs([nic, tun], &[tun]);
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn physical_address_change_is_detected() {
+        let tun = ip("100.64.0.6");
+        let wifi = ip("192.168.1.5");
+        let eth = ip("10.0.0.5");
+        let before = relevant_addrs([wifi, tun], &[tun]);
+        let after = relevant_addrs([eth, tun], &[tun]);
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn noise_addresses_are_filtered() {
+        let loopback = ip("127.0.0.1");
+        let link_local = ip("169.254.1.1");
+        let v6_link_local = ip("fe80::1");
+        let nic = ip("192.168.1.5");
+        assert_eq!(
+            relevant_addrs([loopback, link_local, v6_link_local, nic], &[]),
+            BTreeSet::from([nic])
+        );
     }
 }

--- a/lightway-app-utils/src/network_change_monitor/addr_monitor.rs
+++ b/lightway-app-utils/src/network_change_monitor/addr_monitor.rs
@@ -1,16 +1,70 @@
 #![allow(unsafe_code)]
 use anyhow::Result;
+use std::collections::BTreeSet;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::mpsc;
 use tracing::{debug, error};
 
+use super::relevant_addrs;
 use windows_sys::Win32::{
-    Foundation::{HANDLE, INVALID_HANDLE_VALUE, WAIT_OBJECT_0, WAIT_TIMEOUT},
-    NetworkManagement::IpHelper::NotifyAddrChange,
+    Foundation::{HANDLE, INVALID_HANDLE_VALUE, NO_ERROR, WAIT_OBJECT_0, WAIT_TIMEOUT},
+    NetworkManagement::IpHelper::{
+        FreeMibTable, GetUnicastIpAddressTable, MIB_UNICASTIPADDRESS_ROW,
+        MIB_UNICASTIPADDRESS_TABLE, NotifyAddrChange,
+    },
+    Networking::WinSock::{AF_INET, AF_INET6, AF_UNSPEC},
     System::IO::OVERLAPPED,
     System::Threading::{CreateEventW, ResetEvent, WaitForSingleObject},
 };
+
+/// Read the current system-wide unicast IP addresses via `GetUnicastIpAddressTable`.
+///
+/// Returns an empty vector on failure; callers treat that as "no relevant
+/// addresses", which is safe because a genuine change will still differ from
+/// the previous non-empty snapshot.
+fn current_unicast_addrs() -> Vec<IpAddr> {
+    let mut table: *mut MIB_UNICASTIPADDRESS_TABLE = std::ptr::null_mut();
+    // SAFETY: GetUnicastIpAddressTable allocates the table and writes the
+    // pointer through `table`; we free it with FreeMibTable below.
+    let ret = unsafe { GetUnicastIpAddressTable(AF_UNSPEC, &mut table) };
+    if ret != NO_ERROR || table.is_null() {
+        return Vec::new();
+    }
+
+    // SAFETY: `table` is non-null and stays valid until the matching FreeMibTable.
+    let count = unsafe { (*table).NumEntries } as usize;
+    // SAFETY: `Table` is the flexible-array member of the valid `table`; form a
+    // pointer to its first row without creating an intermediate reference.
+    let first = unsafe { std::ptr::addr_of!((*table).Table) } as *const MIB_UNICASTIPADDRESS_ROW;
+    // SAFETY: `first` points to `count` contiguous, initialised rows owned by the
+    // live table.
+    let rows = unsafe { std::slice::from_raw_parts(first, count) };
+
+    let mut out = Vec::new();
+    for row in rows {
+        // SAFETY: `si_family` is valid to read for any SOCKADDR_INET.
+        let family = unsafe { row.Address.si_family };
+        if family == AF_INET {
+            // SAFETY: family == AF_INET, so the Ipv4 variant is active.
+            let v4 = unsafe { row.Address.Ipv4 };
+            // SAFETY: S_addr is the active union member; it is in network byte
+            // order, so its in-memory bytes are the address octets.
+            let octets = unsafe { v4.sin_addr.S_un.S_addr }.to_ne_bytes();
+            out.push(IpAddr::V4(Ipv4Addr::from(octets)));
+        } else if family == AF_INET6 {
+            // SAFETY: family == AF_INET6, so the Ipv6 variant is active.
+            let v6 = unsafe { row.Address.Ipv6 };
+            // SAFETY: the unioned in6-addr bytes are always valid to read.
+            let bytes = unsafe { v6.sin6_addr.u.Byte };
+            out.push(IpAddr::V6(Ipv6Addr::from(bytes)));
+        }
+    }
+    // SAFETY: `table` was allocated by GetUnicastIpAddressTable and is freed once.
+    unsafe { FreeMibTable(table as *const core::ffi::c_void) };
+    out
+}
 
 /// Represents an address change detected by the monitor.
 ///
@@ -30,14 +84,17 @@ pub struct AsyncAddrListener {
 }
 
 impl AsyncAddrListener {
-    /// Creates a new AsyncAddrListener for monitoring address changes
-    pub fn new() -> Result<Self> {
+    /// Creates a new AsyncAddrListener for monitoring address changes.
+    ///
+    /// `ignore` lists local addresses (the tunnel's own address) whose
+    /// appearance/disappearance must not be reported as a network change.
+    pub fn new(ignore: Vec<IpAddr>) -> Result<Self> {
         let (sender, receiver) = mpsc::unbounded_channel();
         let shutdown = Arc::new(AtomicBool::new(false));
         let shutdown_clone = shutdown.clone();
 
         let join_handle = tokio::task::spawn_blocking(move || {
-            if let Err(e) = Self::monitor_address_changes(sender, shutdown_clone) {
+            if let Err(e) = Self::monitor_address_changes(sender, shutdown_clone, ignore) {
                 error!("Address monitoring task failed: {}", e);
             }
         });
@@ -53,6 +110,7 @@ impl AsyncAddrListener {
     fn monitor_address_changes(
         sender: mpsc::UnboundedSender<AddrChangeEvent>,
         shutdown: Arc<AtomicBool>,
+        ignore: Vec<IpAddr>,
     ) -> Result<()> {
         // RAII wrapper for Windows event handle
         struct EventHandle(HANDLE);
@@ -93,6 +151,12 @@ impl AsyncAddrListener {
         // Create event handle once for the entire monitoring session
         let event_handle = EventHandle::new()?;
 
+        // Baseline snapshot of the relevant (non-tunnel, non-noise) addresses.
+        // `NotifyAddrChange` reports any address change without detail — including
+        // the client's own TUN interface coming up — so we only signal when this
+        // filtered set actually changes between notifications.
+        let mut prev: BTreeSet<IpAddr> = relevant_addrs(current_unicast_addrs(), &ignore);
+
         loop {
             // Check if we should shutdown
             if shutdown.load(Ordering::Relaxed) {
@@ -105,6 +169,15 @@ impl AsyncAddrListener {
 
             match monitoring_result {
                 Ok(()) => {
+                    let now = relevant_addrs(current_unicast_addrs(), &ignore);
+                    if now == prev {
+                        // Change was confined to ignored/tunnel addresses or
+                        // noise — not a real path change, so don't signal.
+                        debug!("Address change ignored (no relevant address delta)");
+                        continue;
+                    }
+                    prev = now;
+
                     tracing::info!("Address change detected!");
                     // Send notification - we use a general event since Windows API
                     // doesn't provide specific details about the type of change
@@ -245,7 +318,7 @@ mod tests {
     #[tokio::test]
     async fn test_addr_listener_creation() {
         // Test that we can create the listener without panic
-        let result = AsyncAddrListener::new();
+        let result = AsyncAddrListener::new(vec![]);
         assert!(result.is_ok());
     }
 }

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -1372,7 +1372,7 @@ pub async fn client<
         let rx = if let Some(ref rx) = config.network_change_signal {
             rx.clone()
         } else {
-            let monitor = NetworkChangeMonitor::spawn()?;
+            let monitor = NetworkChangeMonitor::spawn(vec![config.tun_local_ip.into()])?;
             let rx = monitor.subscribe();
             network_change_monitor = Some(monitor);
             rx


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ignore tunnel IP when detecting network change.

Take the tunnel address(es) in NetworkChangeMonitor::spawn and, on Windows, snapshot the system's relevant unicast addresses (excluding loopback, link-local and the tunnel itself) on each notification, signalling only when that filtered set actually changes. This mirrors the prefix==0 default-route filter already applied to route changes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Windows NotifyAddrChange fallback fired on any address change, including the client's own TUN interface address being assigned during tunnel bring-up. Consumers that feed the signal into the client tear down Stream (TCP) connections on a network change, so on Windows every TCP connect was followed ~2s later by a spurious reconnect before any traffic flowed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified network change sent correctly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
