### PR TITLE
client: cli: allow disable keepalive_continuous via CLI

### DIFF
--- a/lightway-client/src/config.rs
+++ b/lightway-client/src/config.rs
@@ -151,8 +151,8 @@ pub struct Config {
     #[patch(attribute(clap(long)))]
     #[patch(empty_value = false)]
     #[patch(attribute(serde(default)))]
-    #[patch(attribute(doc = "Enable continuous Keepalive"))]
-    pub keepalive_continuous: bool,
+    #[patch(attribute(doc = "Disable continuous keepalive"))]
+    pub disable_keepalive_continuous: bool,
 
     #[patch(attribute(clap(long)))]
     #[patch(attribute(doc = r#"Time it takes to trigger a tracer packet
@@ -480,7 +480,7 @@ impl Default for Config {
             keyshare: KeyShare::default(),
             keepalive_interval: NonZeroDuration::from_std_duration(StdDuration::from_secs(10)),
             keepalive_timeout: NonZeroDuration::from_std_duration(StdDuration::from_secs(60)),
-            keepalive_continuous: true,
+            disable_keepalive_continuous: false,
             tracer_packet_timeout: NonZeroDuration::from_std_duration(StdDuration::from_secs(10)),
             preferred_connection_wait_interval: Duration::from_std_duration(
                 StdDuration::from_secs(0),

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -323,7 +323,7 @@ impl<ExtAppState: Send + Sync> ClientConfig<ExtAppState> {
             expresslane_metrics: None,
             keepalive_interval: config.keepalive_interval.into(),
             keepalive_timeout: config.keepalive_timeout.into(),
-            continuous_keepalive: config.keepalive_continuous,
+            continuous_keepalive: !config.disable_keepalive_continuous,
             tracer_packet_timeout: config.tracer_packet_timeout.into(),
             preferred_connection_wait_interval: config.preferred_connection_wait_interval.into(),
             sndbuf: config.sndbuf,

--- a/lightway-client/src/mobile/lightway.rs
+++ b/lightway-client/src/mobile/lightway.rs
@@ -214,7 +214,7 @@ pub(crate) async fn async_lightway_start(
                     connect_conf,
                     sni_header: config.sni_header.clone(),
                     socket: outside_sockets[instance_id].take(),
-                    enable_keepalive: config.keepalive_continuous,
+                    enable_keepalive: !config.disable_keepalive_continuous,
                     enable_expresslane: config.enable_expresslane,
                     expresslane_keys_rotation_interval: config
                         .expresslane_keys_rotation_interval

--- a/tests/client/client_config.yaml
+++ b/tests/client/client_config.yaml
@@ -18,7 +18,6 @@ enable_tun_iouring: false
 iouring_entry_count: 1024
 keepalive_interval: 10s
 keepalive_timeout: 30s
-keepalive_continuous: true
 enable_expresslane: false
 enable_pmtud: false
 # sndbuf: 1.5 MiB


### PR DESCRIPTION
# client: cli: allow disable keepalive_continuous via CLI

## Description

Renames the `keepalive_continuous` config field to `disable_keepalive_continuous` and exposes it as a `--disable-keepalive-continuous` CLI flag. The internal `continuous_keepalive` value is derived by negating this field, so the runtime behaviour is unchanged when the flag is not set.

## Motivation and Context

Continuous keepalive is enabled by default. The previous field name (`keepalive_continuous`) implied an opt-in, but since the feature is always on there was no CLI way to turn it off. Inverting the flag to `--disable-keepalive-continuous` makes the default state implicit and gives operators a clear opt-out when they need to disable the feature.

**Why not `--keepalive-continuous=false`?**

The `LW_CLIENT_*` environment variable convention is the reason. When `LW_CLIENT_KEEPALIVE_CONTINUOUS` is unset, it is generally interpreted as false, which would inadvertently disable continuous keepalive. For a feature that is enabled by default, a `--disable-*` flag is the more correct and predictable design.

## How Has This Been Tested?

- Verified that the `Default` impl still produces `continuous_keepalive = true` (i.e. `disable_keepalive_continuous = false`).
- Manually confirmed that passing `--disable-keepalive-continuous` on the CLI sets `continuous_keepalive = false` in the resulting `ClientConfig`.
- Existing unit and integration test suites pass with no changes required.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
