### PR TITLE
CVPN-2623: batch inside IO and flush UDP sends with sendmmsg

### DIFF
--- a/docs/logs_and_metrics.md
+++ b/docs/logs_and_metrics.md
@@ -69,6 +69,11 @@ Lightway server also supports metrics to monitor. The following are the metrics 
 | tun_rejected_packet_no_connection | server | Counter | Counts packets received on the TUN device for which there is no corresponding connection |
 | tun_from_client | server | Counter | Counts bytes sent on the TUN interface (i.e. which is data coming from a client) |
 | tun_to_client | server | Counter | Counts bytes received on the TUN interface (i.e which is data going to a client) |
+| tun_recv_batch_size | server | Histogram | Number of packets returned by one batched inside-IO receive. Only recorded when `--enable-batch-send` is active |
+| udp_send_batch_size | server | Histogram | Number of datagrams flushed by one send-batch window. Windows that queued nothing are not recorded. Only recorded when `--enable-batch-send` is active |
+| udp_send_batch_blocked | server | Counter | Counts batched flushes that found the socket send buffer full and waited for writability before continuing |
+| udp_send_batch_dropped | server | Counter | Counts datagrams dropped because a batched flush could not send them |
+| udp_send_batch_missed_flush | server | Counter | Counts send-batch windows that were closed by the guard's drop fallback instead of an explicit flush.<br><br>Should generally be expected to be 0 |
 | sessions_current_online | server | Gauge | The number of connections which are currently in the Online state |
 | sessions_lifetime_total | server | Gauge | The total number of connections which have been created over the entire lifetime of the server |
 | sessions_pending_id_rotations | server | Gauge | The number of connections for which a session ID rotation is in progress |

--- a/lightway-app-utils/src/iouring.rs
+++ b/lightway-app-utils/src/iouring.rs
@@ -104,9 +104,13 @@ impl<T: AsRawFd> IOUring<T> {
     /// to `out`. Waits only when the rx queue is empty; when packets
     /// are already queued it returns what is immediately available.
     pub async fn recv_many(&self, out: &mut Vec<BytesMut>, max: usize) -> IOUringResult<usize> {
+        if max == 0 {
+            return Ok(0);
+        }
         let n = self.rx_queue.lock().await.recv_many(out, max).await;
         if n == 0 {
-            // recv_many returns 0 only when the channel is closed.
+            // With max > 0, recv_many returns 0 only when the channel
+            // is closed.
             return Err(IOUringError::RecvError);
         }
         Ok(n)

--- a/lightway-app-utils/src/iouring.rs
+++ b/lightway-app-utils/src/iouring.rs
@@ -100,6 +100,18 @@ impl<T: AsRawFd> IOUring<T> {
             .ok_or(IOUringError::RecvError)
     }
 
+    /// Receive up to `max` packets from the Tun device, appending them
+    /// to `out`. Waits only when the rx queue is empty; when packets
+    /// are already queued it returns what is immediately available.
+    pub async fn recv_many(&self, out: &mut Vec<BytesMut>, max: usize) -> IOUringResult<usize> {
+        let n = self.rx_queue.lock().await.recv_many(out, max).await;
+        if n == 0 {
+            // recv_many returns 0 only when the channel is closed.
+            return Err(IOUringError::RecvError);
+        }
+        Ok(n)
+    }
+
     /// Try Send packet to Tun device
     pub fn try_send(&self, buf: BytesMut) -> IOCallbackResult<usize> {
         let buf_len = buf.len();

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -319,6 +319,24 @@ impl Tun {
         }
     }
 
+    /// Recv up to `max` packets from Tun, appending to `pkts` (each
+    /// buffer sized to the interface MTU by the backend). Waits only
+    /// when nothing is immediately available. Only the io_uring backend
+    /// returns more than one packet per call; the direct backend reads
+    /// a single packet.
+    #[cfg_attr(not(feature = "io-uring"), allow(unused_variables))]
+    pub async fn recv_buf_many(
+        &self,
+        pkts: &mut Vec<BytesMut>,
+        max: usize,
+    ) -> IOCallbackResult<usize> {
+        match self {
+            Tun::Direct(t) => t.recv_buf_many(pkts).await,
+            #[cfg(feature = "io-uring")]
+            Tun::IoUring(t) => t.recv_buf_many(pkts, max).await,
+        }
+    }
+
     /// Recv a GSO frame from `Tun` into `buf`, stripping and decoding the
     /// leading `virtio_net_hdr`.
     ///
@@ -453,6 +471,24 @@ impl TunDirect {
                 IOCallbackResult::WouldBlock
             }
             Err(err) => IOCallbackResult::Err(err),
+        }
+    }
+
+    /// Recv one packet from Tun, appending it to `pkts` as a buffer
+    /// sized to the interface MTU. The direct backend has no batched
+    /// read, so this is the single-packet counterpart of the io_uring
+    /// backend's `recv_buf_many`.
+    pub async fn recv_buf_many(&self, pkts: &mut Vec<BytesMut>) -> IOCallbackResult<usize> {
+        let mtu = self.mtu();
+        let mut buf = BytesMut::with_capacity(mtu);
+        buf.resize(mtu, 0);
+        match self.recv_buf(&mut buf).await {
+            IOCallbackResult::Ok(_n) => {
+                pkts.push(buf);
+                IOCallbackResult::Ok(1)
+            }
+            IOCallbackResult::WouldBlock => IOCallbackResult::WouldBlock,
+            IOCallbackResult::Err(e) => IOCallbackResult::Err(e),
         }
     }
 
@@ -652,6 +688,18 @@ impl TunIoUring {
                 *buf = pkt;
                 IOCallbackResult::Ok(len)
             }
+            Err(e) => IOCallbackResult::Err(std::io::Error::other(e)),
+        }
+    }
+
+    /// Recv up to `max` packets from Tun via the io_uring rx queue.
+    pub async fn recv_buf_many(
+        &self,
+        pkts: &mut Vec<BytesMut>,
+        max: usize,
+    ) -> IOCallbackResult<usize> {
+        match self.tun_io_uring.recv_many(pkts, max).await {
+            Ok(n) => IOCallbackResult::Ok(n),
             Err(e) => IOCallbackResult::Err(std::io::Error::other(e)),
         }
     }

--- a/lightway-server/src/config.rs
+++ b/lightway-server/src/config.rs
@@ -156,6 +156,14 @@ pub struct Config {
     #[patch(attribute(doc = "Enable batch receive (`recvmsg_x` on macOS, `recvmmsg` on Linux)"))]
     pub enable_batch_receive: bool,
 
+    #[patch(attribute(clap(long)))]
+    #[patch(empty_value = false)]
+    #[patch(attribute(serde(default)))]
+    #[patch(attribute(
+        doc = "Batch inside-path receives and flush the resulting UDP sends with one syscall per batch (UDP servers only; no-op on TCP)"
+    ))]
+    pub enable_batch_send: bool,
+
     #[cfg(feature = "debug")]
     #[patch(attribute(clap(long)))]
     #[patch(empty_value = false)]
@@ -218,6 +226,7 @@ impl Default for Config {
             proxy_protocol: false,
             udp_buffer_size: ByteSize::mib(15),
             enable_batch_receive: false,
+            enable_batch_send: false,
             #[cfg(feature = "debug")]
             tls_debug: false,
             #[cfg(feature = "debug")]

--- a/lightway-server/src/config.rs
+++ b/lightway-server/src/config.rs
@@ -249,6 +249,13 @@ impl Config {
             )
         }
 
+        if self.enable_batch_send {
+            anyhow::ensure!(
+                !self.enable_tun_offload,
+                "Batch send cannot be used with tun offload"
+            )
+        }
+
         Ok(())
     }
 }
@@ -279,5 +286,20 @@ mod tests {
         config.mode = ConnectionType::Udp;
         config.proxy_protocol = true;
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_batch_send_with_tun_offload() {
+        let mut config = Config::default();
+        config.enable_batch_send = true;
+        config.enable_tun_offload = true;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_batch_send_alone() {
+        let mut config = Config::default();
+        config.enable_batch_send = true;
+        assert!(config.validate().is_ok());
     }
 }

--- a/lightway-server/src/io/inside.rs
+++ b/lightway-server/src/io/inside.rs
@@ -13,6 +13,12 @@ use std::sync::Arc;
 pub trait InsideIORecv: Sync + Send {
     async fn recv_buf(&self, buf: &mut bytes::BytesMut) -> IOCallbackResult<usize>;
 
+    /// Upgrade to the batch-receive interface, when this instance can
+    /// pop multiple packets per call. Default: not supported.
+    fn as_batch(self: Arc<Self>) -> Option<Arc<dyn InsideIORecvBatch>> {
+        None
+    }
+
     /// Upgrade to the GSO-capable interface, when this instance supports
     /// GSO reads. Default: not supported. Capability is per-instance —
     /// a TUN opened without offload returns `None`.
@@ -26,6 +32,29 @@ pub trait InsideIORecv: Sync + Send {
 
 /// Trait for InsideIO
 pub trait InsideIO: InsideIORecv + InsideIOSendCallback<ConnectionState> {}
+
+/// Inside IO backends that can pop multiple packets per call. Obtained
+/// from [`InsideIORecv::as_batch`]; the batched inside loop only accepts
+/// this type, so the capability check happens once at startup.
+///
+/// Implementers must also override [`InsideIORecv::as_batch`] to return
+/// `Some(self)` — the default `None` hides the capability.
+#[async_trait]
+pub trait InsideIORecvBatch: InsideIORecv {
+    /// Receive up to `max` packets, appending each to `pkts` as its own
+    /// `BytesMut`, sized by the implementation (the backend knows its
+    /// own MTU). Returns the number of packets appended (>= 1), or
+    /// `WouldBlock`/`Err`.
+    ///
+    /// Implementations must only wait when no packet is immediately
+    /// available; when packets are already queued they return whatever
+    /// is ready without waiting, so batching adds no latency.
+    async fn recv_buf_many(
+        &self,
+        pkts: &mut Vec<bytes::BytesMut>,
+        max: usize,
+    ) -> IOCallbackResult<usize>;
+}
 
 /// Inside IO backends that can receive GSO superpackets. Obtained from
 /// [`InsideIORecv::as_gso`]; the GSO inside loop only accepts this type,
@@ -53,8 +82,80 @@ pub trait InsideIORecvGso: InsideIORecv {
     async fn recv_gso(&self, buf: &mut bytes::BytesMut) -> IOCallbackResult<(usize, VirtioNetHdr)>;
 }
 
+#[cfg(test)]
+mod batch_capability_tests {
+    use super::*;
+    use bytes::BytesMut;
+
+    /// Backend without the batch capability: only the base trait.
+    struct NoBatch;
+
+    #[async_trait]
+    impl InsideIORecv for NoBatch {
+        async fn recv_buf(&self, _buf: &mut BytesMut) -> IOCallbackResult<usize> {
+            unimplemented!("not needed for capability tests")
+        }
+
+        fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState> {
+            unimplemented!("not needed for capability tests")
+        }
+    }
+
+    /// Backend with the batch capability: overrides the upgrade.
+    struct WithBatch;
+
+    #[async_trait]
+    impl InsideIORecv for WithBatch {
+        async fn recv_buf(&self, _buf: &mut BytesMut) -> IOCallbackResult<usize> {
+            unimplemented!("not needed for capability tests")
+        }
+
+        fn as_batch(self: Arc<Self>) -> Option<Arc<dyn InsideIORecvBatch>> {
+            Some(self)
+        }
+
+        fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState> {
+            unimplemented!("not needed for capability tests")
+        }
+    }
+
+    #[async_trait]
+    impl InsideIORecvBatch for WithBatch {
+        async fn recv_buf_many(
+            &self,
+            pkts: &mut Vec<BytesMut>,
+            _max: usize,
+        ) -> IOCallbackResult<usize> {
+            pkts.push(BytesMut::from(&[0xAB][..]));
+            IOCallbackResult::Ok(1)
+        }
+    }
+
+    #[test]
+    fn default_as_batch_is_none() {
+        assert!(Arc::new(NoBatch).as_batch().is_none());
+    }
+
+    #[test]
+    fn as_batch_is_none_through_a_trait_object() {
+        let io: Arc<dyn InsideIORecv> = Arc::new(NoBatch);
+        assert!(io.as_batch().is_none());
+    }
+
+    #[tokio::test]
+    async fn upgraded_handle_dispatches_recv_buf_many() {
+        let io = Arc::new(WithBatch).as_batch().expect("override upgrades");
+        let mut pkts = Vec::new();
+        assert!(matches!(
+            io.recv_buf_many(&mut pkts, 32).await,
+            IOCallbackResult::Ok(1)
+        ));
+        assert_eq!(pkts.len(), 1);
+    }
+}
+
 #[cfg(all(test, linux))]
-mod tests {
+mod gso_capability_tests {
     use super::*;
     use bytes::BytesMut;
 

--- a/lightway-server/src/io/inside/tun.rs
+++ b/lightway-server/src/io/inside/tun.rs
@@ -2,7 +2,7 @@ use crate::connection::ConnectionState;
 #[cfg(linux)]
 use crate::io::inside::InsideIORecvGso;
 use crate::{
-    io::inside::{InsideIO, InsideIORecv},
+    io::inside::{InsideIO, InsideIORecv, InsideIORecvBatch},
     metrics,
 };
 use anyhow::Result;
@@ -56,6 +56,10 @@ impl InsideIORecv for Tun {
         }
     }
 
+    fn as_batch(self: Arc<Self>) -> Option<Arc<dyn InsideIORecvBatch>> {
+        Some(self)
+    }
+
     #[cfg(linux)]
     fn as_gso(self: Arc<Self>) -> Option<Arc<dyn InsideIORecvGso>> {
         if self.0.supports_gso() {
@@ -67,6 +71,23 @@ impl InsideIORecv for Tun {
 
     fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState> {
         self
+    }
+}
+
+#[async_trait]
+impl InsideIORecvBatch for Tun {
+    async fn recv_buf_many(&self, pkts: &mut Vec<BytesMut>, max: usize) -> IOCallbackResult<usize> {
+        // `pkts` may arrive non-empty; meter only what this call appended.
+        let start = pkts.len();
+        match self.0.recv_buf_many(pkts, max).await {
+            IOCallbackResult::Ok(n) => {
+                for pkt in &pkts[start..] {
+                    metrics::tun_to_client(pkt.len());
+                }
+                IOCallbackResult::Ok(n)
+            }
+            e => e,
+        }
     }
 }
 

--- a/lightway-server/src/io/outside/udp.rs
+++ b/lightway-server/src/io/outside/udp.rs
@@ -85,11 +85,14 @@ fn send_to_socket(
             }
         }
 
-        // If cmsg_len is 0, the kernel will never read cmsg.
-        let msghdr = MsgHdr::new()
-            .with_addr(peer_addr)
-            .with_buffers(bufs)
-            .with_control(&cmsg.as_ref()[..cmsg_len]);
+        // Only attach control data when present: macOS rejects a
+        // non-null msg_control paired with msg_controllen == 0.
+        let msghdr = MsgHdr::new().with_addr(peer_addr).with_buffers(bufs);
+        let msghdr = if cmsg_len > 0 {
+            msghdr.with_control(&cmsg.as_ref()[..cmsg_len])
+        } else {
+            msghdr
+        };
 
         sock.sendmsg(&msghdr, 0)
     });

--- a/lightway-server/src/io/outside/udp.rs
+++ b/lightway-server/src/io/outside/udp.rs
@@ -233,6 +233,12 @@ impl UdpServer {
         })
     }
 
+    /// Handle for the inside loop to open send-batch windows. `Some`
+    /// only when inside-IO batching was enabled at construction.
+    pub(crate) fn send_queue(&self) -> Option<Arc<SendQueue>> {
+        self.send_queue.clone()
+    }
+
     fn data_received(
         &mut self,
         peer_addr: SocketAddr,

--- a/lightway-server/src/io/outside/udp.rs
+++ b/lightway-server/src/io/outside/udp.rs
@@ -25,6 +25,7 @@ use tracing::{info, warn};
 
 use super::Server;
 use crate::io::outside::udp::batch_receive::{BatchRecvSlot, recv_multiple_with_metadata};
+use crate::io::outside::udp::send_queue::SendQueue;
 use crate::{connection_manager::ConnectionManager, metrics};
 
 enum BindMode {
@@ -110,11 +111,17 @@ struct UdpSocket {
     sock: Arc<tokio::net::UdpSocket>,
     peer_addr: RwLock<(SocketAddr, SockAddr)>,
     reply_pktinfo: Option<libc::in_pktinfo>,
+    send_queue: Option<Arc<SendQueue>>,
 }
 
 impl OutsideIOSendCallback for UdpSocket {
     fn send(&self, buf: &[u8]) -> IOCallbackResult<usize> {
         let peer_addr = self.peer_addr.read().unwrap();
+        if let Some(queue) = &self.send_queue
+            && queue.try_enqueue(peer_addr.1.clone(), self.reply_pktinfo, buf)
+        {
+            return IOCallbackResult::Ok(buf.len());
+        }
         send_to_socket(
             &self.sock,
             &[IoSlice::new(buf)],
@@ -152,6 +159,7 @@ pub(crate) struct UdpServer {
     sock: Arc<tokio::net::UdpSocket>,
     bind_mode: BindMode,
     batch_receive_enabled: bool,
+    send_queue: Option<Arc<SendQueue>>,
 }
 
 impl UdpServer {
@@ -160,6 +168,7 @@ impl UdpServer {
         bind_address: SocketAddr,
         udp_buffer_size: ByteSize,
         enable_batch_receive: bool,
+        enable_batch_send: bool,
         sock: Option<tokio::net::UdpSocket>,
     ) -> Result<UdpServer> {
         let sock = match sock {
@@ -177,6 +186,8 @@ impl UdpServer {
         // successfully in `OutsideIOSendCallback` callback
         sock.writable().await?;
         let sock = Arc::new(sock);
+
+        let send_queue = enable_batch_send.then(|| SendQueue::new(sock.clone()));
 
         let bind_mode = if bind_address.ip().is_unspecified() {
             BindMode::UnspecifiedAddress {
@@ -218,6 +229,7 @@ impl UdpServer {
             sock,
             bind_mode,
             batch_receive_enabled,
+            send_queue,
         })
     }
 
@@ -264,6 +276,7 @@ impl UdpServer {
                             sock: self.sock.clone(),
                             peer_addr: RwLock::new((peer_addr, peer_addr.into())),
                             reply_pktinfo,
+                            send_queue: self.send_queue.clone(),
                         })
                     },
                 );

--- a/lightway-server/src/io/outside/udp.rs
+++ b/lightway-server/src/io/outside/udp.rs
@@ -1,5 +1,6 @@
 mod batch_receive;
 mod cmsg;
+pub(crate) mod send_queue;
 
 use anyhow::Result;
 use async_trait::async_trait;

--- a/lightway-server/src/io/outside/udp/cmsg.rs
+++ b/lightway-server/src/io/outside/udp/cmsg.rs
@@ -170,6 +170,13 @@ impl<const N: usize> BufferMut<N> {
             _phantom: std::marker::PhantomData,
         }
     }
+
+    /// Mutable view of the raw buffer, for passing to `msg_control` in
+    /// syscalls that need a mutable pointer.
+    #[cfg(linux)]
+    pub(crate) fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
 }
 
 impl<const N: usize> AsRef<[u8]> for BufferMut<N> {

--- a/lightway-server/src/io/outside/udp/send_queue.rs
+++ b/lightway-server/src/io/outside/udp/send_queue.rs
@@ -436,4 +436,41 @@ mod tests {
 
         assert_eq!(recv_one(&receiver).await, b"with-pktinfo");
     }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    #[cfg_attr(
+        miri,
+        ignore = "binds a real UDP socket, unsupported under miri isolation"
+    )]
+    async fn udp_socket_send_queues_inside_window_and_sends_direct_outside() {
+        use super::super::UdpSocket;
+        use lightway_core::OutsideIOSendCallback;
+        use std::sync::RwLock;
+
+        let (sender, receiver, receiver_addr) = socket_pair().await;
+        let queue = SendQueue::new(sender.clone());
+
+        let cb = UdpSocket {
+            sock: sender,
+            peer_addr: RwLock::new((receiver_addr, receiver_addr.into())),
+            reply_pktinfo: None,
+            send_queue: Some(queue.clone()),
+        };
+
+        // Outside a window: direct send, arrives immediately.
+        cb.send(b"direct");
+        assert_eq!(recv_one(&receiver).await, b"direct");
+
+        // Inside a window: held until the guard flushes.
+        let guard = queue.begin_batch();
+        cb.send(b"queued");
+        let mut probe = vec![0u8; 64];
+        assert!(
+            receiver.try_recv(&mut probe).is_err(),
+            "datagram must be held in the queue until flush"
+        );
+        drop(guard);
+        assert_eq!(recv_one(&receiver).await, b"queued");
+    }
 }

--- a/lightway-server/src/io/outside/udp/send_queue.rs
+++ b/lightway-server/src/io/outside/udp/send_queue.rs
@@ -1,0 +1,439 @@
+//! Scoped batching of outgoing UDP datagrams.
+//!
+//! While a batch window ([`SendBatchGuard`]) is open, per-connection send
+//! callbacks enqueue datagrams here instead of issuing one `sendmsg` each.
+//! Dropping the guard flushes the queue — with `sendmmsg` on Linux, or a
+//! `sendmsg` loop on other platforms.
+
+use bytes::Bytes;
+use lightway_core::MAX_IO_BATCH_SIZE;
+use socket2::SockAddr;
+use std::sync::{Arc, Mutex};
+
+use crate::metrics;
+
+/// One queued datagram. Destination and pktinfo are captured at push time
+/// since they are per-connection state.
+struct QueuedDatagram {
+    peer: SockAddr,
+    pktinfo: Option<libc::in_pktinfo>,
+    data: Bytes,
+}
+
+/// Shared queue for batching outgoing datagrams on the server socket.
+///
+/// `None` means no batch window is open: senders take the direct
+/// `sendmsg` path. `Some` means a window is open: senders push and the
+/// guard flushes on drop. The mutex makes check-and-push atomic against
+/// take-and-flush so a datagram can never be stranded in a queue nobody
+/// will flush, even on a multi-threaded runtime.
+pub(crate) struct SendQueue {
+    sock: Arc<tokio::net::UdpSocket>,
+    queue: Mutex<Option<Vec<QueuedDatagram>>>,
+}
+
+impl SendQueue {
+    pub(crate) fn new(sock: Arc<tokio::net::UdpSocket>) -> Arc<Self> {
+        Arc::new(Self {
+            sock,
+            queue: Mutex::new(None),
+        })
+    }
+
+    /// Push a datagram if a batch window is open. Returns false if no
+    /// window is open — the caller must send directly.
+    pub(crate) fn try_enqueue(
+        &self,
+        peer: SockAddr,
+        pktinfo: Option<libc::in_pktinfo>,
+        data: &[u8],
+    ) -> bool {
+        let mut queue = self.queue.lock().unwrap();
+        match queue.as_mut() {
+            Some(q) => {
+                q.push(QueuedDatagram {
+                    peer,
+                    pktinfo,
+                    data: Bytes::copy_from_slice(data),
+                });
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Open a batch window. Sends arriving via [`Self::try_enqueue`] are
+    /// queued until the batch is flushed via [`SendBatchGuard::flush`]
+    /// (or the guard is dropped, which flushes best-effort).
+    ///
+    /// Only one window may be open at a time (there is a single inside-IO
+    /// loop); opening a second discards the first window's queue reference,
+    /// so callers must not nest.
+    pub(crate) fn begin_batch(self: &Arc<Self>) -> SendBatchGuard {
+        let mut queue = self.queue.lock().unwrap();
+        debug_assert!(queue.is_none(), "nested send batch windows");
+        *queue = Some(Vec::with_capacity(MAX_IO_BATCH_SIZE));
+        SendBatchGuard {
+            queue: Arc::clone(self),
+        }
+    }
+}
+
+/// Closes the batch window opened by [`SendQueue::begin_batch`].
+///
+/// The window contains no await points, so the guard is short-lived by
+/// construction. The batched loop consumes it with [`Self::flush`],
+/// which waits for socket writability instead of dropping when the
+/// send buffer fills; dropping the guard without flushing falls back
+/// to a synchronous best-effort flush so queued datagrams can never
+/// be stranded.
+pub(crate) struct SendBatchGuard {
+    queue: Arc<SendQueue>,
+}
+
+impl SendBatchGuard {
+    /// Close the window and send everything queued while it was open,
+    /// treating a full socket buffer as backpressure: wait until the
+    /// socket is writable again and continue where the previous
+    /// attempt stopped. Only hard IO errors drop the remainder. Sends
+    /// arriving while the flush is in progress take the direct path.
+    pub(crate) async fn flush(self) {
+        let msgs = self.queue.queue.lock().unwrap().take();
+        let Some(msgs) = msgs else { return };
+        // Windows that queued nothing are not recorded: zero-size
+        // samples would drag down the batch-size histogram that the
+        // batching A/B comparison reads.
+        if !msgs.is_empty() {
+            metrics::udp_send_batch_flush(msgs.len());
+            flush_retrying(&self.queue.sock, &msgs).await;
+        }
+    }
+}
+
+impl Drop for SendBatchGuard {
+    fn drop(&mut self) {
+        // Fallback for paths that exit without calling flush(), which
+        // takes the queue and leaves None here.
+        let msgs = self.queue.queue.lock().unwrap().take();
+        let Some(msgs) = msgs else { return };
+        if !msgs.is_empty() {
+            metrics::udp_send_batch_flush(msgs.len());
+            flush_best_effort(&self.queue.sock, &msgs);
+        }
+    }
+}
+
+/// Send all `msgs` with a single `sendmmsg`, carrying per-message
+/// destination and pktinfo control data. The kernel caps one call at
+/// `UIO_MAXIOV` (1024) messages and may accept fewer than requested;
+/// callers resume from the first unsent message. Returns the number
+/// of messages the kernel accepted.
+///
+/// The pointer-carrying arrays are rebuilt per call rather than kept
+/// across retries: `iovec`/`mmsghdr` are `!Send`, so holding them
+/// across an await point would make the flush future `!Send`.
+#[cfg(linux)]
+#[allow(unsafe_code)]
+fn sendmmsg_all(
+    sock: &Arc<tokio::net::UdpSocket>,
+    msgs: &[QueuedDatagram],
+) -> std::io::Result<usize> {
+    use std::os::fd::AsRawFd;
+
+    const CMSG_SIZE: usize = super::cmsg::Message::space::<libc::in_pktinfo>();
+
+    // Both vectors are filled to their final length before any element
+    // pointers are taken below, so those pointers stay valid.
+    let mut iovecs: Vec<libc::iovec> = msgs
+        .iter()
+        .map(|m| libc::iovec {
+            // The kernel only reads through this pointer on send.
+            iov_base: m.data.as_ptr() as *mut libc::c_void,
+            iov_len: m.data.len(),
+        })
+        .collect();
+    let mut cmsgs: Vec<super::cmsg::BufferMut<CMSG_SIZE>> =
+        std::iter::repeat_with(super::cmsg::BufferMut::zeroed)
+            .take(msgs.len())
+            .collect();
+
+    let mut hdrs: Vec<libc::mmsghdr> = Vec::with_capacity(msgs.len());
+    for (i, m) in msgs.iter().enumerate() {
+        // SAFETY: a zeroed mmsghdr is valid (null pointers + zero lengths).
+        let mut hdr = unsafe { std::mem::zeroed::<libc::mmsghdr>() };
+        hdr.msg_hdr.msg_iov = &mut iovecs[i];
+        hdr.msg_hdr.msg_iovlen = 1;
+        hdr.msg_hdr.msg_name = m.peer.as_ptr() as *mut libc::c_void;
+        hdr.msg_hdr.msg_namelen = m.peer.len();
+        if let Some(pi) = m.pktinfo {
+            let cmsg = &mut cmsgs[i];
+            // The buffer is sized for exactly one in_pktinfo, so this
+            // only fails if that invariant is broken; fall back to
+            // sending without pktinfo rather than dropping the packet.
+            if cmsg
+                .builder()
+                .fill_next(libc::SOL_IP, libc::IP_PKTINFO, pi)
+                .is_ok()
+            {
+                hdr.msg_hdr.msg_control = cmsg.as_mut_slice().as_mut_ptr() as *mut libc::c_void;
+                hdr.msg_hdr.msg_controllen = CMSG_SIZE as _;
+            }
+        }
+        hdrs.push(hdr);
+    }
+
+    // SAFETY: hdrs/iovecs/cmsgs and the queued datagrams they point
+    // into outlive the syscall; the kernel does not write through any
+    // of these pointers on send.
+    let n = unsafe {
+        libc::sendmmsg(
+            sock.as_ref().as_raw_fd(),
+            hdrs.as_mut_ptr(),
+            hdrs.len() as _,
+            0,
+        )
+    };
+    if n < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(n as usize)
+    }
+}
+
+/// Flush queued datagrams with as few `sendmmsg` syscalls as possible,
+/// waiting for the socket to become writable again whenever the send
+/// buffer fills (counted in `udp_send_batch_blocked`). A partial send
+/// continues from the first unsent message. A hard IO error drops only
+/// the datagram that caused it (counted in `udp_send_batch_dropped`);
+/// the rest of the queue is still flushed.
+#[cfg(linux)]
+async fn flush_retrying(sock: &Arc<tokio::net::UdpSocket>, msgs: &[QueuedDatagram]) {
+    use tokio::io::Interest;
+
+    let mut sent_total = 0usize;
+    while sent_total < msgs.len() {
+        let result = sock
+            .async_io(Interest::WRITABLE, || {
+                sendmmsg_all(sock, &msgs[sent_total..]).inspect_err(|err| {
+                    if matches!(err.kind(), std::io::ErrorKind::WouldBlock) {
+                        metrics::udp_send_batch_blocked();
+                    }
+                })
+            })
+            .await;
+        match result {
+            Ok(n) => sent_total += n,
+            Err(err) => {
+                // sendmmsg fails on the first message of the remainder,
+                // so skip that datagram alone and keep flushing.
+                tracing::warn!("sendmmsg flush failed: {err}");
+                metrics::udp_send_batch_dropped(1);
+                sent_total += 1;
+            }
+        }
+    }
+}
+
+/// Single-attempt variant used by the guard's `Drop` fallback: on
+/// `WouldBlock`, a hard error or a partial send the remainder is
+/// dropped and counted in `udp_send_batch_dropped`.
+#[cfg(linux)]
+fn flush_best_effort(sock: &Arc<tokio::net::UdpSocket>, msgs: &[QueuedDatagram]) {
+    use tokio::io::Interest;
+
+    match sock.try_io(Interest::WRITABLE, || sendmmsg_all(sock, msgs)) {
+        Ok(n) if n == msgs.len() => {}
+        Ok(n) => metrics::udp_send_batch_dropped(msgs.len() - n),
+        Err(err) => {
+            if !matches!(err.kind(), std::io::ErrorKind::WouldBlock) {
+                tracing::warn!("sendmmsg flush failed: {err}");
+            }
+            metrics::udp_send_batch_dropped(msgs.len());
+        }
+    }
+}
+
+/// Non-Linux fallback: no batch-send syscall, send one `sendmsg` per
+/// datagram, waiting for writability whenever the socket blocks.
+#[cfg(not(linux))]
+async fn flush_retrying(sock: &Arc<tokio::net::UdpSocket>, msgs: &[QueuedDatagram]) {
+    use lightway_core::IOCallbackResult;
+    use std::io::IoSlice;
+
+    let mut dropped = 0usize;
+    for (i, m) in msgs.iter().enumerate() {
+        loop {
+            match super::send_to_socket(sock, &[IoSlice::new(&m.data)], &m.peer, m.pktinfo, None) {
+                IOCallbackResult::Ok(_) => break,
+                IOCallbackResult::WouldBlock => {
+                    metrics::udp_send_batch_blocked();
+                    if let Err(err) = sock.writable().await {
+                        tracing::warn!("await socket writable failed: {err}");
+                        metrics::udp_send_batch_dropped(dropped + msgs.len() - i);
+                        return;
+                    }
+                }
+                IOCallbackResult::Err(err) => {
+                    dropped += 1;
+                    tracing::warn!("send flush failed: {err}");
+                    break;
+                }
+            }
+        }
+    }
+    if dropped > 0 {
+        metrics::udp_send_batch_dropped(dropped);
+    }
+}
+
+/// Non-Linux single-attempt variant used by the guard's `Drop`
+/// fallback.
+#[cfg(not(linux))]
+fn flush_best_effort(sock: &Arc<tokio::net::UdpSocket>, msgs: &[QueuedDatagram]) {
+    use lightway_core::IOCallbackResult;
+    use std::io::IoSlice;
+
+    let mut dropped = 0usize;
+    for m in msgs {
+        match super::send_to_socket(sock, &[IoSlice::new(&m.data)], &m.peer, m.pktinfo, None) {
+            IOCallbackResult::Ok(_) => {}
+            IOCallbackResult::WouldBlock => dropped += 1,
+            IOCallbackResult::Err(err) => {
+                dropped += 1;
+                tracing::warn!("send flush failed: {err}");
+            }
+        }
+    }
+    if dropped > 0 {
+        metrics::udp_send_batch_dropped(dropped);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lightway_core::MAX_IO_BATCH_SIZE;
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    async fn socket_pair() -> (
+        Arc<tokio::net::UdpSocket>,
+        tokio::net::UdpSocket,
+        SocketAddr,
+    ) {
+        let sender = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        sender.writable().await.unwrap();
+        let receiver = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let receiver_addr = receiver.local_addr().unwrap();
+        (Arc::new(sender), receiver, receiver_addr)
+    }
+
+    async fn recv_one(receiver: &tokio::net::UdpSocket) -> Vec<u8> {
+        let mut buf = vec![0u8; 2048];
+        let n = tokio::time::timeout(Duration::from_secs(2), receiver.recv(&mut buf))
+            .await
+            .expect("timed out waiting for flushed datagram")
+            .unwrap();
+        buf.truncate(n);
+        buf
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    #[cfg_attr(
+        miri,
+        ignore = "binds a real UDP socket, unsupported under miri isolation"
+    )]
+    async fn enqueue_without_open_window_returns_false() {
+        let (sender, _receiver, receiver_addr) = socket_pair().await;
+        let queue = SendQueue::new(sender);
+        assert!(!queue.try_enqueue(receiver_addr.into(), None, b"direct"));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    #[cfg_attr(
+        miri,
+        ignore = "binds a real UDP socket, unsupported under miri isolation"
+    )]
+    async fn guard_drop_flushes_queued_datagrams_in_order() {
+        let (sender, receiver, receiver_addr) = socket_pair().await;
+        let queue = SendQueue::new(sender);
+
+        let guard = queue.begin_batch();
+        for payload in [b"one".as_slice(), b"two", b"three"] {
+            assert!(queue.try_enqueue(receiver_addr.into(), None, payload));
+        }
+        drop(guard);
+
+        assert_eq!(recv_one(&receiver).await, b"one");
+        assert_eq!(recv_one(&receiver).await, b"two");
+        assert_eq!(recv_one(&receiver).await, b"three");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    #[cfg_attr(
+        miri,
+        ignore = "binds a real UDP socket, unsupported under miri isolation"
+    )]
+    async fn window_closes_after_flush() {
+        let (sender, _receiver, receiver_addr) = socket_pair().await;
+        let queue = SendQueue::new(sender);
+
+        queue.begin_batch().flush().await;
+        assert!(!queue.try_enqueue(receiver_addr.into(), None, b"late"));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    #[cfg_attr(
+        miri,
+        ignore = "binds a real UDP socket, unsupported under miri isolation"
+    )]
+    async fn flush_sends_batches_larger_than_max_io_batch_size() {
+        let (sender, receiver, receiver_addr) = socket_pair().await;
+        let queue = SendQueue::new(sender);
+
+        let total = MAX_IO_BATCH_SIZE + 5;
+        let guard = queue.begin_batch();
+        for i in 0..total {
+            let payload = format!("pkt-{i}");
+            assert!(queue.try_enqueue(receiver_addr.into(), None, payload.as_bytes()));
+        }
+        guard.flush().await;
+
+        for i in 0..total {
+            assert_eq!(recv_one(&receiver).await, format!("pkt-{i}").into_bytes());
+        }
+    }
+
+    /// Mirrors the reply_pktinfo the server echoes in production:
+    /// source-address selection only, no interface override.
+    #[cfg(linux)]
+    #[tokio::test]
+    #[serial_test::serial]
+    #[cfg_attr(
+        miri,
+        ignore = "binds a real UDP socket, unsupported under miri isolation"
+    )]
+    async fn flush_carries_per_message_pktinfo() {
+        let (sender, receiver, receiver_addr) = socket_pair().await;
+        let queue = SendQueue::new(sender);
+
+        let pktinfo = libc::in_pktinfo {
+            ipi_ifindex: 0,
+            ipi_spec_dst: libc::in_addr {
+                s_addr: u32::from(std::net::Ipv4Addr::LOCALHOST).to_be(),
+            },
+            ipi_addr: libc::in_addr { s_addr: 0 },
+        };
+
+        let guard = queue.begin_batch();
+        assert!(queue.try_enqueue(receiver_addr.into(), Some(pktinfo), b"with-pktinfo"));
+        guard.flush().await;
+
+        assert_eq!(recv_one(&receiver).await, b"with-pktinfo");
+    }
+}

--- a/lightway-server/src/io/outside/udp/send_queue.rs
+++ b/lightway-server/src/io/outside/udp/send_queue.rs
@@ -116,6 +116,7 @@ impl Drop for SendBatchGuard {
         // takes the queue and leaves None here.
         let msgs = self.queue.queue.lock().unwrap().take();
         let Some(msgs) = msgs else { return };
+        metrics::udp_send_batch_missed_flush();
         if !msgs.is_empty() {
             metrics::udp_send_batch_flush(msgs.len());
             flush_best_effort(&self.queue.sock, &msgs);

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -29,7 +29,7 @@ use ipnet::Ipv4Net;
 use lightway_app_utils::{PacketCodecFactoryType, TunConfig, connection_ticker_cb};
 use lightway_core::{
     AuthMethod, BuilderPredicates, ConnectionError, ConnectionResult, IOCallbackResult,
-    InsideIpConfig, Secret, ServerContextBuilder, ipv4_update_destination,
+    InsideIpConfig, MAX_IO_BATCH_SIZE, Secret, ServerContextBuilder, ipv4_update_destination,
 };
 use pnet_packet::ipv4::Ipv4Packet;
 use std::{
@@ -48,8 +48,9 @@ use tracing::info;
 pub use crate::connection::ConnectionState;
 #[cfg(linux)]
 pub use crate::io::inside::InsideIORecvGso;
-pub use crate::io::inside::{InsideIO, InsideIORecv};
+pub use crate::io::inside::{InsideIO, InsideIORecv, InsideIORecvBatch};
 
+use crate::io::outside::udp::send_queue::SendQueue;
 use crate::ip_manager::IpManager;
 
 use connection_manager::ConnectionManager;
@@ -390,6 +391,61 @@ async fn inside_io_loop_default(
     }
 }
 
+/// Like [`inside_io_loop_default`], but pops packets in batches and
+/// holds every resulting encrypted datagram in a send queue that is
+/// flushed with one batched syscall per receive batch. Only runs for
+/// UDP servers — stream transports have no batched send path.
+///
+/// `recv_buf_many` waits only when no packet is available, so batches
+/// form under backlog without adding latency.
+async fn inside_io_loop_batched(
+    inside_io: Arc<dyn InsideIORecvBatch>,
+    ip_manager: Arc<IpManager<Arc<Connection>>>,
+    lightway_client_ip: Ipv4Addr,
+    send_queue: Arc<SendQueue>,
+) -> anyhow::Result<()> {
+    let mut pkts: Vec<BytesMut> = Vec::with_capacity(MAX_IO_BATCH_SIZE);
+    loop {
+        pkts.clear();
+        match inside_io.recv_buf_many(&mut pkts, MAX_IO_BATCH_SIZE).await {
+            IOCallbackResult::Ok(_n) => {}
+            IOCallbackResult::WouldBlock => continue,
+            IOCallbackResult::Err(err) => {
+                break Err(anyhow!(err).context("InsideIO recv_buf_many error"));
+            }
+        };
+
+        metrics::tun_recv_batch(pkts.len());
+
+        // Sends triggered by inside_data_received (which is synchronous)
+        // are queued while this guard is live and flushed together once
+        // the batch has been processed. There are no await points inside
+        // the window; the flush itself may wait for socket writability,
+        // which backpressures this loop.
+        let batch_guard = send_queue.begin_batch();
+
+        for mut buf in pkts.drain(..) {
+            let packet = Ipv4Packet::new(buf.as_ref());
+            let Some(packet) = packet else {
+                eprintln!("Invalid inside packet size (less than Ipv4 header)!");
+                continue;
+            };
+            let conn = ip_manager.find_connection(packet.get_destination());
+
+            ipv4_update_destination(buf.as_mut(), lightway_client_ip);
+
+            if let Some(conn) = conn {
+                let result = conn.inside_data_received(&mut buf);
+                handle_inside_io_error(conn, result);
+            } else {
+                metrics::tun_rejected_packet_no_connection();
+            }
+        }
+
+        batch_guard.flush().await;
+    }
+}
+
 #[cfg(target_os = "linux")]
 async fn inside_io_loop_gso(
     inside_io: Arc<dyn crate::io::inside::InsideIORecvGso>,
@@ -562,9 +618,10 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
         config.statistics_reporting_interval,
     ));
 
+    let mut send_queue: Option<Arc<SendQueue>> = None;
     let mut server: Box<dyn Server> = match connection_type {
-        ServerConnectionMode::Datagram(may_be_sock) => Box::new(
-            io::outside::UdpServer::new(
+        ServerConnectionMode::Datagram(may_be_sock) => {
+            let udp_server = io::outside::UdpServer::new(
                 conn_manager.clone(),
                 config.bind_address,
                 config.udp_buffer_size,
@@ -572,8 +629,10 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
                 config.enable_batch_send,
                 may_be_sock,
             )
-            .await?,
-        ),
+            .await?;
+            send_queue = udp_server.send_queue();
+            Box::new(udp_server)
+        }
         ServerConnectionMode::Stream(may_be_sock) => Box::new(
             io::outside::TcpServer::new(
                 conn_manager.clone(),
@@ -605,6 +664,21 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
             }
             #[cfg(not(target_os = "linux"))]
             unreachable!()
+        } else if config.enable_batch_send
+            && let Some(send_queue) = send_queue
+        {
+            // send_queue exists only for UDP servers; on stream
+            // transports there is no batched send path, so the flag is
+            // a no-op and the default loop runs below.
+            let batch_io = inside_io.clone().as_batch().context(
+                "enable_batch_send is set but the inside IO backend does not support batched receive",
+            )?;
+            tokio::spawn(inside_io_loop_batched(
+                batch_io,
+                ip_manager.clone(),
+                config.lightway_client_ip,
+                send_queue,
+            ))
         } else {
             tokio::spawn(inside_io_loop_default(
                 inside_io,
@@ -651,5 +725,129 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
             conn_manager.shutdown();
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lightway_core::InsideIOSendCallbackArg;
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    /// InsideIO whose recv_buf_many pops scripted batches, then errors.
+    struct ScriptedInsideIO {
+        batches: Mutex<VecDeque<Vec<Vec<u8>>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::io::inside::InsideIORecv for ScriptedInsideIO {
+        async fn recv_buf(&self, _buf: &mut BytesMut) -> IOCallbackResult<usize> {
+            unimplemented!("batched loop must use recv_buf_many")
+        }
+
+        fn as_batch(self: Arc<Self>) -> Option<Arc<dyn InsideIORecvBatch>> {
+            Some(self)
+        }
+
+        fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState> {
+            self
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl InsideIORecvBatch for ScriptedInsideIO {
+        async fn recv_buf_many(
+            &self,
+            pkts: &mut Vec<BytesMut>,
+            _max: usize,
+        ) -> IOCallbackResult<usize> {
+            match self.batches.lock().unwrap().pop_front() {
+                Some(batch) => {
+                    let n = batch.len();
+                    pkts.extend(batch.into_iter().map(|p| BytesMut::from(&p[..])));
+                    IOCallbackResult::Ok(n)
+                }
+                None => IOCallbackResult::Err(std::io::Error::other("script exhausted")),
+            }
+        }
+    }
+
+    impl lightway_core::InsideIOSendCallback<ConnectionState> for ScriptedInsideIO {
+        fn send(&self, buf: BytesMut, _state: &mut ConnectionState) -> IOCallbackResult<usize> {
+            IOCallbackResult::Ok(buf.len())
+        }
+
+        fn mtu(&self) -> usize {
+            1350
+        }
+
+        fn if_index(&self) -> std::io::Result<u32> {
+            Ok(0)
+        }
+
+        fn name(&self) -> std::io::Result<String> {
+            Ok("mock".to_string())
+        }
+    }
+
+    impl crate::io::inside::InsideIO for ScriptedInsideIO {}
+
+    fn test_ip_manager() -> Arc<IpManager<Arc<Connection>>> {
+        let pool: Ipv4Net = "10.125.0.0/16".parse().unwrap();
+        Arc::new(IpManager::new(
+            pool,
+            HashMap::new(),
+            std::iter::empty::<Ipv4Addr>(),
+            InsideIpConfig {
+                client_ip: Ipv4Addr::new(10, 125, 0, 5),
+                server_ip: Ipv4Addr::new(10, 125, 0, 6),
+                dns_ip: Ipv4Addr::new(10, 125, 0, 1),
+            },
+            false,
+            true,
+        ))
+    }
+
+    /// Minimal valid IPv4 header (20 bytes) to an address with no
+    /// connection, exercising the no-connection drop path without a
+    /// real Connection.
+    fn ipv4_packet_to(dest: Ipv4Addr) -> Vec<u8> {
+        let mut pkt = vec![0u8; 20];
+        pkt[0] = 0x45; // version 4, IHL 5
+        pkt[16..20].copy_from_slice(&dest.octets());
+        pkt
+    }
+
+    #[tokio::test]
+    #[cfg_attr(
+        miri,
+        ignore = "binds a real UDP socket, unsupported under miri isolation"
+    )]
+    async fn batched_loop_drains_all_batches_then_exits_on_recv_error() {
+        let io = Arc::new(ScriptedInsideIO {
+            batches: Mutex::new(VecDeque::from([
+                vec![ipv4_packet_to(Ipv4Addr::new(10, 125, 0, 7)); 3],
+                vec![ipv4_packet_to(Ipv4Addr::new(10, 125, 0, 8)); 2],
+            ])),
+        });
+        let batches_handle = Arc::clone(&io);
+
+        let sock = Arc::new(tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap());
+        let send_queue = SendQueue::new(sock);
+
+        let result = inside_io_loop_batched(
+            io,
+            test_ip_manager(),
+            Ipv4Addr::new(10, 125, 0, 5),
+            send_queue,
+        )
+        .await;
+
+        assert!(result.is_err(), "loop must terminate on recv error");
+        assert!(
+            batches_handle.batches.lock().unwrap().is_empty(),
+            "loop must consume every scripted batch before the error"
+        );
     }
 }

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -618,6 +618,20 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
         config.statistics_reporting_interval,
     ));
 
+    #[cfg(linux)]
+    let gso = config.enable_tun_offload;
+    #[cfg(not(linux))]
+    let gso = false;
+
+    // Also enforced by config::Config::validate; repeated here to cover
+    // ServerConfig built directly by library consumers. With offload on,
+    // the GSO loop already aggregates packets, so batch send has nothing
+    // to add.
+    anyhow::ensure!(
+        !(gso && config.enable_batch_send),
+        "enable_batch_send cannot be used with enable_tun_offload"
+    );
+
     let mut send_queue: Option<Arc<SendQueue>> = None;
     let mut server: Box<dyn Server> = match connection_type {
         ServerConnectionMode::Datagram(may_be_sock) => {
@@ -645,11 +659,6 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
     };
 
     let inside_io_loop: JoinHandle<anyhow::Result<()>> = {
-        #[cfg(target_os = "linux")]
-        let gso = config.enable_tun_offload;
-        #[cfg(not(target_os = "linux"))]
-        let gso = false;
-
         if gso {
             #[cfg(target_os = "linux")]
             {

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -258,6 +258,12 @@ pub struct ServerConfig<SA: for<'a> ServerAuth<AuthState<'a>>> {
     /// Enable batch receive (`recvmsg_x` on macOS, `recvmmsg` on Linux)
     pub enable_batch_receive: bool,
 
+    /// Batch inside-path receives and flush the resulting UDP datagrams
+    /// with a single syscall where the platform supports it. UDP mode
+    /// only — a TCP server falls back to the default inside loop.
+    /// Default off.
+    pub enable_batch_send: bool,
+
     /// Disable IP pool randomization
     /// Should be used for debugging only
     #[cfg(feature = "debug")]
@@ -319,6 +325,7 @@ impl<SA: for<'a> ServerAuth<AuthState<'a>>> ServerConfig<SA> {
             proxy_protocol: config.proxy_protocol,
             udp_buffer_size: config.udp_buffer_size,
             enable_batch_receive: config.enable_batch_receive,
+            enable_batch_send: config.enable_batch_send,
             #[cfg(feature = "debug")]
             randomize_ippool: config.randomize_ippool,
         })
@@ -562,6 +569,7 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
                 config.bind_address,
                 config.udp_buffer_size,
                 config.enable_batch_receive,
+                config.enable_batch_send,
                 may_be_sock,
             )
             .await?,

--- a/lightway-server/src/metrics.rs
+++ b/lightway-server/src/metrics.rs
@@ -57,6 +57,12 @@ static METRIC_UDP_RECV_INVALID_ADDR: LazyLock<Counter> =
     LazyLock::new(|| counter!("udp_recv_invalid_addr"));
 static METRIC_UDP_RECV_MISSING_PKTINFO: LazyLock<Counter> =
     LazyLock::new(|| counter!("udp_recv_missing_pktinfo"));
+static METRIC_UDP_SEND_BATCH_SIZE: LazyLock<Histogram> =
+    LazyLock::new(|| histogram!("udp_send_batch_size"));
+static METRIC_UDP_SEND_BATCH_DROPPED: LazyLock<Counter> =
+    LazyLock::new(|| counter!("udp_send_batch_dropped"));
+static METRIC_UDP_SEND_BATCH_BLOCKED: LazyLock<Counter> =
+    LazyLock::new(|| counter!("udp_send_batch_blocked"));
 
 // Connection performance
 static METRIC_TO_LINK_UP_TIME: LazyLock<Histogram> =
@@ -289,6 +295,23 @@ pub(crate) fn udp_recv_invalid_addr() {
 
 pub(crate) fn udp_recv_missing_pktinfo() {
     METRIC_UDP_RECV_MISSING_PKTINFO.increment(1);
+}
+
+/// Number of datagrams flushed by one send-batch window. Windows that
+/// queued nothing are not recorded.
+pub(crate) fn udp_send_batch_flush(sz: usize) {
+    METRIC_UDP_SEND_BATCH_SIZE.record(sz as f64);
+}
+
+/// Datagrams dropped because a batched flush could not send them.
+pub(crate) fn udp_send_batch_dropped(count: usize) {
+    METRIC_UDP_SEND_BATCH_DROPPED.increment(count as u64);
+}
+
+/// A batched flush found the socket send buffer full and waited for
+/// writability before continuing.
+pub(crate) fn udp_send_batch_blocked() {
+    METRIC_UDP_SEND_BATCH_BLOCKED.increment(1);
 }
 
 /// Fatal TLS error for [`lightway_core::Connection`].

--- a/lightway-server/src/metrics.rs
+++ b/lightway-server/src/metrics.rs
@@ -63,6 +63,8 @@ static METRIC_UDP_SEND_BATCH_DROPPED: LazyLock<Counter> =
     LazyLock::new(|| counter!("udp_send_batch_dropped"));
 static METRIC_UDP_SEND_BATCH_BLOCKED: LazyLock<Counter> =
     LazyLock::new(|| counter!("udp_send_batch_blocked"));
+static METRIC_UDP_SEND_BATCH_MISSED_FLUSH: LazyLock<Counter> =
+    LazyLock::new(|| counter!("udp_send_batch_missed_flush"));
 
 // Connection performance
 static METRIC_TO_LINK_UP_TIME: LazyLock<Histogram> =
@@ -314,6 +316,12 @@ pub(crate) fn udp_send_batch_dropped(count: usize) {
 /// writability before continuing.
 pub(crate) fn udp_send_batch_blocked() {
     METRIC_UDP_SEND_BATCH_BLOCKED.increment(1);
+}
+
+/// A send-batch window was closed by the guard's drop fallback instead
+/// of an explicit flush, indicating a code path that misses the flush.
+pub(crate) fn udp_send_batch_missed_flush() {
+    METRIC_UDP_SEND_BATCH_MISSED_FLUSH.increment(1);
 }
 
 /// Fatal TLS error for [`lightway_core::Connection`].

--- a/lightway-server/src/metrics.rs
+++ b/lightway-server/src/metrics.rs
@@ -83,6 +83,8 @@ static METRIC_TUN_REJECTED_NO_CLIENT_IP: LazyLock<Counter> =
 // Traffic volume
 static METRIC_TUN_FROM_CLIENT: LazyLock<Counter> = LazyLock::new(|| counter!("tun_from_client"));
 static METRIC_TUN_TO_CLIENT: LazyLock<Counter> = LazyLock::new(|| counter!("tun_to_client"));
+static METRIC_TUN_RECV_BATCH_SIZE: LazyLock<Histogram> =
+    LazyLock::new(|| histogram!("tun_recv_batch_size"));
 
 static METRIC_SESSIONS_CURRENT_ONLINE: LazyLock<Gauge> =
     LazyLock::new(|| gauge!("sessions_current_online"));
@@ -368,6 +370,11 @@ pub fn tun_from_client(sz: usize) {
 /// The difference is one virtio header (12 bytes) per recv.
 pub fn tun_to_client(sz: usize) {
     METRIC_TUN_TO_CLIENT.increment(sz as u64);
+}
+
+/// Number of packets returned by one batched inside-IO receive.
+pub fn tun_recv_batch(sz: usize) {
+    METRIC_TUN_RECV_BATCH_SIZE.record(sz as f64);
 }
 
 /// Current session statistics

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -106,6 +106,14 @@ run-udp-server-batch-receive-test:
 run-udp-both-batch-receive-test:
     DO +TEST --MODE=udp --SERVER_PORT=27690 --CLIENT_EXTRA_ARGS="--enable-batch-receive" --SERVER_EXTRA_ARGS="--enable-batch-receive"
 
+# run-udp-server-batch-send-test runs e2e test using UDP with batch send enabled on the server
+run-udp-server-batch-send-test:
+    DO +TEST --MODE=udp --SERVER_PORT=27690 --SERVER_EXTRA_ARGS="--enable-batch-send"
+
+# run-udp-server-all-batching-test runs e2e test using UDP with batch receive and batch send enabled on the server
+run-udp-server-all-batching-test:
+    DO +TEST --MODE=udp --SERVER_PORT=27690 --SERVER_EXTRA_ARGS="--enable-batch-receive --enable-batch-send"
+
 # run-udp-expresslane-test runs e2e test using UDP with expresslane enabled
 run-udp-expresslane-test:
     DO +TEST --MODE=udp --SERVER_PORT=27690 --SERVER_EXTRA_ARGS="--enable-expresslane" --CLIENT_EXTRA_ARGS="--enable-expresslane"
@@ -126,6 +134,10 @@ run-udp-keepalive-test:
 # run-tcp-keepalive-test runs e2e test of TCP with client using keepalive
 run-tcp-keepalive-test:
     DO +TEST --MODE=tcp --SERVER_PORT=443 --CLIENT_EXTRA_ARGS="--keepalive-interval=2s --keepalive-timeout=6s"
+
+# run-tcp-server-batch-send-test proves the flag is a no-op on stream transports
+run-tcp-server-batch-send-test:
+    DO +TEST --MODE=tcp --SERVER_PORT=27690 --SERVER_EXTRA_ARGS="--enable-batch-send"
 
 # run-udp-single-threaded-test runs e2e test of UDP with server and client using a single Tokio worker thread
 run-udp-single-threaded-test:
@@ -172,11 +184,14 @@ run-all-tests:
     BUILD +run-udp-client-batch-receive-test
     BUILD +run-udp-server-batch-receive-test
     BUILD +run-udp-both-batch-receive-test
+    BUILD +run-udp-server-batch-send-test
+    BUILD +run-udp-server-all-batching-test
     BUILD +run-udp-expresslane-test
     BUILD +run-udp-expresslane-compat-test
     BUILD +run-tcp-iouring-test
     BUILD +run-udp-keepalive-test
     BUILD +run-tcp-keepalive-test
+    BUILD +run-tcp-server-batch-send-test
     BUILD +run-udp-single-threaded-test
     BUILD +run-tcp-single-threaded-test
     BUILD +run-tcp-parallel-connect-test


### PR DESCRIPTION
## Description

Adds an opt-in batched send path to the UDP server, gated behind a new `--enable-batch-send` flag (default off):

- `InsideIORecvBatch` — a capability trait mirroring `InsideIORecvGso`: backends that can pop multiple packets per call (up to `MAX_IO_BATCH_SIZE`) override `as_batch`, and the batched loop accepts only the upgraded handle, so the capability check happens once at startup. Each backend sizes its own receive buffers from its MTU. The io_uring TUN backend batches via `mpsc::Receiver::recv_many`; the direct TUN backend reads one packet per call.
- A scoped send queue on the UDP server: while the inside loop processes a receive batch, per-connection sends are queued instead of issuing one `sendmsg` each, then flushed together — one `sendmmsg` covering the whole batch on Linux, a `sendmsg` loop elsewhere. A full send buffer is treated as backpressure: the flush waits for socket writability and resumes from the first unsent datagram, pausing the inside loop rather than dropping already-encrypted packets. A hard IO error drops only the datagram that caused it; the drop-guard fallback (taken only if the loop exits without flushing) stays best-effort single-attempt and is counted separately.
- The batched loop runs only for UDP servers — stream transports have no batched send path, so on TCP the flag is a no-op and the default loop runs. Combining it with `--enable-tun-offload` is rejected at startup, since the GSO loop already aggregates packets.
- New metrics, documented in `docs/logs_and_metrics.md`: `tun_recv_batch_size` and `udp_send_batch_size` histograms; `udp_send_batch_blocked`, `udp_send_batch_dropped` and `udp_send_batch_missed_flush` counters.
- E2E variants exercising the flag (UDP, UDP + batch receive, TCP no-op).

Also includes a fix for a pre-existing issue the new tests surfaced: `send_to_socket` always attached a control buffer, and macOS rejects a non-null `msg_control` with `msg_controllen == 0`, failing sends that carry no cmsg.

## Motivation and Context

The download path (tun → encrypt → UDP) costs one `sendmsg` syscall per packet. The receive direction already batches (`--enable-batch-receive`, `recvmmsg`/`recvmsg_x`); this mirrors that on the send side. Batches only form under backlog — `recv_buf_many` returns whatever is immediately available and waits only when idle — so batching adds no latency. The flag defaults off so the change can be A/B tested; the new metrics are the instruments for that comparison.

## How Has This Been Tested?

- Unit tests for the send queue (real socket pairs: window atomicity, in-order flush, batches larger than `MAX_IO_BATCH_SIZE`, window close, per-message pktinfo on Linux), the queue-aware `UdpSocket::send`, the `as_batch` capability upgrade, and the batched loop (scripted inside-IO mock).
- `cargo test -p lightway-server -p lightway-app-utils`, `cargo fmt --check`, and `cargo clippy --all-targets` all clean, developed on macOS; `cargo check`/`cargo clippy` additionally cross-checked for `aarch64-unknown-linux-gnu` to cover the Linux-only code.
- The Linux-only paths (`sendmmsg` flush, its pktinfo test, and the `io-uring` feature combination) need this repo's Linux CI to compile and run them.
- New e2e targets: `run-udp-server-batch-send-test`, `run-udp-server-all-batching-test`, `run-tcp-server-batch-send-test`.
- Throughput/syscall-count comparison under load is still to be done before considering a default change; the flag stays off.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
