### PR TITLE
keepalive: add disconnect to Err exit path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,9 +469,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bytes = "1.5.0"
 bytesize = { version = "1.3.0", features = ["serde"] }
 clap = { version = "4.4.7", features = ["derive"] }
 ctrlc = { version = "3.4.6" }
-cfg_aliases = "0.2.1"
+cfg_aliases = "0.2.2"
 delegate = "0.12.0"
 educe = { version = "0.6.0", default-features = false, features = ["Debug"] }
 ipnet = { version = "2.8.0", features = ["serde"]}

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -1164,6 +1164,17 @@ pub async fn connect<
             let _ = disconnected_rx.await;
         } else {
             tracing::warn!("Connection task ended:\n{:?}", result);
+            // Teardown on an error exit (keepalive timeout, I/O loop exit,
+            // ticker stop, ...) must still tear down the connection the same
+            // way a user-initiated stop does: drive the state machine to
+            // Disconnected (emitting StateChanged events) and make a
+            // best-effort attempt to notify the peer with a Goodbye frame.
+            // Without this the connection task just aborts its I/O tasks,
+            // leaving no Disconnecting/Disconnected transition. `disconnect()`
+            // is a no-op if the connection never reached a connected state.
+            if let Ok(mut conn) = stop_conn.lock() {
+                let _ = conn.disconnect();
+            }
         }
 
         outside_io_loop.abort();


### PR DESCRIPTION
It seems that only the OK() exits run disconnect teardown, however the Err path just propogate Err, but do not run a proper teardown.



## Description
Exit Err path do not run disconnect. Adding disconnect path for Err exit path

## Motivation and Context
Keepalive was exiting without disconnect 

## How Has This Been Tested?
this has been tested on linux manually client
Inttest and unit tested as well

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
