### PR TITLE
client: expose selected connection's inside IP config in BestConnecti…

### DIFF
--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -143,6 +143,8 @@ pub struct BestConnectionInfo {
     pub index: usize,
     /// Details about the established outside connection (socket type + peer).
     pub connection: ConnectionInfo,
+    /// Inside IP configuration assigned by the server to the selected connection
+    pub ip_config: InsideIpConfig,
 }
 
 #[derive(educe::Educe)]
@@ -1438,15 +1440,24 @@ pub async fn client<
         .unwrap();
     let (_, mut connection) = connections.swap_remove(pos);
 
-    if let Some(signal) = config.best_connection_selected_signal.take()
-        && signal
+    if let Some(signal) = config.best_connection_selected_signal.take() {
+        let ip_config = connection
+            .conn
+            .lock()
+            .unwrap()
+            .app_state()
+            .ip_config
+            .expect("selected connection is Online, so ip_config is set");
+        if signal
             .send(BestConnectionInfo {
                 index: best_connection_index,
                 connection: connection.outside_connection_info(),
+                ip_config,
             })
             .is_err()
-    {
-        tracing::error!("Failed to send best_connection_selected_signal");
+        {
+            tracing::error!("Failed to send best_connection_selected_signal");
+        }
     }
 
     for (_, conn) in connections.iter_mut() {


### PR DESCRIPTION
## Description
Add the winning connection's `InsideIpConfig` to `BestConnectionInfo`, the payload sent over `best_connection_selected_signal`. The field is read from the selected connection's app state at the send site in `client()`.

The field is non-optional: the selected connection is always `Online` at that point (selection breaks on the connection's online signal), and the auth response sets `ip_config` immediately before the transition to `Online`, so the value is always present. This is the only constructor of `BestConnectionInfo`, so the change is additive for consumers.

## Motivation and Context
`BestConnectionInfo` previously carried only the connection index and outside socket details (socket type / peer addr). Consumers that learn about the selected connection solely through `best_connection_selected_signal` — rather
than holding their own connection handles — had no way to obtain the server-assigned inside IP configuration (client IP / server IP / DNS IP) at selection time. Exposing it here, post-selection, avoids intercepting the `ClientIpConfig` callback earlier, where concurrent endpoint candidates could be assigned different inside configs.

## How Has This Been Tested?
`cargo check`, `cargo clippy`, and `cargo test -p lightway-client` on macOS.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`