### PR TITLE
client: Emit Disconnected state on fatal connection errors

### DIFF
--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -1164,6 +1164,16 @@ pub async fn connect<
             let _ = disconnected_rx.await;
         } else {
             tracing::warn!("Connection task ended:\n{:?}", result);
+            // On fatal errors (e.g. keepalive timeout) the connection is torn
+            // down without going through the user-initiated stop path, so
+            // event handlers would never observe a terminal state. Disconnect
+            // explicitly — goodbye/shutdown inside disconnect() are
+            // best-effort on a dead link — and wait for the Disconnected
+            // event to flush through the event stream before aborting tasks.
+            let disconnected = stop_conn.lock().unwrap().disconnect().is_ok();
+            if disconnected {
+                let _ = disconnected_rx.await;
+            }
         }
 
         outside_io_loop.abort();


### PR DESCRIPTION
On fatal errors (e.g. keepalive timeout) the connection task returned without calling disconnect(), so no StateChanged(Disconnected) event was ever emitted. Downstream consumers watching state changes never saw a terminal state and stayed stuck reporting the connection as up.

Disconnect explicitly on the error path and wait for the Disconnected event to flush through the event stream before aborting tasks.

<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CI Tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
