### PR TITLE
Publish Expresslane keys when peer-addr or session id update

### DIFF
--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -701,7 +701,11 @@ impl<AppState: Send> Connection<AppState> {
 
     /// Set the address of this connection's peer
     pub fn set_peer_addr(&mut self, addr: SocketAddr) -> SocketAddr {
-        self.session.io_cb_mut().io.set_peer_addr(addr)
+        let old = self.session.io_cb_mut().io.set_peer_addr(addr);
+        if old != addr {
+            self.publish_expresslane_key();
+        }
+        old
     }
 
     /// Get the negotiated cipher, only valid after [`State::LinkUp`]

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -1504,6 +1504,7 @@ impl<AppState: Send> Connection<AppState> {
             Client { .. } => {
                 self.session_id = session_id;
                 self.session.io_cb_mut().set_session_id(session_id);
+                self.publish_expresslane_key();
             }
             Server {
                 ref mut pending_session_id,

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -1444,6 +1444,12 @@ impl<AppState: Send> Connection<AppState> {
                     new: new_session_id,
                 });
 
+                // Announce the rotation: the keepalive ping is stamped
+                // with the new session id and the pong reply echoes it
+                // back, completing the rotation within one round trip
+                // instead of waiting for organic client traffic
+                let _ = self.keepalive();
+
                 Ok(new_session_id)
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Publish Expresslane keys when peer-addr or session id update

## Motivation and Context

Found in local testing that the published keys are stale, whenever there is a session id update or the client roams.

## How Has This Been Tested?

Verified the keys are valid even in case of roaming or sesion id update.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
