### PR TITLE
ci: only open a Rust toolchain PR when the version changed

### DIFF
--- a/.github/workflows/nightly-rust-update-check.yaml
+++ b/.github/workflows/nightly-rust-update-check.yaml
@@ -24,25 +24,37 @@ jobs:
       run: |
         rustup install stable
         stable=$(rustup run stable rustc -V | sed -E -e 's/^rustc ([0-9\.]+) \(.*\)$/\1/g')
-        echo "Latest stable rust is ${stable}"
+        current=$(sed -E -n 's/^channel = "([0-9\.]+)"$/\1/p' rust-toolchain.toml)
+        echo "Latest stable rust is ${stable}, currently pinned to ${current}"
 
         echo rust="$stable" >> "$GITHUB_OUTPUT"
+        if [ "$stable" != "$current" ]; then
+          echo changed=true >> "$GITHUB_OUTPUT"
+        else
+          echo changed=false >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Update Rust version in Earthfile
+      if: steps.check-version.outputs.changed == 'true'
       run: sed -i -E 's/^(\s*FROM rust):(:?[0-9\.]+)(-.+)?$/\1:${{ steps.check-version.outputs.rust }}\3/g' Earthfile
 
     - name: Update Rust version in rust-toolchain.toml
+      if: steps.check-version.outputs.changed == 'true'
       run: sed -i -E 's/^(channel = ")[0-9\.]+(")$/\1${{ steps.check-version.outputs.rust }}\2/' rust-toolchain.toml
 
     # nix (rust-overlay) can only resolve the pinned stable version once flake.lock points at a
-    # rust-overlay revision that carries it, so refresh that input in the same PR.
+    # rust-overlay revision that carries it, so refresh that input in the same PR. Gated on an
+    # actual version change so we don't bump the input (and open a spurious PR) on an unchanged night.
     - name: Install Nix
+      if: steps.check-version.outputs.changed == 'true'
       uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
 
     - name: Update rust-overlay in flake.lock
+      if: steps.check-version.outputs.changed == 'true'
       run: nix flake update rust-overlay
 
-    - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+    - if: steps.check-version.outputs.changed == 'true'
+      uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
       with:
         token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
         delete-branch: true


### PR DESCRIPTION
## Description
The nightly Rust update workflow now detects whether the latest stable Rust
actually differs from the version pinned in `rust-toolchain.toml` before doing
any work. The check step compares the two and exposes a `changed` output, and
every mutating step — the Earthfile and `rust-toolchain.toml` edits, the Nix
install, `nix flake update rust-overlay`, and the `create-pull-request` step —
is gated on that flag.

## Motivation and Context
`nix flake update rust-overlay` ran unconditionally, bumping the `rust-overlay`
input to its newest revision every night regardless of whether the stable Rust
version had moved. That always dirtied `flake.lock`, so `create-pull-request`
opened a fresh PR each night even when the pinned toolchain was already current.
Gating on an actual version change means an unchanged night touches nothing and
opens no PR.

## How Has This Been Tested?
Will manually check if there's no PR created tmr

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
