### PR TITLE
core: increase ExpressLane replay window to 8192 packets

### DIFF
--- a/lightway-core/src/wire/expresslane_data.rs
+++ b/lightway-core/src/wire/expresslane_data.rs
@@ -136,7 +136,7 @@ type ExpresslaneResult<T> = Result<T, ExpresslaneError>;
 ///
 /// Tracks received packet counters to detect and prevent replay attacks
 /// while handling out-of-order packet delivery typical in UDP.
-/// Uses a 2048-bit bitmap (32 x u64) to tolerate significant packet
+/// Uses an 8192-bit bitmap (128 x u64) to tolerate significant packet
 /// reordering under high-throughput conditions.
 #[derive(Debug, Clone)]
 struct ReplayWindow {
@@ -165,8 +165,8 @@ impl Default for ReplayWindow {
 
 impl ReplayWindow {
     /// Number of u64 blocks in the bitmap
-    const NUM_BLOCKS: usize = 32;
-    /// Window size in packets (32 * 64 = 2048)
+    const NUM_BLOCKS: usize = 128;
+    /// Window size in packets (128 * 64 = 8192)
     const WINDOW_SIZE: u64 = (Self::NUM_BLOCKS as u64) * 64;
 
     /// Set a bit at the given position in the bitmap
@@ -798,12 +798,12 @@ mod tests {
     fn replay_window_rejects_too_old_packets() {
         let mut window = ReplayWindow::default();
         assert!(window.commit(100));
-        assert!(window.commit(3000)); // Advance window past 2048
-        // Packet 100 is now outside the window (3000 - 2048 = 952)
+        assert!(window.commit(10000)); // Advance window past 8192
+        // Packet 100 is now outside the window (10000 - 8192 = 1808)
         assert!(!window.commit(100));
-        assert!(!window.commit(951));
+        assert!(!window.commit(1808));
         // But packets within window should work
-        assert!(window.commit(953));
+        assert!(window.commit(1809));
         assert_eq!(window.packets_received, 3);
     }
 
@@ -812,8 +812,8 @@ mod tests {
         let mut window = ReplayWindow::default();
         assert!(window.commit(100));
         // Jump way ahead (> window size)
-        assert!(window.commit(3000));
-        assert_eq!(window.max_counter, 3000);
+        assert!(window.commit(10000));
+        assert_eq!(window.max_counter, 10000);
         // Old packets should be rejected
         assert!(!window.commit(100));
         assert_eq!(window.packets_received, 2);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Increase expresslane replay window to 8192

## Motivation and Context
With high performing server/client which can do parallel expresslane processing, we are hitting some limits on the existing replay window and packets were dropped.

## How Has This Been Tested?

Verified with high performing servers.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
