### PR TITLE
CVPN-2621: Fix race condition where expresslane self keys becomes None

### DIFF
--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -1914,7 +1914,9 @@ impl<AppState: Send> Connection<AppState> {
     }
 
     fn expresslane_ready(&self) -> bool {
-        self.expresslane_supported() && matches!(self.expresslane.state, ExpresslaneState::Active)
+        self.expresslane_supported()
+            && matches!(self.expresslane.state, ExpresslaneState::Active)
+            && self.expresslane.data.has_valid_keys()
     }
 
     /// Set the expresslane state and emit the event if the state has changed.

--- a/lightway-core/src/wire/expresslane_data.rs
+++ b/lightway-core/src/wire/expresslane_data.rs
@@ -360,8 +360,10 @@ impl ExpresslaneData {
     }
 
     pub(crate) fn update_self_key(&mut self) {
-        self.current_self = self.next_self.take();
-        debug!("Updating expresslane self keys: {:?}", self);
+        if let Some(next) = self.next_self.take() {
+            self.current_self = Some(next);
+            debug!("Updating expresslane self keys: {:?}", self);
+        }
     }
 
     pub(crate) fn update_peer_key(&mut self, key: ExpresslaneKey) -> ExpresslaneResult<()> {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When expresslane config ack message is received, handler flow tries to promote next self key to current. But this it not idempotent. i.e when a duplicate message is received, it replaced the valid key with a null one.

Fixed it by checking whether it is a valid key 

## Motivation and Context

Some clients went to Connect Cannot Browse with following errors:

`Failed to process outside data: Protocol Error: Insufficient data`

## How Has This Been Tested?


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
