### PR TITLE
build: pin stable Rust version via rust-toolchain.toml

### DIFF
--- a/.github/workflows/nightly-rust-update-check.yaml
+++ b/.github/workflows/nightly-rust-update-check.yaml
@@ -31,6 +31,17 @@ jobs:
     - name: Update Rust version in Earthfile
       run: sed -i -E 's/^(\s*FROM rust):(:?[0-9\.]+)(-.+)?$/\1:${{ steps.check-version.outputs.rust }}\3/g' Earthfile
 
+    - name: Update Rust version in rust-toolchain.toml
+      run: sed -i -E 's/^(channel = ")[0-9\.]+(")$/\1${{ steps.check-version.outputs.rust }}\2/' rust-toolchain.toml
+
+    # nix (rust-overlay) can only resolve the pinned stable version once flake.lock points at a
+    # rust-overlay revision that carries it, so refresh that input in the same PR.
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@v21
+
+    - name: Update rust-overlay in flake.lock
+      run: nix flake update rust-overlay
+
     - uses: peter-evans/create-pull-request@v6
       with:
         token: ${{ secrets.SERVICE_ACCOUNT_PAT }}

--- a/nix/modules/checks.nix
+++ b/nix/modules/checks.nix
@@ -4,7 +4,7 @@
     {
       lib,
       pkgs,
-      rustLatest,
+      rustStable,
       ...
     }:
     let
@@ -12,7 +12,7 @@
       src = ../..;
 
       # Rust toolchain with rustfmt component
-      rust = rustLatest.default.override {
+      rust = rustStable.default.override {
         extensions = [ "rustfmt" ];
       };
 

--- a/nix/modules/common.nix
+++ b/nix/modules/common.nix
@@ -6,15 +6,20 @@
       cargoToml = builtins.fromTOML (builtins.readFile ../../Cargo.toml);
       msrv = cargoToml.workspace.package.rust-version;
 
+      # Pinned stable version, shared with the Earthfile and local dev via rust-toolchain.toml.
+      # rust-overlay does not read rust-toolchain.toml itself, so parse the channel and pin explicitly.
+      rustToolchain = builtins.fromTOML (builtins.readFile ../../rust-toolchain.toml);
+      rustStableVersion = rustToolchain.toolchain.channel;
+
       # Rust toolchains (shared across all modules)
-      rustLatest = pkgs.rust-bin.stable.latest;
+      rustStable = pkgs.rust-bin.stable.${rustStableVersion};
       rustMsrv = pkgs.rust-bin.stable.${msrv};
       rustNightly = pkgs.rust-bin.nightly.latest;
     in
     {
       # Export via _module.args for use in other modules
       _module.args = {
-        inherit rustLatest rustMsrv rustNightly;
+        inherit rustStable rustMsrv rustNightly;
       };
     };
 }

--- a/nix/modules/cross.nix
+++ b/nix/modules/cross.nix
@@ -6,7 +6,7 @@
       pkgs,
       pkgsDarwinX64,
       system,
-      rustLatest,
+      rustStable,
       ...
     }:
     let
@@ -91,7 +91,7 @@
       mkCrossToolchain =
         targetName: config:
         let
-          rust = (config.rustBin or rustLatest).minimal.override { targets = [ config.rustTarget ]; };
+          rust = (config.rustBin or rustStable).minimal.override { targets = [ config.rustTarget ]; };
         in
         {
           inherit (config) pkgsCross rustTarget isStatic;

--- a/nix/modules/devshells.nix
+++ b/nix/modules/devshells.nix
@@ -5,7 +5,7 @@
       config,
       lib,
       pkgs,
-      rustLatest,
+      rustStable,
       rustMsrv,
       rustNightly,
       system,
@@ -16,7 +16,7 @@
         default = config.devShells.stable;
 
         stable = pkgs.callPackage ../shell.nix {
-          rustc = rustLatest.default;
+          rustc = rustStable.default;
         };
         nightly = pkgs.callPackage ../shell.nix {
           rustc = rustNightly.default;
@@ -57,7 +57,7 @@
               .${system} or null;
           in
           pkgsCross.callPackage ../shell.nix ({
-            rustc = rustLatest.minimal.override {
+            rustc = rustStable.minimal.override {
               targets = [
                 "aarch64-linux-android"
                 "armv7-linux-androideabi"

--- a/nix/modules/native.nix
+++ b/nix/modules/native.nix
@@ -5,15 +5,15 @@
       lib,
       pkgs,
       system,
-      rustLatest,
+      rustStable,
       rustMsrv,
       ...
     }:
     let
       # Rust platforms
-      rustPlatformLatest = pkgs.makeRustPlatform {
-        cargo = rustLatest.minimal;
-        rustc = rustLatest.minimal;
+      rustPlatformStable = pkgs.makeRustPlatform {
+        cargo = rustStable.minimal;
+        rustc = rustStable.minimal;
       };
       rustPlatformMsrv = pkgs.makeRustPlatform {
         cargo = rustMsrv.minimal;
@@ -44,9 +44,9 @@
 
       # Native packages for all platforms
       nativePackages = {
-        # Latest stable builds
-        "lightway-client-${nativeSuffix}" = mkPackage "lightway-client" pkgs rustPlatformLatest;
-        "lightway-server-${nativeSuffix}" = mkPackage "lightway-server" pkgs rustPlatformLatest;
+        # Pinned stable builds
+        "lightway-client-${nativeSuffix}" = mkPackage "lightway-client" pkgs rustPlatformStable;
+        "lightway-server-${nativeSuffix}" = mkPackage "lightway-server" pkgs rustPlatformStable;
 
         # MSRV builds
         "lightway-client-${nativeSuffix}-msrv" = mkPackage "lightway-client" pkgs rustPlatformMsrv;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.97.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The stable Rust version lived only in the Earthfile's base image tag. Local builds were left unpinned, and the nix flake floated on rust-overlay's latest stable, so the three could silently drift onto different compilers.

Add a rust-toolchain.toml that rustup honours for both local builds and the Earthfile image, and pin the nix stable toolchain to that same channel (rustLatest -> rustStable) rather than tracking latest. The nightly updater now rewrites the toml alongside the Earthfile and refreshes the rust-overlay input in flake.lock, so nix can resolve the freshly pinned version within the same PR.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Earthly, local build and nix build uses the same rust compiler

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passed CI and tested building lightway-client/core locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
