### PR TITLE
deny: use licenses instead of license as deny argument

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -166,4 +166,4 @@ lint:
 # check-dependencies lints our dependencies via `cargo deny`
 check-dependencies:
     FROM +source
-    DO lib-rust+CARGO --args="deny --all-features check --deny warnings bans license sources"
+    DO lib-rust+CARGO --args="deny --all-features check --deny warnings bans licenses sources"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
use licenses instead of license as deny argument

```
Error:
   +check-dependencies *failed* | Repeating the failure error...
   +check-dependencies *failed* | --> RUN set -e; cargo $args; cargo sweep -r -t $EARTHLY_SWEEP_DAYS; cargo sweep -r -i; $EARTHLY_FUNCTIONS_HOME/copy-output.sh "$output";
   +check-dependencies *failed* | error: invalid value 'license' for '[WHICH]...'

   +check-dependencies *failed* | For more information, try '--help'.
```

## Motivation and Context

Fixing CI failure
https://github.com/expressvpn/lightway/actions/runs/29062837334/job/86268170560

## How Has This Been Tested?

CI passed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
