### PR TITLE
CVPN-2671: Downgrade inside packet codec if stalled

### DIFF
--- a/docs/inside_packet_codec.md
+++ b/docs/inside_packet_codec.md
@@ -142,3 +142,16 @@ to encoding requests with its id higher or equal to the id of the most recently 
 
 The number of re-transmission is limited by a constant to avoid wasting network resources in case the server does not have encoding enabled. If the client
 cannot receive a response after the maximum number of re-transmissions has been attempted, the request is considered as failed.
+
+## Data-Plane Stall Detection
+A faulty codec can silently black-hole the data plane: its encoder accepts inside packets (`PacketAccepted`) but never emits the encoded packets, so nothing
+reaches the tunnel. Keepalive cannot detect this, because keepalive ping/pong are control frames that bypass the codec and keep flowing, so the connection
+still looks alive while every inside packet is dropped.
+
+To catch this, the client tracks when a decoded packet was last delivered to the inside path. Control frames (such as keepalive) are deliberately excluded, so
+this reflects real data-plane delivery. If encoding is enabled but nothing has been delivered to the inside path within `ClientConfig::inside_pkt_codec_stall_timeout`,
+the client disables the codec through the [encoding request](#encoding-request) mechanism, downgrading to unencoded traffic instead of tearing the tunnel down.
+A single request is issued per stall episode.
+
+The check is evaluated on the inside-to-outside path, so it only runs while the client is sending traffic; an idle connection is never downgraded. A timeout of
+`Duration::ZERO` (the default) disables the check.

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -248,6 +248,12 @@ pub struct ClientConfig<ExtAppState: Send + Sync> {
     /// Inside packet codec's config
     pub inside_pkt_codec_config: Option<ClientInsidePacketCodecConfig>,
 
+    /// When the inside packet codec is active and the user is pushing traffic
+    /// but no decoded packet has reached the inside path within this timeout,
+    /// tear down the tunnel to force a reconnect. `Duration::ZERO` disables the
+    /// check (default)
+    pub inside_pkt_codec_stall_timeout: Duration,
+
     /// Signal for notifying a network change event
     /// network change being defined as a change in
     /// wifi networks or a change of network interfaces
@@ -343,6 +349,7 @@ impl<ExtAppState: Send + Sync> ClientConfig<ExtAppState> {
             #[cfg(feature = "io-uring")]
             iouring_sqpoll_idle_time: config.iouring_sqpoll_idle_time.into(),
             inside_pkt_codec_config: None,
+            inside_pkt_codec_stall_timeout: Duration::ZERO,
             config_reload_signal,
             network_change_signal: None,
             best_connection_selected_signal: None,
@@ -632,6 +639,7 @@ pub async fn inside_io_task<ExtAppState: Send + Sync>(
     tun_dns_ip: Ipv4Addr,
     keepalive: Keepalive,
     keepalive_config: KeepaliveConfig,
+    inside_pkt_codec_stall_timeout: Duration,
 ) -> Result<()> {
     let tracer_trigger_timeout = if keepalive_config.continuous {
         Duration::ZERO
@@ -673,7 +681,26 @@ pub async fn inside_io_task<ExtAppState: Send + Sync>(
             }
 
             match conn.inside_data_received(&mut buf) {
-                Ok(()) => conn.activity().last_outside_data_received,
+                Ok(()) => {
+                    // If the inside packet codec has stalled the data plane, downgrade to
+                    // unencoded rather than tearing the tunnel down. Control frames bypass
+                    // the codec, so keepalive/tracer can't detect this on their own.
+                    match conn.downgrade_inside_pkt_codec_if_stalled(inside_pkt_codec_stall_timeout)
+                    {
+                        Ok(true) => {
+                            tracing::warn!(
+                                "inside packet codec data-plane stalled; disabling codec"
+                            )
+                        }
+                        Ok(false) => {}
+                        Err(e) => {
+                            tracing::error!(
+                                "failed to disable inside packet codec after stall: {e}"
+                            )
+                        }
+                    }
+                    conn.activity().last_outside_data_received
+                }
                 Err(ConnectionError::PluginDropWithReply(reply)) => {
                     // Send the reply packet to inside path
                     let _ = inside_io.try_send(reply, ip_config);
@@ -1105,6 +1132,7 @@ pub async fn connect<
         config.tun_dns_ip,
         keepalive.clone(),
         keepalive_config,
+        config.inside_pkt_codec_stall_timeout,
     ));
 
     let (network_change_tx, network_change_rx) = tokio::sync::mpsc::channel(1);

--- a/lightway-client/src/mobile/lightway.rs
+++ b/lightway-client/src/mobile/lightway.rs
@@ -394,6 +394,7 @@ pub(crate) async fn async_lightway_start(
         config.tun_dns_ip,
         keepalive,
         keepalive_config,
+        Duration::ZERO,
     ));
 
     tokio::select! {

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -347,6 +347,11 @@ pub struct ConnectionActivity {
     /// When the last `wire::Frame::Data` from peer (going to inside
     /// path) was seen.
     pub last_data_traffic_from_peer: Instant,
+
+    /// When a decoded packet was last delivered to the inside/TUN path.
+    /// Unlike `last_outside_data_received`, control frames (ping/pong) never
+    /// touch this, so it reflects real data-plane delivery.
+    pub last_data_delivered_to_inside: Instant,
 }
 
 /// The result of an operation on a [`Connection`].
@@ -518,6 +523,7 @@ impl<AppState: Send> Connection<AppState> {
             activity: ConnectionActivity {
                 last_data_traffic_from_peer: now,
                 last_outside_data_received: now,
+                last_data_delivered_to_inside: now,
             },
             tls_tick_interval: None,
             tls_pending_queue: VecDeque::new(),
@@ -840,6 +846,7 @@ impl<AppState: Send> Connection<AppState> {
     /// Update TLS Session to use the new outside IO Callback
     pub fn set_outside_io(&mut self, new_io: OutsideIOSendCallbackArg) {
         self.session.io_cb_mut().io = new_io;
+        self.activity.last_data_delivered_to_inside = Instant::now();
     }
 
     /// Accept some data from outside and run an iteration of the I/O
@@ -2323,6 +2330,7 @@ impl<AppState: Send> Connection<AppState> {
         }
 
         self.activity.last_data_traffic_from_peer = Instant::now();
+        self.activity.last_data_delivered_to_inside = Instant::now();
         match inside_io.send(inside_pkt, &mut self.app_state) {
             IOCallbackResult::Ok(_nr) => {}
             IOCallbackResult::Err(err) => {
@@ -2544,6 +2552,39 @@ impl<AppState: Send> Connection<AppState> {
         );
 
         self.send_frame_or_queue(msg)
+    }
+
+    /// Data-plane stall guard for the inside packet codec. (Client only)
+    ///
+    /// When the codec is active but no decoded packet has reached the inside
+    /// path within `timeout`, the codec is black-holing the data plane: control
+    /// frames (keepalive) bypass the codec, so the tunnel still looks alive and
+    /// neither keepalive nor the tracer can observe the failure. Request
+    /// disabling the codec so traffic falls back to unencoded, rather than
+    /// tearing the tunnel down.
+    ///
+    /// Returns `true` if a disable request was sent this call. A single stall
+    /// episode sends one request: calls are suppressed while a request is
+    /// pending and once encoding is off. `timeout == ZERO` disables the check.
+    pub fn downgrade_inside_pkt_codec_if_stalled(
+        &mut self,
+        timeout: Duration,
+    ) -> ConnectionResult<bool> {
+        if timeout.is_zero() || !self.is_encoding_enabled() {
+            return Ok(false);
+        }
+        // A codec change is already in flight; wait for it to resolve.
+        if self.encoding_request_states.pending_request_pkt.is_some() {
+            return Ok(false);
+        }
+        let stalled = Instant::now()
+            .saturating_duration_since(self.activity.last_data_delivered_to_inside)
+            > timeout;
+        if !stalled {
+            return Ok(false);
+        }
+        self.set_encoding(false)?;
+        Ok(true)
     }
 
     /// Attempts to retransmit the currently pending encoding request packet. (Client only)

--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -22,7 +22,7 @@ use lightway_app_utils::{
 use lightway_core::*;
 
 mod packet_codec;
-use packet_codec::TestPacketCodecFactory;
+use packet_codec::{BlackHolePacketCodecFactory, TestPacketCodecFactory};
 
 const CA_CERT: &[u8] = &include!("data/ca_cert_der_2048");
 const SERVER_CERT: &[u8] = &include!("data/server_cert_der_2048");
@@ -161,11 +161,11 @@ impl OutsideIOSendCallback for TestDatagramSock {
     fn send(&self, buf: &[u8]) -> IOCallbackResult<usize> {
         match self.0.try_send(buf) {
             Ok(nr) => IOCallbackResult::Ok(nr),
-            Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
-                // Real sockets never block (and doing so confuses the TLS library!), but they do drop, so we do too!
-                IOCallbackResult::Ok(buf.len())
-            }
-            Err(err) => IOCallbackResult::Err(err),
+            // Real datagram sockets never block (blocking confuses the TLS library),
+            // but they do drop. A full send buffer surfaces as WouldBlock on Linux and
+            // ENOBUFS on macOS; both are just a drop, so report success and let DTLS
+            // retransmit rather than propagating a fatal socket error to wolfSSL.
+            Err(_) => IOCallbackResult::Ok(buf.len()),
         }
     }
 
@@ -819,6 +819,151 @@ async fn test_datagram_connection(
         false,
     )
     .await;
+}
+
+/// A black-hole inside packet codec accepts every outbound packet but never
+/// emits it, so once encoding is enabled the data plane silently stalls while
+/// control frames (which bypass the codec) keep the tunnel alive. Verify the
+/// client detects the stall via `downgrade_inside_pkt_codec_if_stalled` and
+/// disables the codec, rather than depending on keepalive which cannot observe
+/// a codec-level black-hole.
+#[tokio::test]
+async fn inside_pkt_codec_stall_triggers_codec_downgrade() {
+    const STALL_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(50);
+
+    let (client_sock, server_sock) = UnixDatagram::pair().expect("UnixDatagram");
+    let server_sock = Arc::new(TestDatagramSock(server_sock));
+    let client_sock = Arc::new(TestDatagramSock(client_sock));
+
+    let (auth, _last_method) = TestAuth::new();
+    let pqc = PQCrypto {
+        server_pqc: false,
+        keyshare: None,
+    };
+
+    // Server reflects inside data and ACKs the client's encoding requests.
+    let mut server_task = tokio::spawn(server(server_sock, auth, pqc, false));
+
+    let ca_cert = RootCertificate::Asn1Buffer(CA_CERT);
+    let (tun, _inside_rx) = ChannelTun::new();
+    let (event_cb, mut event_stream) = EventStreamCallback::new();
+
+    let packet_codec = BlackHolePacketCodecFactory::default().build();
+    let encoder = packet_codec.encoder.clone();
+    let (packet_codec, mut encoded_pkt_receiver, mut decoded_pkt_receiver) = (
+        Some((packet_codec.encoder, packet_codec.decoder)),
+        packet_codec.encoded_pkt_receiver,
+        packet_codec.decoded_pkt_receiver,
+    );
+
+    let (ticker, ticker_task) = ConnectionTicker::new();
+    let state = ConnectionState { ticker };
+
+    let client = ClientContextBuilder::new(
+        client_sock.connection_type(),
+        ca_cert,
+        Some(Arc::new(tun)),
+        Arc::new(Client),
+        connection_ticker_cb,
+    )
+    .unwrap()
+    .build()
+    .start_connect(client_sock.clone().into_io_send_callback(), MAX_OUTSIDE_MTU)
+    .unwrap()
+    .with_auth_token("LET ME IN")
+    .with_event_cb(Box::new(event_cb))
+    .with_inside_pkt_codec(packet_codec)
+    .connect(state)
+    .unwrap();
+    let client = Arc::new(Mutex::new(client));
+
+    let mut join_set = JoinSet::new();
+    ticker_task.spawn_in(Arc::downgrade(&client), &mut join_set);
+
+    // Drain events so the stream never backpressures the connection.
+    tokio::spawn(async move { while event_stream.next().await.is_some() {} });
+
+    #[derive(PartialEq, Debug)]
+    enum Step {
+        Connecting,
+        EncodingRequested,
+        MessageSent,
+        Downgraded,
+    }
+    let mut step = Step::Connecting;
+    let mut stall_check = tokio::time::interval(std::time::Duration::from_millis(10));
+
+    let driver = async {
+        loop {
+            tokio::select! {
+                // inside -> outside: the black-hole encoder never emits, so this stays
+                // silent once encoding is enabled.
+                Some(mut encoded) = encoded_pkt_receiver.recv() => {
+                    client.lock().unwrap().send_to_outside(&mut encoded, true).expect("send encoded");
+                }
+                Some(decoded) = decoded_pkt_receiver.recv() => {
+                    client.lock().unwrap().send_to_inside(decoded).expect("send decoded");
+                }
+                is_readable = client_sock.readable() => {
+                    is_readable.expect("client socket readable");
+                    let mut buf = BytesMut::with_capacity(MAX_OUTSIDE_MTU);
+                    match client_sock.try_recv_buf(&mut buf) {
+                        Ok(0) => panic!("EOF"),
+                        Ok(_) => {}
+                        Err(e) if matches!(e.kind(), std::io::ErrorKind::WouldBlock) => continue,
+                        Err(e) => panic!("client recv: {e}"),
+                    }
+                    let mut c = client.lock().unwrap();
+                    let pkt = OutsidePacket::Wire(&mut buf, client_sock.connection_type());
+                    c.outside_data_received(pkt).expect("outside data received");
+                    if !matches!(c.state(), State::Online) {
+                        continue;
+                    }
+                    match step {
+                        Step::Connecting => {
+                            c.set_encoding(true).expect("enable encoding");
+                            step = Step::EncodingRequested;
+                        }
+                        Step::EncodingRequested if encoder.get_encoding_state() => {
+                            // Codec is enabled: push a packet the black-hole encoder drops.
+                            let mut msg = BytesMut::from(&b"\x40Hello World!"[..]);
+                            c.inside_data_received(&mut msg).expect("send message");
+                            step = Step::MessageSent;
+                        }
+                        _ => {}
+                    }
+                }
+                _ = stall_check.tick() => {
+                    let mut c = client.lock().unwrap();
+                    match step {
+                        Step::MessageSent => {
+                            if c
+                                .downgrade_inside_pkt_codec_if_stalled(STALL_TIMEOUT)
+                                .expect("stall check")
+                            {
+                                step = Step::Downgraded;
+                            }
+                        }
+                        // Server ACKed the disable: the codec is off, fix confirmed.
+                        Step::Downgraded if !encoder.get_encoding_state() => return,
+                        _ => {}
+                    }
+                }
+            }
+        }
+    };
+
+    tokio::time::timeout(
+        std::time::Duration::from_millis(get_test_timeout()),
+        async {
+            tokio::select! {
+                _ = driver => {}
+                r = &mut server_task => panic!("server task ended early: {r:?}"),
+            }
+        },
+    )
+    .await
+    .expect("test timed out");
 }
 
 #[cfg_attr(feature = "postquantum",

--- a/lightway-core/tests/packet_codec/mod.rs
+++ b/lightway-core/tests/packet_codec/mod.rs
@@ -2,6 +2,7 @@ use lightway_app_utils::{PacketCodec, PacketCodecFactory};
 use lightway_core::{CodecStatus, PacketCodecResult, PacketDecoder, PacketEncoder};
 
 use bytes::BytesMut;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -119,5 +120,55 @@ impl PacketDecoder for TestPacketDecoder {
         sender.send(data.clone()).expect("TestPacketDecoder send");
 
         Ok(CodecStatus::PacketAccepted)
+    }
+}
+
+/// Encoder that ACCEPTS every packet (`PacketAccepted`) but never emits it on
+/// the encoded channel, modelling a codec that silently black-holes the data
+/// plane once encoding is enabled.
+#[derive(Default)]
+pub(crate) struct BlackHolePacketCodecFactory {}
+
+impl PacketCodecFactory for BlackHolePacketCodecFactory {
+    fn build(&self) -> PacketCodec {
+        let (encoded_pkt_sender, encoded_pkt_receiver) = tokio::sync::mpsc::unbounded_channel();
+        let (decoded_pkt_sender, decoded_pkt_receiver) = tokio::sync::mpsc::unbounded_channel();
+
+        PacketCodec {
+            encoder: Arc::new(BlackHoleEncoder {
+                codec_enabled: AtomicBool::new(false),
+                _encoded_pkt_sender: encoded_pkt_sender,
+            }),
+            decoder: Arc::new(TestPacketDecoder::new(decoded_pkt_sender)),
+            encoded_pkt_receiver,
+            decoded_pkt_receiver,
+        }
+    }
+
+    fn get_codec_name(&self) -> String {
+        String::from("Black Hole Packet Codec")
+    }
+}
+
+struct BlackHoleEncoder {
+    codec_enabled: AtomicBool,
+    _encoded_pkt_sender: UnboundedSender<BytesMut>,
+}
+
+impl PacketEncoder for BlackHoleEncoder {
+    fn store(&self, _data: &mut BytesMut) -> PacketCodecResult<CodecStatus> {
+        if !self.codec_enabled.load(Ordering::SeqCst) {
+            return Ok(CodecStatus::SkipPacket);
+        }
+        // Accept and drop: the packet is never sent on `_encoded_pkt_sender`.
+        Ok(CodecStatus::PacketAccepted)
+    }
+
+    fn set_encoding_state(&self, enabled: bool) {
+        self.codec_enabled.store(enabled, Ordering::SeqCst);
+    }
+
+    fn get_encoding_state(&self) -> bool {
+        self.codec_enabled.load(Ordering::SeqCst)
     }
 }

--- a/lightway-server/src/statistics.rs
+++ b/lightway-server/src/statistics.rs
@@ -174,6 +174,7 @@ mod tests {
         let sessions = vec![ConnectionActivity {
             last_outside_data_received: now - outside_data_age,
             last_data_traffic_from_peer: now - data_traffic_age,
+            last_data_delivered_to_inside: now - data_traffic_age,
         }];
 
         let (standby, active) = calculate_session_stats(&sessions);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a client-side data-plane stall guard for the inside packet codec.
New `ClientConfig::inside_pkt_codec_stall_timeout` param defines the timeout.

When the codec is active (encoding enabled) but no decoded packet has reached the inside/TUN path within a configurable timeout, the client requests disabling the codec (EncodingRequest{enable: false}) so traffic falls back to unencoded, instead of tearing the tunnel down. The connection keeps running and the data plane recovers.

- New Connection::downgrade_inside_pkt_codec_if_stalled(timeout) (lightway-core) encapsulates the check + downgrade. It self-guards: it only acts while encoding is enabled and no encoding request is already in flight, so a stall episode issues a single disable request.
- New ConnectionActivity::last_data_delivered_to_inside, updated only when a decoded packet is actually delivered to the inside path. Control frames (keepalive ping/pong) deliberately do not touch it, so it reflects real data-plane delivery.
- inside_io_task (lightway-client) calls the guard each iteration with the configurable ClientConfig::inside_pkt_codec_stall_timeout (Duration::ZERO disables the check).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A failing inside packet codec can silently black-hole the data plane: it accepts outbound packets but never emits them. Keepalive and the tracer cannot detect this, because keepalive ping/pong are sent as raw `wire::Frame::Ping` control frames that bypass the codec. The tunnel looks perfectly healthy while every user packet is dropped.

Rather than tear down the tunnel (which false-positives on legitimately one-way / bursty-outbound traffic), it gracefully downgrades to unencoded and lets traffic recover. Idle tunnels are never affected: the check only runs while outbound traffic is flowing, since it is evaluated in the inside-read loop.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests with a blackhole packet adapter (drops every packet)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
