### PR TITLE
server: give recv_gso a default Unsupported impl

### DIFF
--- a/lightway-server/src/io/inside.rs
+++ b/lightway-server/src/io/inside.rs
@@ -15,6 +15,10 @@ pub trait InsideIORecv: Sync + Send {
 
     /// Receive a GSO superpacket into `buf`.
     ///
+    /// The default implementation returns `Unsupported`, for inside
+    /// IO backends that don't provide GSO reads. Backends that do
+    /// must uphold the contract below.
+    ///
     /// Implementations write into `buf.spare_capacity_mut()` so the
     /// caller can reuse one allocation across iterations with no
     /// zero-init cost. On `Ok((n, hdr))`, the virtio header has been
@@ -28,7 +32,12 @@ pub trait InsideIORecv: Sync + Send {
     /// itself fails to decode (each cause is logged + metered
     /// inside the impl). Returns `Err` on IO errors.
     #[cfg(target_os = "linux")]
-    async fn recv_gso(&self, buf: &mut bytes::BytesMut) -> IOCallbackResult<(usize, VirtioNetHdr)>;
+    async fn recv_gso(
+        &self,
+        _buf: &mut bytes::BytesMut,
+    ) -> IOCallbackResult<(usize, VirtioNetHdr)> {
+        IOCallbackResult::Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+    }
 
     fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState>;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make InsideIORecv::recv_gso a provided method that returns Unsupported instead of a required one. Inside IO backends that don't offer GSO reads (e.g. alternate/external ones) no longer have to implement it, while Tun keeps its real implementation. Update the doc comment to describe the default and frame the contract as what GSO-capable backends must uphold.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Make recv_gso() fail by default if we don't implement it

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
NA

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
