### PR TITLE
Add tx/rx bytes in expresslane metrics

### DIFF
--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -1779,6 +1779,19 @@ impl<AppState: Send> Connection<AppState> {
         loss_ratio > PACKET_LOSS_RATIO_THRESHOLD
     }
 
+    /// Fold one keepalive window into a direction's strike counter, as a
+    /// leaky bucket: a bad window adds one, a good window drains one.
+    /// Draining rather than clearing is what stops an attacker from
+    /// resetting the count with one clean window between drop bursts.
+    /// Returns the updated count and whether it now warrants degrading.
+    fn advance_strikes(strikes: u8, sent: u64, received: u64) -> (u8, bool) {
+        if !Self::has_packet_drops(sent, received) {
+            return (strikes.saturating_sub(1), false);
+        }
+        let strikes = strikes.saturating_add(1);
+        (strikes, strikes >= expresslane::EXPRESSLANE_DEGRADE_STRIKES)
+    }
+
     /// Check expresslane health from keepalive pong payload
     ///  and disable if packet drops detected
     fn check_expresslane_health(&mut self, mut payload: &[u8]) -> ConnectionResult<()> {
@@ -1794,8 +1807,8 @@ impl<AppState: Send> Connection<AppState> {
         // Detect counter reset: cumulative stats should never decrease.
         // If they do, an external stats provider re-initialized its state
         // with fresh counters. Log for debugging but continue with the
-        // health check — the underflow will trigger degradation and fall
-        // back to DTLS as a safe default.
+        // health check — the underflow reads as loss, so a reset that
+        // persists degrades to DTLS as a safe default.
         if total_peer_sent < self.expresslane.prev_peer_sent
             || total_peer_recv < self.expresslane.prev_peer_recv
         {
@@ -1837,14 +1850,26 @@ impl<AppState: Send> Connection<AppState> {
         );
 
         // Inbound packet drops
-        if Self::has_packet_drops(peer_sent_delta, my_recv_delta) {
+        let (inbound_strikes, degrade) = Self::advance_strikes(
+            self.expresslane.inbound_strikes,
+            peer_sent_delta,
+            my_recv_delta,
+        );
+        self.expresslane.inbound_strikes = inbound_strikes;
+        if degrade {
             warn!("Expresslane degraded (INBOUND): Falling back to DTLS");
             self.set_expresslane_degraded();
             return Ok(());
         }
 
         // Outbound packet drops
-        if Self::has_packet_drops(my_sent_delta, peer_recv_delta) {
+        let (outbound_strikes, degrade) = Self::advance_strikes(
+            self.expresslane.outbound_strikes,
+            my_sent_delta,
+            peer_recv_delta,
+        );
+        self.expresslane.outbound_strikes = outbound_strikes;
+        if degrade {
             warn!("Expresslane degraded (OUTBOUND): Falling back to DTLS");
             self.set_expresslane_degraded();
             return Ok(());
@@ -2625,5 +2650,90 @@ impl<AppState: Send> Connection<AppState> {
 
         let msg = wire::Frame::EncodingRequest(pending_request_pkt.clone());
         self.send_frame_or_queue(msg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `advance_strikes` ignores AppState; pick the simplest `Send` type.
+    type Conn = Connection<()>;
+
+    const BAD: (u64, u64) = (100, 0); // 100% loss
+    const GOOD: (u64, u64) = (100, 100);
+    const BELOW_MIN: (u64, u64) = (9, 0); // under MIN_PACKETS_FOR_LOSS_CHECK
+
+    #[test]
+    fn single_bad_window_does_not_degrade() {
+        assert_eq!(Conn::advance_strikes(0, BAD.0, BAD.1), (1, false));
+    }
+
+    #[test]
+    fn consecutive_bad_windows_degrade() {
+        let threshold = expresslane::EXPRESSLANE_DEGRADE_STRIKES;
+        let mut strikes = 0;
+        for window in 1..threshold {
+            let degrade;
+            (strikes, degrade) = Conn::advance_strikes(strikes, BAD.0, BAD.1);
+            assert_eq!((strikes, degrade), (window, false));
+        }
+        assert_eq!(
+            Conn::advance_strikes(strikes, BAD.0, BAD.1),
+            (threshold, true)
+        );
+    }
+
+    #[test]
+    fn good_window_drains_one_strike() {
+        let (strikes, _) = Conn::advance_strikes(0, BAD.0, BAD.1);
+        let (strikes, _) = Conn::advance_strikes(strikes, BAD.0, BAD.1);
+        assert_eq!(strikes, 2);
+        assert_eq!(
+            Conn::advance_strikes(strikes, GOOD.0, GOOD.1),
+            (1, false),
+            "a clean window drains one strike, it does not clear the bucket"
+        );
+    }
+
+    #[test]
+    fn drain_floors_at_zero() {
+        assert_eq!(Conn::advance_strikes(0, GOOD.0, GOOD.1), (0, false));
+    }
+
+    /// An attacker alternating (threshold - 1) bad windows with one clean
+    /// window would evade a reset-on-good counter forever. Draining makes
+    /// the bucket climb anyway.
+    #[test]
+    fn pulsed_drops_still_degrade() {
+        let threshold = expresslane::EXPRESSLANE_DEGRADE_STRIKES;
+        let mut strikes = 0;
+        for _ in 0..10 {
+            for _ in 0..threshold - 1 {
+                let degrade;
+                (strikes, degrade) = Conn::advance_strikes(strikes, BAD.0, BAD.1);
+                if degrade {
+                    return;
+                }
+            }
+            (strikes, _) = Conn::advance_strikes(strikes, GOOD.0, GOOD.1);
+        }
+        panic!("pulsed drop pattern never degraded, bucket stuck at {strikes}");
+    }
+
+    #[test]
+    fn idle_window_is_not_a_strike() {
+        assert_eq!(
+            Conn::advance_strikes(1, BELOW_MIN.0, BELOW_MIN.1),
+            (0, false)
+        );
+    }
+
+    #[test]
+    fn strikes_saturate_instead_of_wrapping() {
+        assert_eq!(
+            Conn::advance_strikes(u8::MAX, BAD.0, BAD.1),
+            (u8::MAX, true)
+        );
     }
 }

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -643,6 +643,24 @@ impl<AppState: Send> Connection<AppState> {
         self.activity
     }
 
+    /// Refresh activity timestamps from offloaded (kernel-path) traffic that
+    /// never reaches the userspace data path. Kept kernel-ref-free: the caller
+    /// (the offload stats poller) decides when to call it from kernel counter
+    /// deltas. `rx` (peer -> us) bumps both the peer-data and outside-data
+    /// timestamps; `tx` (us -> peer) refreshes only the outside-data timestamp
+    /// so a download keeps the connection out of idle-eviction without marking
+    /// the peer as actively sending.
+    pub fn mark_offload_activity(&mut self, rx: bool, tx: bool) {
+        let now = Instant::now();
+        if rx {
+            self.activity.last_data_traffic_from_peer = now;
+            self.activity.last_outside_data_received = now;
+        }
+        if tx {
+            self.activity.last_outside_data_received = now;
+        }
+    }
+
     /// Query the TLS protocol version of this connection, only valid
     /// after [`State::LinkUp`] has been reached.
     pub fn tls_protocol_version(&mut self) -> ProtocolVersion {

--- a/lightway-core/src/connection/expresslane.rs
+++ b/lightway-core/src/connection/expresslane.rs
@@ -41,10 +41,14 @@ pub(crate) const EXPRESSLANE_DEGRADE_STRIKES: u8 = 3;
 /// Packet counters for ExpressLane health monitoring.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ExpresslanePacketStats {
-    /// Total sent via expresslane
-    pub sent: u64,
-    /// Total received via expresslane
-    pub received: u64,
+    /// Total packets sent via expresslane
+    pub sent_packets: u64,
+    /// Total packets received via expresslane
+    pub received_packets: u64,
+    /// Total bytes sent via expresslane
+    pub sent_bytes: u64,
+    /// Total bytes received via expresslane
+    pub received_bytes: u64,
 }
 
 /// Provider of ExpressLane packet metrics.
@@ -127,7 +131,7 @@ impl<AppState: Send> Expresslane<AppState> {
         match &self.metrics {
             Some(provider) => {
                 let stats = provider.get_stats(session_id);
-                (stats.sent, stats.received)
+                (stats.sent_packets, stats.received_packets)
             }
             None => (self.data.packets_sent(), self.data.packets_received()),
         }

--- a/lightway-core/src/connection/expresslane.rs
+++ b/lightway-core/src/connection/expresslane.rs
@@ -33,6 +33,11 @@ pub type ExpresslaneCbType<AppState> = Arc<dyn ExpresslaneCb<AppState> + Sync + 
 /// Default interval between expresslane key rotations
 pub const DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL: Duration = Duration::from_mins(15);
 
+/// Strike-bucket level at which a direction degrades expresslane. A single
+/// over-threshold window can be an artifact of bursty traffic straddling
+/// the peer's counter snapshot, so one is never enough.
+pub(crate) const EXPRESSLANE_DEGRADE_STRIKES: u8 = 3;
+
 /// Packet counters for ExpressLane health monitoring.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ExpresslanePacketStats {
@@ -77,6 +82,10 @@ pub(crate) struct Expresslane<AppState: Send> {
     pub(crate) last_snapshot_sent: u64,
     /// Packets received at the time of last keepalive exchange
     pub(crate) last_snapshot_recv: u64,
+    /// Inbound loss strike bucket; +1 per bad window, -1 per good one
+    pub(crate) inbound_strikes: u8,
+    /// Outbound loss strike bucket; +1 per bad window, -1 per good one
+    pub(crate) outbound_strikes: u8,
     /// Wire-level crypto engine (encrypt/decrypt/serialize)
     pub(crate) data: ExpresslaneData,
     /// Callback invoked on session key updates so the application can
@@ -104,6 +113,8 @@ impl<AppState: Send> Expresslane<AppState> {
             prev_peer_recv: 0,
             last_snapshot_sent: 0,
             last_snapshot_recv: 0,
+            inbound_strikes: 0,
+            outbound_strikes: 0,
             data: ExpresslaneData::default(),
             cb,
             metrics,

--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -950,3 +950,51 @@ async fn test_server_dn(server_dn: Option<&str>) {
         .await
         .expect("Timed out");
 }
+
+/// Builds a `Connection` by reusing the `client()` construction pattern
+/// above (`ClientContextBuilder` -> `start_connect` -> `with_auth_token` ->
+/// `connect`), trimmed down to just the construction step - no handshake is
+/// driven. `Connection::new` performs one (pending) TLS negotiation attempt
+/// internally, which is enough to exercise `mark_offload_activity` without
+/// needing the full client/server event loop.
+#[tokio::test]
+async fn mark_offload_activity_bumps_by_rule() {
+    let (client_sock, _server_sock) = UnixStream::pair().expect("UnixStream");
+    let client_sock = Arc::new(TestStreamSock(client_sock));
+
+    let ca_cert = RootCertificate::Asn1Buffer(CA_CERT);
+    let (ticker, _ticker_task) = ConnectionTicker::new();
+    let state = ConnectionState { ticker };
+
+    let mut conn = ClientContextBuilder::new(
+        client_sock.connection_type(),
+        ca_cert,
+        None,
+        Arc::new(Client),
+        connection_ticker_cb,
+    )
+    .unwrap()
+    .build()
+    .start_connect(client_sock.clone().into_io_send_callback(), MAX_OUTSIDE_MTU)
+    .unwrap()
+    .with_auth_token("LET ME IN")
+    .connect(state)
+    .unwrap();
+
+    let before = conn.activity();
+    std::thread::sleep(std::time::Duration::from_millis(2));
+
+    conn.mark_offload_activity(false, true); // tx only
+    let after_tx = conn.activity();
+    assert!(after_tx.last_outside_data_received > before.last_outside_data_received);
+    assert_eq!(
+        after_tx.last_data_traffic_from_peer,
+        before.last_data_traffic_from_peer
+    );
+
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    conn.mark_offload_activity(true, false); // rx bumps both
+    let after_rx = conn.activity();
+    assert!(after_rx.last_data_traffic_from_peer > before.last_data_traffic_from_peer);
+    assert!(after_rx.last_outside_data_received > after_tx.last_outside_data_received);
+}

--- a/lightway-server/src/connection.rs
+++ b/lightway-server/src/connection.rs
@@ -102,6 +102,7 @@ impl Connection {
             pub fn tls_protocol_version(&self) -> ProtocolVersion;
             pub fn connection_type(&self) -> ConnectionType;
             pub fn session_id(&self) -> SessionId;
+            pub fn mark_offload_activity(&self, rx: bool, tx: bool);
             pub fn peer_addr(&self) -> SocketAddr;
             pub fn set_peer_addr(&self, addr: SocketAddr) -> SocketAddr;
             pub fn current_cipher(&self) -> Option<String>;

--- a/lightway-server/src/connection_manager.rs
+++ b/lightway-server/src/connection_manager.rs
@@ -530,6 +530,18 @@ impl ConnectionManager {
             .collect()
     }
 
+    /// Snapshot of the currently-online connections (Arc clones). The map
+    /// lock is released with the returned Vec, so callers can do per-connection
+    /// work (e.g. a kernel ioctl) without holding it - unlike iter_connections.
+    pub(crate) fn online_connections(self: &Arc<Self>) -> Vec<Arc<Connection>> {
+        self.connections
+            .lock()
+            .iter_connections()
+            .filter(|c| matches!(c.state(), State::Online))
+            .cloned()
+            .collect()
+    }
+
     #[instrument(level = "trace", skip_all)]
     fn evict_idle_connections(&self) {
         tracing::trace!("Aging connections");

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -4,6 +4,7 @@ mod connection_manager;
 mod io;
 mod ip_manager;
 pub mod metrics;
+mod offload_stats;
 mod statistics;
 
 // re-export so server app does not need to depend on lightway-core
@@ -633,6 +634,15 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
     );
 
     let mut send_queue: Option<Arc<SendQueue>> = None;
+
+    if let Some(provider) = config.expresslane_metrics.clone() {
+        tokio::spawn(offload_stats::run(
+            conn_manager.clone(),
+            provider,
+            offload_stats::DEFAULT_OFFLOAD_STATS_INTERVAL,
+        ));
+    }
+
     let mut server: Box<dyn Server> = match connection_type {
         ServerConnectionMode::Datagram(may_be_sock) => {
             let udp_server = io::outside::UdpServer::new(

--- a/lightway-server/src/metrics.rs
+++ b/lightway-server/src/metrics.rs
@@ -87,6 +87,10 @@ static METRIC_TUN_FROM_CLIENT: LazyLock<Counter> = LazyLock::new(|| counter!("tu
 static METRIC_TUN_TO_CLIENT: LazyLock<Counter> = LazyLock::new(|| counter!("tun_to_client"));
 static METRIC_TUN_RECV_BATCH_SIZE: LazyLock<Histogram> =
     LazyLock::new(|| histogram!("tun_recv_batch_size"));
+static METRIC_EXPRESSLANE_OFFLOAD_TX_BYTES: LazyLock<Counter> =
+    LazyLock::new(|| counter!("expresslane_offload_tx_bytes"));
+static METRIC_EXPRESSLANE_OFFLOAD_RX_BYTES: LazyLock<Counter> =
+    LazyLock::new(|| counter!("expresslane_offload_rx_bytes"));
 
 static METRIC_SESSIONS_CURRENT_ONLINE: LazyLock<Gauge> =
     LazyLock::new(|| gauge!("sessions_current_online"));
@@ -383,6 +387,15 @@ pub fn tun_to_client(sz: usize) {
 /// Number of packets returned by one batched inside-IO receive.
 pub fn tun_recv_batch(sz: usize) {
     METRIC_TUN_RECV_BATCH_SIZE.record(sz as f64);
+}
+
+/// Bytes sent to the peer over the kernel-offload (expresslane) path.
+pub fn expresslane_offload_tx_bytes(sz: u64) {
+    METRIC_EXPRESSLANE_OFFLOAD_TX_BYTES.increment(sz);
+}
+/// Bytes received from the peer over the kernel-offload (expresslane) path.
+pub fn expresslane_offload_rx_bytes(sz: u64) {
+    METRIC_EXPRESSLANE_OFFLOAD_RX_BYTES.increment(sz);
 }
 
 /// Current session statistics

--- a/lightway-server/src/offload_stats.rs
+++ b/lightway-server/src/offload_stats.rs
@@ -1,0 +1,132 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use lightway_core::{ExpresslaneMetricsType, ExpresslanePacketStats, SessionId};
+use tokio_stream::StreamExt;
+
+use crate::connection_manager::ConnectionManager;
+
+/// Per-session cumulative counters last observed by the poll.
+#[derive(Clone, Copy, Default)]
+struct Seen {
+    sent_packets: u64,
+    received_packets: u64,
+    sent_bytes: u64,
+    received_bytes: u64,
+}
+
+/// Decide what a poll tick does for one session given the previous observation
+/// (None = first time seen) and the current cumulative stats. Returns
+/// (rx_active, tx_active, rx_bytes_delta, tx_bytes_delta). First observation
+/// records a baseline and does nothing (all false / 0) so a rotation - where a
+/// new session id inherits carried-over cumulative counters - can't spike.
+fn decide(prev: Option<Seen>, cur: ExpresslanePacketStats) -> (bool, bool, u64, u64) {
+    match prev {
+        None => (false, false, 0, 0),
+        Some(p) => {
+            let rx = cur.received_packets > p.received_packets;
+            let tx = cur.sent_packets > p.sent_packets;
+            let rx_bytes = cur.received_bytes.saturating_sub(p.received_bytes);
+            let tx_bytes = cur.sent_bytes.saturating_sub(p.sent_bytes);
+            (rx, tx, rx_bytes, tx_bytes)
+        }
+    }
+}
+
+/// Default interval between offload-stats polls.
+pub const DEFAULT_OFFLOAD_STATS_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Periodically pull each online session's kernel-offload counters via the
+/// ExpresslaneMetrics provider and (a) refresh the connection activity
+/// timestamps so offloaded sessions classify active / don't idle-evict, and
+/// (b) emit aggregate offload byte metrics. Kernel-ref-free: the ioctl lives
+/// behind `metrics`.
+pub(crate) async fn run(
+    conn_manager: Arc<ConnectionManager>,
+    metrics: ExpresslaneMetricsType,
+    interval: Duration,
+) {
+    let weak = Arc::downgrade(&conn_manager);
+    let mut seen: HashMap<SessionId, Seen> = HashMap::new();
+
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut ticker = tokio_stream::wrappers::IntervalStream::new(ticker);
+
+    while ticker.next().await.is_some() {
+        let Some(conn_manager) = weak.upgrade() else {
+            return;
+        };
+        let conns = conn_manager.online_connections();
+        let mut live: std::collections::HashSet<SessionId> = std::collections::HashSet::new();
+
+        for conn in conns {
+            let sid = conn.session_id();
+            live.insert(sid);
+            let cur = metrics.get_stats(sid);
+            let (rx, tx, rx_bytes, tx_bytes) = decide(seen.get(&sid).copied(), cur);
+            if rx || tx {
+                conn.mark_offload_activity(rx, tx);
+            }
+            if rx_bytes > 0 {
+                crate::metrics::expresslane_offload_rx_bytes(rx_bytes);
+            }
+            if tx_bytes > 0 {
+                crate::metrics::expresslane_offload_tx_bytes(tx_bytes);
+            }
+            seen.insert(
+                sid,
+                Seen {
+                    sent_packets: cur.sent_packets,
+                    received_packets: cur.received_packets,
+                    sent_bytes: cur.sent_bytes,
+                    received_bytes: cur.received_bytes,
+                },
+            );
+        }
+        seen.retain(|sid, _| live.contains(sid));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stats(sent: u64, received: u64, sb: u64, rb: u64) -> ExpresslanePacketStats {
+        ExpresslanePacketStats {
+            sent_packets: sent,
+            received_packets: received,
+            sent_bytes: sb,
+            received_bytes: rb,
+        }
+    }
+
+    #[test]
+    fn first_seen_is_baseline_only() {
+        assert_eq!(decide(None, stats(5, 9, 500, 900)), (false, false, 0, 0));
+    }
+
+    #[test]
+    fn rx_and_tx_deltas() {
+        let prev = Some(Seen {
+            sent_packets: 5,
+            received_packets: 9,
+            sent_bytes: 500,
+            received_bytes: 900,
+        });
+        assert_eq!(decide(prev, stats(5, 12, 500, 1200)), (true, false, 300, 0));
+        assert_eq!(decide(prev, stats(8, 9, 800, 900)), (false, true, 0, 300));
+    }
+
+    #[test]
+    fn no_growth_is_noop() {
+        let prev = Some(Seen {
+            sent_packets: 5,
+            received_packets: 9,
+            sent_bytes: 500,
+            received_bytes: 900,
+        });
+        assert_eq!(decide(prev, stats(5, 9, 500, 900)), (false, false, 0, 0));
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add support to export tx/rx bytes in expresslane metrics in case of offloaded path

Also make expresslane healthcheck use strikes instead of degrading in single failure. Will avoid spurious degrades.

## Motivation and Context

Add metrics to expresslane data path

## How Has This Been Tested?

Added unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
