### PR TITLE
server: make GSO offload a typed inside IO capability

### DIFF
--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -337,6 +337,17 @@ impl Tun {
         }
     }
 
+    /// Whether this Tun supports GSO reads/writes. Only the direct
+    /// backend, opened with [`TunConfig::offload`], does.
+    #[cfg(linux)]
+    pub fn supports_gso(&self) -> bool {
+        match self {
+            Tun::Direct(t) => t.supports_gso(),
+            #[cfg(feature = "io-uring")]
+            Tun::IoUring(_) => false,
+        }
+    }
+
     /// Send a packet to `Tun`
     pub fn try_send(&self, buf: BytesMut) -> IOCallbackResult<usize> {
         match self {
@@ -540,6 +551,13 @@ impl TunDirect {
     /// MTU of Tun
     pub fn mtu(&self) -> usize {
         self.mtu as usize
+    }
+
+    /// Whether this device was opened with offload (`IFF_VNET_HDR`), so
+    /// reads and writes carry a `virtio_net_hdr`.
+    #[cfg(linux)]
+    pub fn supports_gso(&self) -> bool {
+        self.vnet_hdr
     }
 
     /// Interface index of Tun

--- a/lightway-server/src/io/inside.rs
+++ b/lightway-server/src/io/inside.rs
@@ -13,11 +13,30 @@ use std::sync::Arc;
 pub trait InsideIORecv: Sync + Send {
     async fn recv_buf(&self, buf: &mut bytes::BytesMut) -> IOCallbackResult<usize>;
 
+    /// Upgrade to the GSO-capable interface, when this instance supports
+    /// GSO reads. Default: not supported. Capability is per-instance —
+    /// a TUN opened without offload returns `None`.
+    #[cfg(linux)]
+    fn as_gso(self: Arc<Self>) -> Option<Arc<dyn InsideIORecvGso>> {
+        None
+    }
+
+    fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState>;
+}
+
+/// Trait for InsideIO
+pub trait InsideIO: InsideIORecv + InsideIOSendCallback<ConnectionState> {}
+
+/// Inside IO backends that can receive GSO superpackets. Obtained from
+/// [`InsideIORecv::as_gso`]; the GSO inside loop only accepts this type,
+/// so the capability check happens once at startup.
+///
+/// Implementers must also override [`InsideIORecv::as_gso`] to return
+/// `Some(self)` — the default `None` hides the capability.
+#[cfg(linux)]
+#[async_trait]
+pub trait InsideIORecvGso: InsideIORecv {
     /// Receive a GSO superpacket into `buf`.
-    ///
-    /// The default implementation returns `Unsupported`, for inside
-    /// IO backends that don't provide GSO reads. Backends that do
-    /// must uphold the contract below.
     ///
     /// Implementations write into `buf.spare_capacity_mut()` so the
     /// caller can reuse one allocation across iterations with no
@@ -31,16 +50,73 @@ pub trait InsideIORecv: Sync + Send {
     /// contain a full virtio header, or when the virtio header
     /// itself fails to decode (each cause is logged + metered
     /// inside the impl). Returns `Err` on IO errors.
-    #[cfg(target_os = "linux")]
-    async fn recv_gso(
-        &self,
-        _buf: &mut bytes::BytesMut,
-    ) -> IOCallbackResult<(usize, VirtioNetHdr)> {
-        IOCallbackResult::Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
-    }
-
-    fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState>;
+    async fn recv_gso(&self, buf: &mut bytes::BytesMut) -> IOCallbackResult<(usize, VirtioNetHdr)>;
 }
 
-/// Trait for InsideIO
-pub trait InsideIO: InsideIORecv + InsideIOSendCallback<ConnectionState> {}
+#[cfg(all(test, linux))]
+mod tests {
+    use super::*;
+    use bytes::BytesMut;
+
+    /// Backend without the GSO capability: only the base trait.
+    struct NoGso;
+
+    #[async_trait]
+    impl InsideIORecv for NoGso {
+        async fn recv_buf(&self, _buf: &mut BytesMut) -> IOCallbackResult<usize> {
+            unimplemented!("not needed for capability tests")
+        }
+
+        fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState> {
+            unimplemented!("not needed for capability tests")
+        }
+    }
+
+    /// Backend with the GSO capability: overrides the upgrade.
+    struct WithGso;
+
+    #[async_trait]
+    impl InsideIORecv for WithGso {
+        async fn recv_buf(&self, _buf: &mut BytesMut) -> IOCallbackResult<usize> {
+            unimplemented!("not needed for capability tests")
+        }
+
+        fn as_gso(self: Arc<Self>) -> Option<Arc<dyn InsideIORecvGso>> {
+            Some(self)
+        }
+
+        fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState> {
+            unimplemented!("not needed for capability tests")
+        }
+    }
+
+    #[async_trait]
+    impl InsideIORecvGso for WithGso {
+        async fn recv_gso(&self, _buf: &mut BytesMut) -> IOCallbackResult<(usize, VirtioNetHdr)> {
+            // Proves dispatch through the typed handle without needing
+            // to construct a VirtioNetHdr.
+            IOCallbackResult::Err(std::io::Error::other("mock recv_gso reached"))
+        }
+    }
+
+    #[test]
+    fn default_as_gso_is_none() {
+        assert!(Arc::new(NoGso).as_gso().is_none());
+    }
+
+    #[test]
+    fn as_gso_is_none_through_a_trait_object() {
+        let io: Arc<dyn InsideIORecv> = Arc::new(NoGso);
+        assert!(io.as_gso().is_none());
+    }
+
+    #[tokio::test]
+    async fn upgraded_handle_dispatches_recv_gso() {
+        let gso = Arc::new(WithGso).as_gso().expect("override upgrades");
+        let mut buf = BytesMut::new();
+        assert!(matches!(
+            gso.recv_gso(&mut buf).await,
+            IOCallbackResult::Err(_)
+        ));
+    }
+}

--- a/lightway-server/src/io/inside/tun.rs
+++ b/lightway-server/src/io/inside/tun.rs
@@ -1,9 +1,10 @@
+use crate::connection::ConnectionState;
+#[cfg(linux)]
+use crate::io::inside::InsideIORecvGso;
 use crate::{
     io::inside::{InsideIO, InsideIORecv},
     metrics,
 };
-
-use crate::connection::ConnectionState;
 use anyhow::Result;
 use async_trait::async_trait;
 use bytes::BytesMut;
@@ -55,7 +56,23 @@ impl InsideIORecv for Tun {
         }
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(linux)]
+    fn as_gso(self: Arc<Self>) -> Option<Arc<dyn InsideIORecvGso>> {
+        if self.0.supports_gso() {
+            Some(self)
+        } else {
+            None
+        }
+    }
+
+    fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState> {
+        self
+    }
+}
+
+#[cfg(linux)]
+#[async_trait]
+impl InsideIORecvGso for Tun {
     async fn recv_gso(&self, buf: &mut BytesMut) -> IOCallbackResult<(usize, VirtioNetHdr)> {
         match self.0.recv_gso(buf).await {
             IOCallbackResult::Ok((n, hdr)) => {
@@ -67,10 +84,6 @@ impl InsideIORecv for Tun {
             IOCallbackResult::WouldBlock => IOCallbackResult::WouldBlock,
             IOCallbackResult::Err(e) => IOCallbackResult::Err(e),
         }
-    }
-
-    fn into_io_send_callback(self: Arc<Self>) -> InsideIOSendCallbackArg<ConnectionState> {
-        self
     }
 }
 

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -46,6 +46,8 @@ use tokio::{
 use tracing::info;
 
 pub use crate::connection::ConnectionState;
+#[cfg(linux)]
+pub use crate::io::inside::InsideIORecvGso;
 pub use crate::io::inside::{InsideIO, InsideIORecv};
 
 use crate::ip_manager::IpManager;
@@ -383,7 +385,7 @@ async fn inside_io_loop_default(
 
 #[cfg(target_os = "linux")]
 async fn inside_io_loop_gso(
-    inside_io: Arc<dyn InsideIO>,
+    inside_io: Arc<dyn crate::io::inside::InsideIORecvGso>,
     ip_manager: Arc<IpManager<Arc<Connection>>>,
     lightway_client_ip: Ipv4Addr,
 ) -> anyhow::Result<()> {
@@ -584,8 +586,11 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
         if gso {
             #[cfg(target_os = "linux")]
             {
+                let gso_io = inside_io.clone().as_gso().context(
+                    "enable_tun_offload is set but the inside IO backend does not support GSO offload",
+                )?;
                 tokio::spawn(inside_io_loop_gso(
-                    inside_io,
+                    gso_io,
                     ip_manager.clone(),
                     config.lightway_client_ip,
                 ))


### PR DESCRIPTION
## Description

Makes GSO offload a typed capability on the server's inside-IO interface:

- `recv_gso` moves from a defaulted (`Unsupported`) method on `InsideIORecv` into a Linux-only `InsideIORecvGso: InsideIORecv` sub-trait where it is mandatory.
- `InsideIORecv` gains a defaulted `as_gso(self: Arc<Self>) -> Option<Arc<dyn InsideIORecvGso>>` upgrade accessor. `Tun` upgrades only when the underlying device was actually opened with offload (`IFF_VNET_HDR`), via new `supports_gso()` accessors in lightway-app-utils — the capability is per-instance, not per-type.
- `inside_io_loop_gso` now takes `Arc<dyn InsideIORecvGso>`, so it cannot be handed a backend without GSO support, and `server()` resolves the capability once at startup.

FYI: Claude generated most of code, reviewed by human 👀 

## Motivation and Context

`--enable-tun-offload` combined with a backend that cannot do GSO reads (a custom `inside_io`, an io_uring-backed TUN, or a TUN opened without offload) previously failed at runtime: the GSO loop's first `recv_gso` returned `Unsupported` and killed the inside loop. After this change the same misconfiguration fails at startup with a clear error, and the type system prevents the loop from calling an unsupported method at all. Behavior with the flag off, or with the flag on and a capable TUN, is unchanged.

## How Has This Been Tested?

- New unit tests (Linux-only, like the trait itself): the default `as_gso` returns `None`, including through a trait object; an implementing backend upgrades and dispatches `recv_gso` through the typed handle.
- `cargo test -p lightway-server -p lightway-app-utils`, `cargo fmt --check`, `cargo clippy --all-targets` all clean; developed on macOS, so Linux CI is the gate for the cfg-gated code and the new tests.
- Existing offload e2e variants cover the flag-on happy path unchanged.
- Out-of-tree `InsideIORecv` implementations that never overrode `recv_gso` compile unchanged (the removed method was defaulted; the added one is defaulted). An implementation that did override `recv_gso` gets a compile error pointing at the new trait; migration is moving the method into `impl InsideIORecvGso` and overriding `as_gso`.
- Tested on an actual Linux server as well

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`