### PR TITLE
client: policy routing on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,6 +1917,7 @@ dependencies = [
  "pnet_packet",
  "regex",
  "route_manager",
+ "rtnetlink",
  "schemars 1.2.2",
  "serde",
  "serde-env",
@@ -2264,6 +2265,18 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-packet-route"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
@@ -2275,14 +2288,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "netlink-proto"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f7398dddf5f152d2a91a2921a134c6097056e292c0d4b9906007855e7cece6"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "netlink-sys"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
 dependencies = [
  "bytes",
+ "futures-util",
  "libc",
  "log",
+ "tokio",
 ]
 
 [[package]]
@@ -3005,6 +3035,24 @@ dependencies = [
  "netlink-sys",
  "tokio",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtnetlink"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route 0.28.0",
+ "netlink-proto",
+ "netlink-sys",
+ "nix 0.30.1",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ rand = "0.10.0"
 rcgen = { version = "0.14", features = ["aws_lc_rs"] }
 regex = "1"
 route_manager = { version = "0.2.6", features = ["async"] }
+rtnetlink = "0.20"  # use netlink-packet-route 0.28 which as the same as route_manager using.
 schemars = "1.2.1"
 serde = "1.0.189"
 serde-env = "0.3"

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@
 * [Supported TLS/DTLS versions](./tls_versions.md)
 * [TLS backends (wolfSSL / BoringSSL)](./tls_backends.md)
 * [Inside Packet Codec](./inside_packet_codec.md)
+* [Policy Routing (Linux)](./policy_routing.md)
 * [Expresslane](./expresslane.md)
 * [FAQ](./faq.md)
 

--- a/docs/policy_routing.md
+++ b/docs/policy_routing.md
@@ -1,0 +1,237 @@
+# Policy Routing (Linux)
+
+On Linux, Lightway uses firewall-mark-based policy routing to route VPN traffic.
+This eliminates an encapsulation loop race condition that exists in the simpler
+host-route approach.
+
+## Background — The Race Condition
+
+Without policy routing, Lightway keeps a `/32` host route for the VPN server in
+the main routing table alongside the tunnel's catch-all routes (`0.0.0.0/1` and
+`128.0.0.0/1`). The host route is maintained reactively by watching netlink
+notifications.
+
+During a Wi-Fi roam, the kernel removes the old default route **before** the new
+one appears. In that window the server's `/32` also disappears. An outbound VPN
+packet then matches the tunnel catch-all, gets re-encrypted, is read back off the
+TUN device, re-encrypted again, and so on — an encapsulation loop that persists
+until the new default route arrives.
+
+## Solution — fwmark Policy Routing
+
+The tunnel routes move out of the main table into a private routing table. The
+outside UDP socket is stamped with a firewall mark (`SO_MARK=0x4865_0000`, "He"
+from Helium's chemical symbol encoded in the high bytes — an uncommon value chosen to avoid clashes). Four `ip rule` entries then
+steer packets by mark:
+
+```
+Rule MARKED          (default priority 100):  fwmark <MARK>      lookup main     # tunnel socket → WAN
+Rule SERVER          (default priority 105):  to <SERVER_IP>/32  lookup main     # rp_filter fix
+Rule MARKED_FALLBACK (default priority 107):  fwmark <MARK>      unreachable     # loop-breaker (roam guard)
+Rule TUNNEL          (default priority 110):  (no condition)     lookup <TABLE>  # all other traffic → tunnel
+```
+
+The kernel manages the main table's default route on its own. Lightway no longer
+needs a reactive server host route, and the race window is gone.
+
+## The 4 Rules Explained
+
+### Rule MARKED — Tunnel socket → WAN
+
+```
+ip rule add fwmark 0x4865_0000 lookup main priority 100
+```
+
+The outside UDP socket carries `SO_MARK=0x4865_0000` (set once at socket creation,
+[`src/io/outside/udp.rs`](../lightway-client/src/io/outside/udp.rs)).
+Every packet from that socket matches this rule and resolves through the main
+table, which holds the kernel-managed WAN default route. No Lightway-owned server
+route is needed.
+
+### Rule SERVER — rp_filter fix
+
+```
+ip rule add to <SERVER_IP>/32 lookup main priority 105
+```
+
+Linux's strict reverse-path filter (`rp_filter=1`) validates incoming packets by
+asking: *"If I were to send a packet to this source IP (with the incoming packet's
+mark, which is 0), which interface would I use?"* After `Rule TUNNEL` is
+installed, an unmarked lookup for the server IP falls to `Rule TUNNEL` →
+tunnel table → `0.0.0.0/1 via lightway`. The rp_filter then sees the server's
+reply arriving on `wlan0` but the route saying `lightway`, which is a mismatch —
+the packet is silently dropped.
+
+`Rule SERVER` intercepts that unmarked lookup and redirects it to main,
+where the WAN default route resolves via the physical interface. The rp_filter sees
+a consistent interface and accepts the packet.
+
+This rule is **never hit by regular outbound traffic** — it only fires when the
+kernel performs the internal rp_filter route lookup on an incoming server packet.
+
+### Rule MARKED_FALLBACK — Loop-breaker (roam guard)
+
+```
+ip rule add fwmark 0x4865_0000 unreachable priority 107
+```
+
+`ip rule` falls through to the next rule when a table returns no matching route.
+During a Wi-Fi roam the kernel briefly removes the old default route from main.
+Marked packets find no route at `Rule MARKED`, skip
+`Rule SERVER` (destination is not `SERVER_IP`), and without
+`Rule MARKED_FALLBACK` would reach `Rule TUNNEL` — the tunnel
+table — causing re-encapsulation.
+
+`Rule MARKED_FALLBACK` catches them with a second fwmark match and
+returns `ENETUNREACH`. The outside I/O send handler treats this as a transient
+failure ([`src/io/outside/udp.rs`](../lightway-client/src/io/outside/udp.rs)) and
+drops the packet cleanly instead of looping.
+
+During normal operation `Rule MARKED_FALLBACK` is never reached —
+marked packets always exit at `Rule MARKED`.
+
+### Rule TUNNEL — VPN data → tunnel table
+
+```
+ip rule add lookup <TABLE> priority 110
+```
+
+Unmarked packets (decrypted VPN data from userspace) fall through
+`Rule MARKED`, `Rule SERVER`, and `Rule MARKED_FALLBACK`
+and hit this unconditional catch-all. They resolve through the private tunnel
+table, which holds `0.0.0.0/1` and `128.0.0.0/1` via the TUN device, plus the
+DNS route.
+
+## Packet Lifetime — ping to 8.8.8.8
+
+The following traces a single ICMP Echo Request from a local application through
+the VPN and back.
+
+### Outbound (application → 8.8.8.8)
+
+<pre>
+1. APPLICATION (ICMP Echo Request)  src=10.x.x.x  dst=8.8.8.8  mark=0
+   └─ kernel evaluates ip rules:
+      Rule MARKED (100):          fwmark==0x4865_0000? NO  → skip
+      Rule SERVER (105):          dst==server_ip? NO  → skip
+      Rule MARKED_FALLBACK (107): fwmark==0x4865_0000? NO  → skip
+<b>      Rule TUNNEL (110):          catch-all → lookup tunnel table
+        0.0.0.0/1 matches → route via lightway (TUN device)</b>
+
+2. TUN DEVICE receives packet  src=10.x.x.x  dst=8.8.8.8  mark=0
+   └─ inside_io_task: inside_io.recv_buf(&mut buf)  [lib.rs:657]
+
+3. IP SOURCE REWRITE  src=100.64.0.5  dst=8.8.8.8  mark=0
+   └─ ipv4_update_source(buf, ip_config.client_ip)  [lib.rs:672]
+      src 10.x.x.x → 100.64.0.5 (server-assigned client IP)
+
+4. ENCRYPTION  src=100.64.0.5  dst=8.8.8.8  mark=0  →  DTLS record
+   └─ conn.inside_data_received(&mut buf)  [lib.rs:683]
+      lightway_core wraps plaintext into encrypted DTLS record
+
+5. OUTSIDE UDP SOCKET sends  src=client_wan_ip  dst=server_ip  mark=0x4865_0000
+   └─ Udp::send(encrypted_buf)  [udp.rs:199]
+      SO_MARK=0x4865_0000 stamped by kernel on every packet from this socket  [udp.rs:50]
+      kernel evaluates ip rules:
+<b>      Rule MARKED (100): fwmark==0x4865_0000? YES → lookup main → WAN default → out via wlan0</b>
+
+6. NIC (wlan0) emits packet  src=client_wan_ip  dst=server_ip  mark=0x4865_0000
+   └─ encrypted UDP travels over internet to VPN server
+      (VPN server decrypts, SNATs, forwards to 8.8.8.8; 8.8.8.8 replies to server)
+</pre>
+
+### Inbound (8.8.8.8 → application)
+
+<pre>
+7. NIC (wlan0) receives encrypted UDP  src=server_ip  dst=client_wan_ip  mark=0
+   └─ kernel rp_filter check (mark=0): "how would I reach server_ip?"
+      Rule MARKED (100):  fwmark==0x4865_0000? NO  → skip
+<b>      Rule SERVER (105):  dst==server_ip? YES → lookup main → WAN default → wlan0
+        rp_filter: arrived on wlan0, route says wlan0 → MATCH → packet accepted ✓</b>
+
+8. OUTSIDE IO TASK reads encrypted packet  src=server_ip  dst=client_wan_ip  mark=0
+   └─ outside_io.recv_buf(&mut bufs[0])  [lib.rs:612]
+
+9. DECRYPTION  src=8.8.8.8  dst=100.64.0.5  mark=0
+   └─ conn.multiple_outside_data_received(pkts)  [lib.rs:622]
+      lightway_core decrypts DTLS record back to plaintext ICMP reply
+      calls InsideIOSendCallback::send() → Tun::send()  [tun.rs:90]
+
+10. IP DESTINATION REWRITE  src=8.8.8.8  dst=10.x.x.x  mark=0
+    └─ ipv4_update_destination(buf, self.ip)  [tun.rs:61]
+       dst 100.64.0.5 → 10.x.x.x (tun_local_ip)
+
+11. TUN DEVICE delivers packet  src=8.8.8.8  dst=10.x.x.x  mark=0
+    └─ tun.try_send(buf)  [tun.rs:73]
+       kernel delivers ICMP Echo Reply to application socket ✓
+</pre>
+
+### Which rules each packet hits
+
+| Packet | `Rule MARKED` | `Rule SERVER` | `Rule MARKED_FALLBACK` | `Rule TUNNEL` |
+|---|---|---|---|---|
+| Outbound app traffic (mark=0) | skip | skip | skip | **HIT** → tunnel table |
+| rp_filter check for server_ip (mark=0) | skip | **HIT** → main | — | — |
+| Encrypted packet leaving client (mark=0x4865_0000) | **HIT** → WAN | — | — | — |
+| Marked packet during roam (mark=0x4865_0000, no default route) | fall through | skip | **HIT** → ENETUNREACH | — |
+
+## RouteMode
+
+`RouteMode` is defined in [`src/route_manager.rs`](../lightway-client/src/route_manager.rs)
+and controls how routes are installed. On Linux the default is `Fwmark`; all other
+platforms default to `Default`.
+
+| Mode | Server route | Tunnel routes in | Policy rules | Linux default |
+|---|---|---|---|---|
+| `Fwmark` | None — rules handle it | tunnel table | `Rule MARKED`, `Rule SERVER`, `Rule MARKED_FALLBACK`, `Rule TUNNEL` | ✓ |
+| `Default` | /32 in main, reactively managed | main table | None | |
+| `Lan` | /32 in main, reactively managed | main table + RFC 1918 + link-local | None | |
+| `NoExec` | None | None installed | None | |
+
+`Fwmark` is Linux-only (`#[cfg(linux)]`). It skips the server `/32` entirely;
+`Rule MARKED` replaces it without the race window.
+
+## Configuration
+
+All parameters are in `FWMarkConfig`
+([`src/policy_routing.rs`](../lightway-client/src/policy_routing.rs)) and are
+user-configurable. Validation enforces the strict ordering:
+`Rule MARKED < Rule SERVER < Rule TUNNEL` and `Rule MARKED_FALLBACK < Rule TUNNEL`.
+
+| Field | Default | Constraint | Notes |
+|---|---|---|---|
+| `fwmark` | `1214464000` (`0x4865_0000`) | u32 | "He" from Helium's chemical symbol in the high bytes — uncommon value avoids clashes |
+| `fwmark_route_table` | `2` | 1–252 | Avoids reserved IDs: 253 (default), 254 (main), 255 (local) |
+| `rule_priority_marked` | `100` | < `rule_priority_marked_fallback` | Tunnel socket → main; must precede the loop-breaker |
+| `rule_priority_server` | `105` | < `rule_priority_tunnel` | rp_filter fix; must precede `Rule TUNNEL` |
+| `rule_priority_marked_fallback` | `107` | < `rule_priority_tunnel` | Loop-breaker; must precede `Rule TUNNEL` |
+| `rule_priority_tunnel` | `110` | > `rule_priority_marked` and `rule_priority_marked_fallback` | Catch-all; must be the last Lightway-owned rule |
+
+The routing table is registered in `/etc/iproute2/rt_tables` as `lightway-tunnel`
+so that `ip rule show` displays a human-readable name instead of a bare table ID.
+
+## Key Source Files
+
+| File | Role |
+|---|---|
+| [`lightway-client/src/policy_routing.rs`](../lightway-client/src/policy_routing.rs) | Installs/removes the 4 ip rules via netlink; manages rt_tables registration |
+| [`lightway-client/src/route_manager.rs`](../lightway-client/src/route_manager.rs) | `RouteMode` enum; Fwmark routes go into the tunnel table instead of main |
+| [`lightway-client/src/config.rs`](../lightway-client/src/config.rs) | `FWMarkConfig` builder and validation |
+| [`lightway-client/src/lib.rs`](../lightway-client/src/lib.rs) | Wires it together: rules installed before routes, cleaned up after |
+| [`lightway-client/src/io/outside/udp.rs`](../lightway-client/src/io/outside/udp.rs) | Applies `SO_MARK` to the outside socket and verifies it was accepted |
+
+### Initialization order
+
+Rules must be installed before routes, and removed after:
+
+```
+1. PolicyRouting::new()       open netlink handle, store server_ip
+2. policy_routing.install()   add 4 ip rules  ← MUST be before routes
+3. UdpSocket::new(fwmark)     create outside socket + SO_MARK + verify read-back
+4. RouteManager::new()        configure with tunnel table ID
+5. route_manager.apply()      install routes into tunnel table
+
+Shutdown (reverse):
+route_manager.stop()          remove tunnel routes
+policy_routing.cleanup()      remove 4 rules, unregister table name
+```

--- a/lightway-client/Cargo.toml
+++ b/lightway-client/Cargo.toml
@@ -79,6 +79,9 @@ cfg_aliases.workspace = true
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]
 route_manager.workspace = true
 
+[target.'cfg(target_os = "linux")'.dependencies]
+rtnetlink.workspace = true
+
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-core-foundation = "0.3.1"
 objc2-system-configuration = "0.3.1"

--- a/lightway-client/src/config.rs
+++ b/lightway-client/src/config.rs
@@ -1,5 +1,12 @@
 #[cfg(desktop)]
 use super::dns_manager::DnsConfigMode;
+#[cfg(linux)]
+use super::policy_routing::{
+    DEFAULT_FWMARK, RULE_PRIORITY_MARKED, RULE_PRIORITY_MARKED_FALLBACK, RULE_PRIORITY_SERVER,
+    RULE_PRIORITY_TUNNEL,
+};
+#[cfg(linux)]
+use super::route_manager::FWMARK_ROUTE_TABLE;
 #[cfg(desktop)]
 use super::route_manager::RouteMode;
 use bytesize::ByteSize;
@@ -213,7 +220,8 @@ pub struct Config {
     Modes:
         default: Sets up routes as specified in server, tun_local_ip, tun_peer_ip, tun_dns_ip
         noexec : Does not setup any routes
-        lan    : Sets up default + additional lan routes"#))]
+        lan    : Sets up default + additional lan routes
+        fwmark : Setup routes fwmark(linux only)"#))]
     #[schemars(extend("x-cfg" = "desktop"))]
     pub route_mode: RouteMode,
 
@@ -223,12 +231,63 @@ pub struct Config {
     #[patch(
         attribute(doc = r#"Firewall mark (SO_MARK) applied to the outside socket.
         The tunnel's own encrypted packets carry this mark so policy routing
-        rules can keep them out of the tunnel.
+        rules can keep them out of the tunnel with fwmark route mode.  
         In Linux networking, a fwmark of 0 represents the default unmarked state
         and will not apply SO_MARK to the socket."#)
     )]
     #[schemars(extend("x-cfg" = "linux"))]
     pub fwmark: u32,
+
+    #[cfg(linux)]
+    #[patch(attribute(serde(default)))]
+    #[patch(attribute(clap(long)))]
+    #[patch(attribute(
+        doc = r#"Routing table id for fwmark tunnel routes (route_mode=fwmark).
+        Must be in 1..=252 to avoid reserved tables (main=254, default=253, local=255).
+        Defaults to 2 (Helium atomic number)."#
+    ))]
+    #[schemars(extend("x-cfg" = "linux"))]
+    pub fwmark_route_table: u8,
+
+    #[cfg(linux)]
+    #[patch(attribute(serde(default)))]
+    #[patch(attribute(clap(long)))]
+    #[patch(attribute(
+        doc = r#"Priority of the ip rule that routes the tunnel socket's traffic via the
+        main table (route_mode=fwmark). Must be less than rule_priority_marked_fallback."#
+    ))]
+    #[schemars(extend("x-cfg" = "linux"))]
+    pub rule_priority_marked: u32,
+
+    #[cfg(linux)]
+    #[patch(attribute(serde(default)))]
+    #[patch(attribute(clap(long)))]
+    #[patch(attribute(
+        doc = r#"Priority of the ip rule that fixes rp_filter for incoming server
+        reply packets (route_mode=fwmark). Must be less than rule_priority_tunnel."#
+    ))]
+    #[schemars(extend("x-cfg" = "linux"))]
+    pub rule_priority_server: u32,
+
+    #[cfg(linux)]
+    #[patch(attribute(serde(default)))]
+    #[patch(attribute(clap(long)))]
+    #[patch(
+        attribute(doc = r#"Priority of the loop-breaker ip rule (route_mode=fwmark).
+        Must be less than rule_priority_tunnel."#)
+    )]
+    #[schemars(extend("x-cfg" = "linux"))]
+    pub rule_priority_marked_fallback: u32,
+
+    #[cfg(linux)]
+    #[patch(attribute(serde(default)))]
+    #[patch(attribute(clap(long)))]
+    #[patch(
+        attribute(doc = r#"Priority of the ip rule that sends all other traffic into the
+        tunnel table (route_mode=fwmark). Must be greater than rule_priority_marked_fallback."#)
+    )]
+    #[schemars(extend("x-cfg" = "linux"))]
+    pub rule_priority_tunnel: u32,
 
     #[cfg(desktop)]
     #[patch(attribute(clap(long, value_enum)))]
@@ -365,6 +424,25 @@ pub struct Config {
 }
 
 impl Config {
+    /// Returns a [`crate::policy_routing::FWMarkConfig`] built from this config's fwmark fields.
+    #[cfg(linux)]
+    pub fn fwmark_config(&self) -> super::policy_routing::FWMarkConfig {
+        super::policy_routing::FWMarkConfig {
+            fwmark: if self.fwmark == 0 {
+                // If the FWMarkConfig is using in FWMark route mode, but user does not assing any
+                // value to fwmark, we will use a defaul value
+                DEFAULT_FWMARK
+            } else {
+                self.fwmark
+            },
+            table: self.fwmark_route_table,
+            rule_priority_marked: self.rule_priority_marked,
+            rule_priority_server: self.rule_priority_server,
+            rule_priority_marked_fallback: self.rule_priority_marked_fallback,
+            rule_priority_tunnel: self.rule_priority_tunnel,
+        }
+    }
+
     /// The number of servers
     pub fn len(&self) -> usize {
         if self.server.is_empty() {
@@ -506,6 +584,42 @@ impl Config {
                     "tun_txqueuelen is below the recommended minimum of 1000"
                 );
             }
+            if self.route_mode == RouteMode::Fwmark {
+                if self.fwmark == 0 {
+                    tracing::warn!(
+                        "enable fwmark route mode need fwmark setting, will use {} instead",
+                        DEFAULT_FWMARK
+                    );
+                }
+                anyhow::ensure!(
+                    self.fwmark_route_table >= 1 && self.fwmark_route_table <= 252,
+                    "fwmark_route_table must be in 1..=252 (reserved: local=255, main=254, default=253)"
+                );
+                // Rule MARKED must precede Rule MARKED_FALLBACK: marked packets must
+                // attempt the main table before the loop-breaker returns ENETUNREACH.
+                anyhow::ensure!(
+                    self.rule_priority_marked < self.rule_priority_marked_fallback,
+                    "rule_priority_marked ({}) must be less than rule_priority_marked_fallback ({})",
+                    self.rule_priority_marked,
+                    self.rule_priority_marked_fallback,
+                );
+                // Rule MARKED_FALLBACK must precede Rule TUNNEL: during a roam,
+                // marked packets must get ENETUNREACH before reaching the tunnel table.
+                anyhow::ensure!(
+                    self.rule_priority_marked_fallback < self.rule_priority_tunnel,
+                    "rule_priority_marked_fallback ({}) must be less than rule_priority_tunnel ({})",
+                    self.rule_priority_marked_fallback,
+                    self.rule_priority_tunnel,
+                );
+                // Rule SERVER must precede Rule TUNNEL: server-IP lookups must resolve
+                // via main so that rp_filter accepts incoming server packets.
+                anyhow::ensure!(
+                    self.rule_priority_server < self.rule_priority_tunnel,
+                    "rule_priority_server ({}) must be less than rule_priority_tunnel ({})",
+                    self.rule_priority_server,
+                    self.rule_priority_tunnel,
+                );
+            }
         }
         Ok(())
     }
@@ -555,6 +669,16 @@ impl Default for Config {
             route_mode: RouteMode::default(),
             #[cfg(linux)]
             fwmark: 0,
+            #[cfg(linux)]
+            fwmark_route_table: FWMARK_ROUTE_TABLE,
+            #[cfg(linux)]
+            rule_priority_marked: RULE_PRIORITY_MARKED,
+            #[cfg(linux)]
+            rule_priority_server: RULE_PRIORITY_SERVER,
+            #[cfg(linux)]
+            rule_priority_marked_fallback: RULE_PRIORITY_MARKED_FALLBACK,
+            #[cfg(linux)]
+            rule_priority_tunnel: RULE_PRIORITY_TUNNEL,
             #[cfg(desktop)]
             dns_config_mode: DnsConfigMode::default(),
             log_level: LogLevel::Info,

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -205,9 +205,9 @@ pub struct ClientConfig<ExtAppState: Send + Sync> {
     #[cfg(desktop)]
     pub route_mode: RouteMode,
 
-    /// Firewall mark applied to the outside socket (Linux only).
+    /// Fwmark policy-routing parameters. Only effective under [`RouteMode::Fwmark`].
     #[cfg(linux)]
-    pub fwmark: u32,
+    pub fwmark_config: policy_routing::FWMarkConfig,
 
     /// DNS configuration mode
     #[cfg(desktop)]
@@ -354,7 +354,7 @@ impl<ExtAppState: Send + Sync> ClientConfig<ExtAppState> {
             #[cfg(desktop)]
             route_mode: config.route_mode,
             #[cfg(linux)]
-            fwmark: config.fwmark,
+            fwmark_config: config.fwmark_config(),
             #[cfg(desktop)]
             dns_config_mode: config.dns_config_mode,
             enable_pmtud: config.enable_pmtud,
@@ -1055,7 +1055,7 @@ impl<ExtAppState: Send + Sync> ClientConnection<ExtAppState> {
         transition_rx: Option<watch::Receiver<()>>,
         nudge_on_route_event: bool,
         #[cfg(apple)] nudge_on_route_update: bool,
-        #[cfg(linux)] fwmark: u32,
+        #[cfg(linux)] fwmark_config: policy_routing::FWMarkConfig,
     ) -> Result<()> {
         let server_ip = self.outside_io.peer_addr().ip();
         let tun_index = self.inside_io.if_index()?;
@@ -1074,14 +1074,7 @@ impl<ExtAppState: Send + Sync> ClientConnection<ExtAppState> {
         // keep the tunnel's own packets out of it.
         #[cfg(linux)]
         if route_mode == RouteMode::Fwmark {
-            if fwmark == 0 {
-                anyhow::bail!("route_mode=fwmark requires `fwmark` to be set in the config");
-            };
-            let mut pr = policy_routing::PolicyRouting::new(
-                fwmark,
-                route_manager::FWMARK_ROUTE_TABLE,
-                server_ip,
-            )?;
+            let mut pr = policy_routing::PolicyRouting::new(fwmark_config, server_ip)?;
             if let Err(e) = pr.install().await {
                 pr.cleanup().await;
                 return Err(e);
@@ -1089,8 +1082,15 @@ impl<ExtAppState: Send + Sync> ClientConnection<ExtAppState> {
             self.policy_routing = Some(pr);
         }
 
-        let mut route_manager =
-            RouteManager::new(route_mode, server_ip, tun_index, tun_peer_ip, tun_dns_ip)?;
+        let mut route_manager = RouteManager::new(
+            route_mode,
+            server_ip,
+            tun_index,
+            tun_peer_ip,
+            tun_dns_ip,
+            #[cfg(linux)]
+            fwmark_config.table,
+        )?;
         let route_updater = route_manager.start().await?;
 
         // A weak ref keeps the coordinator task from extending the outside
@@ -1177,7 +1177,7 @@ pub async fn connect<
                     server,
                     maybe_sock,
                     #[cfg(all(linux, not(feature = "mobile")))]
-                    config.fwmark,
+                    config.fwmark_config.fwmark,
                 )
                 .await
                 .inspect_err(|e| tracing::error!("Failed to create outside IO UDP socket: {e}"))
@@ -1211,7 +1211,7 @@ pub async fn connect<
                     server,
                     maybe_sock,
                     #[cfg(all(linux, not(feature = "mobile")))]
-                    config.fwmark,
+                    config.fwmark_config.fwmark,
                 )
                 .await
                 .inspect_err(|e| tracing::error!("Failed to create outside IO TCP socket: {e}"))
@@ -1824,7 +1824,7 @@ pub async fn client<
                 #[cfg(apple)]
                 nudge_on_route_update,
                 #[cfg(linux)]
-                config.fwmark,
+                config.fwmark_config,
             )
             .await?;
     }

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -5,6 +5,8 @@ pub mod dns_manager;
 pub mod io;
 pub mod keepalive;
 pub mod platform;
+#[cfg(linux)]
+pub mod policy_routing;
 #[cfg(desktop)]
 pub mod route_manager;
 
@@ -1019,6 +1021,8 @@ pub struct ClientConnection<T: Send + Sync> {
     encoding_request_signal: mpsc::Sender<bool>,
     #[cfg(desktop)]
     route_manager: Option<RouteManager>,
+    #[cfg(linux)]
+    policy_routing: Option<policy_routing::PolicyRouting>,
     #[cfg(desktop)]
     dns_manager: Option<DnsManager>,
 }
@@ -1051,6 +1055,7 @@ impl<ExtAppState: Send + Sync> ClientConnection<ExtAppState> {
         transition_rx: Option<watch::Receiver<()>>,
         nudge_on_route_event: bool,
         #[cfg(apple)] nudge_on_route_update: bool,
+        #[cfg(linux)] fwmark: u32,
     ) -> Result<()> {
         let server_ip = self.outside_io.peer_addr().ip();
         let tun_index = self.inside_io.if_index()?;
@@ -1063,6 +1068,27 @@ impl<ExtAppState: Send + Sync> ClientConnection<ExtAppState> {
             tun_peer_ip,
             tun_dns_ip
         );
+        // Under Fwmark mode the policy rules must exist *before* any tunnel
+        // route is installed. Installing the tunnel table first would leave a
+        // window where traffic can reach the tunnel table with no fwmark rule to
+        // keep the tunnel's own packets out of it.
+        #[cfg(linux)]
+        if route_mode == RouteMode::Fwmark {
+            if fwmark == 0 {
+                anyhow::bail!("route_mode=fwmark requires `fwmark` to be set in the config");
+            };
+            let mut pr = policy_routing::PolicyRouting::new(
+                fwmark,
+                route_manager::FWMARK_ROUTE_TABLE,
+                server_ip,
+            )?;
+            if let Err(e) = pr.install().await {
+                pr.cleanup().await;
+                return Err(e);
+            }
+            self.policy_routing = Some(pr);
+        }
+
         let mut route_manager =
             RouteManager::new(route_mode, server_ip, tun_index, tun_peer_ip, tun_dns_ip)?;
         let route_updater = route_manager.start().await?;
@@ -1423,6 +1449,8 @@ pub async fn connect<
         encoding_request_signal: encoding_request_tx,
         #[cfg(desktop)]
         route_manager: None,
+        #[cfg(linux)]
+        policy_routing: None,
         #[cfg(desktop)]
         dns_manager: None,
     })
@@ -1795,6 +1823,8 @@ pub async fn client<
                 nudge_on_route_event,
                 #[cfg(apple)]
                 nudge_on_route_update,
+                #[cfg(linux)]
+                config.fwmark,
             )
             .await?;
     }
@@ -1807,6 +1837,12 @@ pub async fn client<
     #[cfg(desktop)]
     if let Some(mut route_manager) = connection.route_manager {
         let _ = route_manager.stop().await;
+    }
+
+    // Rules come down after the routes they steer traffic to.
+    #[cfg(linux)]
+    if let Some(mut pr) = connection.policy_routing {
+        pr.cleanup().await;
     }
 
     // Dropping the monitor aborts its background task.

--- a/lightway-client/src/platform.rs
+++ b/lightway-client/src/platform.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 pub mod linux;
 #[cfg(target_os = "macos")]
 pub mod macos;

--- a/lightway-client/src/policy_routing.rs
+++ b/lightway-client/src/policy_routing.rs
@@ -78,17 +78,97 @@ use anyhow::{Context, Result};
 use rtnetlink::Handle;
 use rtnetlink::packet_route::rule::{RuleAction, RuleMessage};
 
+const RT_TABLES_PATH: &str = "/etc/iproute2/rt_tables";
+
 /// Prefix for all policy-routing names used by Lightway.
 ///
 /// Each rule and the tunnel routing table get a distinct name under this prefix:
 ///
-/// | Rule            | Name                                  | Visible in  |
-/// | --------------- | ------------------------------------- | ----------- |
-/// | MARKED          | `lightway-marked-0x<fwmark>`          | tracing log |
-/// | SERVER          | `lightway-server`                     | tracing log |
-/// | MARKED_FALLBACK | `lightway-marked-0x<fwmark>-fallback` | tracing log |
-/// | TUNNEL (table)  | `lightway-tunnel`                     | tracing log |
+/// | Rule            | Name                                  | Visible in              |
+/// | --------------- | ------------------------------------- | ----------------------- |
+/// | MARKED          | `lightway-marked-0x<fwmark>`          | tracing log             |
+/// | SERVER          | `lightway-server`                     | tracing log             |
+/// | MARKED_FALLBACK | `lightway-marked-0x<fwmark>-fallback` | tracing log             |
+/// | TUNNEL (table)  | `lightway-tunnel`                     | tracing log + rt_tables |
+///
+/// Only the tunnel routing table name is registered in `/etc/iproute2/rt_tables`
+/// because ip rules themselves have no name field; the kernel identifies them by
+/// priority alone.
 const TABLE_PREFIX: &str = "lightway";
+
+/// Writes `"<id>\t<name>"` to `/etc/iproute2/rt_tables`, creating the file if
+/// it does not yet exist.
+///
+/// In debug builds, reads the file first: skips the write if the entry is
+/// already present with the correct id, and returns an error if it exists with
+/// a different id.  In release builds the check is skipped and the line is
+/// always appended — duplicates are harmless because the kernel never reads
+/// this file and `unregister_rt_table` removes all matching lines on cleanup.
+fn register_rt_table(id: u32, name: &str) -> Result<()> {
+    #[cfg(feature = "debug")]
+    {
+        let content = std::fs::read_to_string(RT_TABLES_PATH)
+            .with_context(|| format!("Cannot read {RT_TABLES_PATH}"))?;
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            let mut cols = trimmed.split_whitespace();
+            let (Some(id_str), Some(tbl)) = (cols.next(), cols.next()) else {
+                continue;
+            };
+            if tbl == name {
+                let existing: u32 = id_str
+                    .parse()
+                    .with_context(|| format!("Malformed id for '{name}' in {RT_TABLES_PATH}"))?;
+                anyhow::ensure!(
+                    existing == id,
+                    "Table '{name}' already registered with id {existing}, expected {id}"
+                );
+                return Ok(()); // already present with the correct id
+            }
+        }
+    }
+
+    use std::io::Write as _;
+    let mut file = std::fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(RT_TABLES_PATH)
+        .with_context(|| format!("Cannot open {RT_TABLES_PATH} for writing"))?;
+    writeln!(file, "{id}\t{name}").with_context(|| format!("Cannot write to {RT_TABLES_PATH}"))?;
+    tracing::debug!(id, name, "Registered routing table name");
+    Ok(())
+}
+
+/// Removes every line whose table-name field equals `name` from
+/// `/etc/iproute2/rt_tables`.
+fn unregister_rt_table(name: &str) {
+    let content = match std::fs::read_to_string(RT_TABLES_PATH) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("Cannot read {RT_TABLES_PATH} during cleanup: {e}");
+            return;
+        }
+    };
+
+    let filtered: String = content
+        .lines()
+        .filter(|line| {
+            let mut cols = line.split_whitespace();
+            let _ = cols.next(); // skip id field
+            cols.next() != Some(name)
+        })
+        .flat_map(|line| [line, "\n"])
+        .collect();
+
+    if let Err(e) = std::fs::write(RT_TABLES_PATH, filtered) {
+        tracing::warn!("Cannot update {RT_TABLES_PATH} during cleanup: {e}");
+    } else {
+        tracing::debug!(name, "Unregistered routing table name");
+    }
+}
 
 /// Default firewall mark (`SO_MARK`) applied to the outside socket under `RouteMode::Fwmark` (Linux
 /// only).
@@ -233,6 +313,14 @@ impl PolicyRouting {
         .await
         .context("Failed to add fwmark fallback rule")?;
 
+        // Register the tunnel table name so that `ip rule show` displays
+        // `from all lookup lightway-tunnel` instead of a bare table id.
+        if let Err(e) = register_rt_table(self.table as u32, &tunnel_name)
+            .with_context(|| format!("Failed to register '{tunnel_name}' in {RT_TABLES_PATH}"))
+        {
+            tracing::error!("Fail to register table name: {}", e);
+        }
+
         self.add_rule(
             self.rule_priority_tunnel,
             None,
@@ -337,7 +425,8 @@ impl PolicyRouting {
         Ok(())
     }
 
-    /// Removes every rule this instance installed.
+    /// Removes every rule this instance installed and unregisters the table
+    /// name from `/etc/iproute2/rt_tables`.
     ///
     /// Failures are logged rather than propagated: leaving a stale rule behind
     /// is bad, but aborting cleanup half way through is worse.
@@ -347,6 +436,7 @@ impl PolicyRouting {
                 tracing::warn!("Failed to delete ip rule during cleanup: {e}");
             }
         }
+        unregister_rt_table(&format!("{TABLE_PREFIX}-tunnel"));
         tracing::info!("Removed policy routing rules");
     }
 }

--- a/lightway-client/src/policy_routing.rs
+++ b/lightway-client/src/policy_routing.rs
@@ -1,0 +1,266 @@
+//! Linux policy routing for the tunnel, based on a firewall mark.
+//!
+//! # Why
+//!
+//! Without policy routing, the tunnel's catch-all routes (`0.0.0.0/1` +
+//! `128.0.0.0/1`) live in the *main* table alongside the WAN default route.
+//! A `/32` host route for the VPN server then keeps the tunnel's own encrypted
+//! packets off the tunnel.  That host route is maintained by
+//! [`crate::route_manager`] in reaction to netlink notifications, so there is a
+//! race window after a network change (e.g. Wi-Fi roam) where the kernel has
+//! already invalidated the old host route but the new one has not been installed
+//! yet.  During that window the VPN server's IP matches the tunnel's own
+//! catch-all route, causing an encapsulation loop.
+//!
+//! # How this fixes it
+//!
+//! The tunnel routes move out of *main* into a private table, and four rules
+//! determine which table is consulted:
+//!
+//! ```text
+//! priority 100:  fwmark <MARK>              lookup main   # (1) tunnel socket → WAN
+//! priority 105:  to <SERVER_IP>/32          lookup main   # (2) rp_filter fix (see below)
+//! priority 107:  fwmark <MARK>              unreachable   # (3) loop-breaker (see below)
+//! priority 110:  (no condition)             lookup <TABLE># (4) all other traffic → tunnel
+//! ```
+//!
+//! The tunnel's outside socket carries `<MARK>`, so its outgoing packets hit
+//! Rule MARKED and resolve via *main* — whose default route the kernel keeps
+//! current on its own, with no Lightway-managed entry involved.
+//!
+//! # Rule 105 — rp_filter fix
+//!
+//! Linux's reverse-path filter (strict mode, `rp_filter=1`) checks incoming
+//! packets by looking up the *source* IP through the routing rules — but using
+//! the *incoming packet's* mark, which is 0 for plain packets from the WAN.
+//!
+//! After rule 110 is installed, an unmarked lookup for the server IP falls
+//! through rules 100 and 107 (both require `fwmark <MARK>`) and lands on
+//! rule 110 → tunnel table → `0.0.0.0/1 via lightway`.  Strict rp_filter
+//! would then consider `SERVER_IP` routed via `lightway`, but the server's
+//! reply packet arrived on `wlan0` (or whichever physical interface), producing
+//! an interface mismatch and silently **dropping** every pong — which the
+//! keepalive mechanism observes as a timeout.
+//!
+//! Rule 105 intercepts the unmarked lookup for `<SERVER_IP>/32` and redirects
+//! it to *main*, where the WAN default route sends it back out the physical
+//! interface.  rp_filter sees a consistent interface and accepts the packet.
+//!
+//! # Rule 107 — loop-breaker
+//!
+//! `ip rule` falls through to the next rule when the selected table returns no
+//! matching route.  During a Wi-Fi roam, the kernel removes the old default
+//! route from *main* before a new one arrives.  In that brief window:
+//!
+//! 1. Rule 100: `fwmark <MARK> → lookup main` — no route → **fall through**
+//! 2. Rule 105: `to <SERVER_IP>/32 → lookup main` — no route → **fall through**
+//! 3. Rule 107: (absent without this fix) — skipped
+//! 4. Rule 110: `→ lookup <TABLE>` — `0.0.0.0/1` and `128.0.0.0/1` via `tun`
+//!    — the VPN socket's own encrypted packet is read back off the tun device
+//!    as an inside packet, re-encapsulated (+69 bytes per lap), and re-sent →
+//!    **encapsulation loop**.
+//!
+//! Rule 107 (`fwmark <MARK> unreachable`) intercepts the fall-through:
+//! - During normal operation marked packets are already handled by rule 100 and
+//!   rule 107 is never reached.
+//! - During a roam, marked packets fall through rules 100 and 105 (both consult
+//!   *main*, which has no route) and hit rule 107, which returns `ENETUNREACH`
+//!   to the caller.  The outside I/O callback already treats this as a transient
+//!   send failure, dropping the packet cleanly and preventing the loop.
+
+use std::net::Ipv4Addr;
+
+use anyhow::{Context, Result};
+// Use rtnetlink's re-export rather than depending on netlink-packet-route
+// directly: that guarantees these types come from the exact same crate version
+// rtnetlink itself was built against.
+use rtnetlink::Handle;
+use rtnetlink::packet_route::rule::{RuleAction, RuleMessage};
+
+/// Priority of the rule matching the tunnel's own (marked) traffic.
+pub const RULE_PRIORITY_MARKED: u32 = 100;
+
+/// Priority of the rule that fixes rp_filter for incoming server reply packets.
+///
+/// See the module-level documentation for a full explanation.
+pub const RULE_PRIORITY_SERVER: u32 = 105;
+
+/// Priority of the fallback rule that breaks the encapsulation loop.
+///
+/// Must be between [`RULE_PRIORITY_SERVER`] and [`RULE_PRIORITY_TUNNEL`].
+/// See the module-level documentation for a full explanation.
+pub const RULE_PRIORITY_FWMARK_FALLBACK: u32 = 107;
+
+/// Priority of the rule sending everything else into the tunnel table.
+pub const RULE_PRIORITY_TUNNEL: u32 = 110;
+
+/// `main` routing table id.
+const RT_TABLE_MAIN: u32 = 254;
+
+/// Installs and removes the policy routing rules for a marked tunnel.
+///
+/// The installed rules are remembered so that [`Self::cleanup`] removes exactly
+/// what was added, rather than deleting anything that happens to match.
+pub struct PolicyRouting {
+    handle: Handle,
+    /// Netlink connection task; dropping it tears the connection down.
+    _conn: tokio::task::JoinHandle<()>,
+    installed: Vec<RuleMessage>,
+    fwmark: u32,
+    table: u8,
+    server_ipv4: Option<Ipv4Addr>,
+}
+
+impl PolicyRouting {
+    /// Opens a netlink connection for rule manipulation.
+    ///
+    /// `server_ip` should be the VPN server's IPv4 address.  It is used to
+    /// install the rp_filter-bypass rule (priority [`RULE_PRIORITY_SERVER`]).
+    /// Pass `None` for IPv6-only servers where rp_filter handling is not needed.
+    pub fn new(fwmark: u32, table: u8, server_ip: std::net::IpAddr) -> Result<Self> {
+        let server_ipv4 = match server_ip {
+            std::net::IpAddr::V4(a) => Some(a),
+            std::net::IpAddr::V6(_) => None,
+        };
+        let (conn, handle, _) =
+            rtnetlink::new_connection().context("Failed to open netlink connection for rules")?;
+        let conn = tokio::spawn(async move {
+            conn.await;
+        });
+        Ok(Self {
+            handle,
+            _conn: conn,
+            installed: Vec::new(),
+            fwmark,
+            table,
+            server_ipv4,
+        })
+    }
+
+    /// Installs all policy routing rules.
+    ///
+    /// Call this *before* any tunnel route is installed, so that no traffic can
+    /// be routed into the tunnel while only a subset of the rules exists.
+    pub async fn install(&mut self) -> Result<()> {
+        // Rule 100: marked traffic (the tunnel socket) resolves via `main`.
+        self.add_rule(RULE_PRIORITY_MARKED, Some(self.fwmark), RT_TABLE_MAIN)
+            .await
+            .context("Failed to add fwmark rule")?;
+
+        // Rule 105: rp_filter fix — unmarked lookups for the server IP are
+        // redirected to main so that strict rp_filter accepts the server's
+        // reply packets (which arrive on the physical interface, not the tunnel).
+        if let Some(server_ipv4) = self.server_ipv4 {
+            self.add_rule_with_destination(
+                RULE_PRIORITY_SERVER,
+                server_ipv4,
+                Ipv4Addr::BITS as u8,
+                RT_TABLE_MAIN,
+            )
+            .await
+            .context("Failed to add server-IP rp_filter rule")?;
+        }
+
+        // Rule 107: loop-breaker — if `main` has no route for marked traffic
+        // (e.g. during a Wi-Fi roam when the default route is momentarily
+        // absent), return ENETUNREACH instead of falling through to
+        // RULE_PRIORITY_TUNNEL and starting an encapsulation loop.
+        self.add_fwmark_unreachable_rule(RULE_PRIORITY_FWMARK_FALLBACK, self.fwmark)
+            .await
+            .context("Failed to add fwmark fallback rule")?;
+
+        // Rule 110: everything else goes to the tunnel table.
+        self.add_rule(RULE_PRIORITY_TUNNEL, None, self.table as u32)
+            .await
+            .context("Failed to add tunnel table rule")?;
+
+        tracing::info!(
+            fwmark = self.fwmark,
+            table = self.table,
+            "Installed policy routing rules"
+        );
+        Ok(())
+    }
+
+    async fn add_rule(&mut self, priority: u32, fwmark: Option<u32>, table: u32) -> Result<()> {
+        let mut req = self
+            .handle
+            .rule()
+            .add()
+            .v4()
+            .priority(priority)
+            .table_id(table)
+            .action(RuleAction::ToTable);
+
+        if let Some(mark) = fwmark {
+            req = req.fw_mark(mark);
+        }
+
+        let message = req.message_mut().clone();
+        req.execute().await?;
+        self.installed.push(message);
+
+        tracing::debug!(priority, ?fwmark, table, "Added ip rule");
+        Ok(())
+    }
+
+    async fn add_rule_with_destination(
+        &mut self,
+        priority: u32,
+        destination: Ipv4Addr,
+        prefix_len: u8,
+        table: u32,
+    ) -> Result<()> {
+        let mut req = self
+            .handle
+            .rule()
+            .add()
+            .v4()
+            .priority(priority)
+            .table_id(table)
+            .action(RuleAction::ToTable)
+            .destination_prefix(destination, prefix_len);
+
+        let message = req.message_mut().clone();
+        req.execute().await?;
+        self.installed.push(message);
+
+        tracing::debug!(priority, %destination, prefix_len, table, "Added ip rule with destination");
+        Ok(())
+    }
+
+    /// Adds a `fwmark <mark> unreachable` rule (no table lookup).
+    ///
+    /// The kernel maps `FR_ACT_UNREACHABLE` to `ENETUNREACH`, which the
+    /// outside-IO send callback already handles as a transient failure.
+    async fn add_fwmark_unreachable_rule(&mut self, priority: u32, fwmark: u32) -> Result<()> {
+        let mut req = self
+            .handle
+            .rule()
+            .add()
+            .v4()
+            .priority(priority)
+            .action(RuleAction::Unreachable)
+            .fw_mark(fwmark);
+
+        let message = req.message_mut().clone();
+        req.execute().await?;
+        self.installed.push(message);
+
+        tracing::debug!(priority, fwmark, "Added fwmark unreachable ip rule");
+        Ok(())
+    }
+
+    /// Removes every rule this instance installed.
+    ///
+    /// Failures are logged rather than propagated: leaving a stale rule behind
+    /// is bad, but aborting cleanup half way through is worse.
+    pub async fn cleanup(&mut self) {
+        for message in self.installed.drain(..).rev() {
+            if let Err(e) = self.handle.rule().del(message).execute().await {
+                tracing::warn!("Failed to delete ip rule during cleanup: {e}");
+            }
+        }
+        tracing::info!("Removed policy routing rules");
+    }
+}

--- a/lightway-client/src/policy_routing.rs
+++ b/lightway-client/src/policy_routing.rs
@@ -18,55 +18,56 @@
 //! determine which table is consulted:
 //!
 //! ```text
-//! priority 100:  fwmark <MARK>              lookup main   # (1) tunnel socket → WAN
-//! priority 105:  to <SERVER_IP>/32          lookup main   # (2) rp_filter fix (see below)
-//! priority 107:  fwmark <MARK>              unreachable   # (3) loop-breaker (see below)
-//! priority 110:  (no condition)             lookup <TABLE># (4) all other traffic → tunnel
+//! Rule MARKED:          fwmark <MARK>              lookup main   # (1) tunnel socket → WAN
+//! Rule SERVER:          to <SERVER_IP>/32          lookup main   # (2) rp_filter fix (see below)
+//! Rule MARKED_FALLBACK: fwmark <MARK>              unreachable   # (3) loop-breaker (see below)
+//! Rule TUNNEL:          (no condition)             lookup <TABLE># (4) all other traffic → tunnel
 //! ```
 //!
 //! The tunnel's outside socket carries `<MARK>`, so its outgoing packets hit
 //! Rule MARKED and resolve via *main* — whose default route the kernel keeps
 //! current on its own, with no Lightway-managed entry involved.
 //!
-//! # Rule 105 — rp_filter fix
+//! # Rule SERVER — rp_filter fix
 //!
 //! Linux's reverse-path filter (strict mode, `rp_filter=1`) checks incoming
 //! packets by looking up the *source* IP through the routing rules — but using
 //! the *incoming packet's* mark, which is 0 for plain packets from the WAN.
 //!
-//! After rule 110 is installed, an unmarked lookup for the server IP falls
-//! through rules 100 and 107 (both require `fwmark <MARK>`) and lands on
-//! rule 110 → tunnel table → `0.0.0.0/1 via lightway`.  Strict rp_filter
-//! would then consider `SERVER_IP` routed via `lightway`, but the server's
-//! reply packet arrived on `wlan0` (or whichever physical interface), producing
-//! an interface mismatch and silently **dropping** every pong — which the
-//! keepalive mechanism observes as a timeout.
+//! After Rule TUNNEL is installed, an unmarked lookup for the server IP falls
+//! through Rules MARKED and MARKED_FALLBACK (both require `fwmark <MARK>`) and
+//! lands on Rule TUNNEL → tunnel table → `0.0.0.0/1 via lightway`.  Strict
+//! rp_filter would then consider `SERVER_IP` routed via `lightway`, but the
+//! server's reply packet arrived on `wlan0` (or whichever physical interface),
+//! producing an interface mismatch and silently **dropping** every pong — which
+//! the keepalive mechanism observes as a timeout.
 //!
-//! Rule 105 intercepts the unmarked lookup for `<SERVER_IP>/32` and redirects
+//! Rule SERVER intercepts the unmarked lookup for `<SERVER_IP>/32` and redirects
 //! it to *main*, where the WAN default route sends it back out the physical
 //! interface.  rp_filter sees a consistent interface and accepts the packet.
 //!
-//! # Rule 107 — loop-breaker
+//! # Rule MARKED_FALLBACK — loop-breaker
 //!
 //! `ip rule` falls through to the next rule when the selected table returns no
 //! matching route.  During a Wi-Fi roam, the kernel removes the old default
 //! route from *main* before a new one arrives.  In that brief window:
 //!
-//! 1. Rule 100: `fwmark <MARK> → lookup main` — no route → **fall through**
-//! 2. Rule 105: `to <SERVER_IP>/32 → lookup main` — no route → **fall through**
-//! 3. Rule 107: (absent without this fix) — skipped
-//! 4. Rule 110: `→ lookup <TABLE>` — `0.0.0.0/1` and `128.0.0.0/1` via `tun`
+//! 1. Rule MARKED: `fwmark <MARK> → lookup main` — no route → **fall through**
+//! 2. Rule SERVER: `to <SERVER_IP>/32 → lookup main` — no route → **fall through**
+//! 3. Rule MARKED_FALLBACK: (absent without this fix) — skipped
+//! 4. Rule TUNNEL: `→ lookup <TABLE>` — `0.0.0.0/1` and `128.0.0.0/1` via `tun`
 //!    — the VPN socket's own encrypted packet is read back off the tun device
 //!    as an inside packet, re-encapsulated (+69 bytes per lap), and re-sent →
 //!    **encapsulation loop**.
 //!
-//! Rule 107 (`fwmark <MARK> unreachable`) intercepts the fall-through:
-//! - During normal operation marked packets are already handled by rule 100 and
-//!   rule 107 is never reached.
-//! - During a roam, marked packets fall through rules 100 and 105 (both consult
-//!   *main*, which has no route) and hit rule 107, which returns `ENETUNREACH`
-//!   to the caller.  The outside I/O callback already treats this as a transient
-//!   send failure, dropping the packet cleanly and preventing the loop.
+//! Rule MARKED_FALLBACK (`fwmark <MARK> unreachable`) intercepts the fall-through:
+//! - During normal operation marked packets are already handled by Rule MARKED and
+//!   Rule MARKED_FALLBACK is never reached.
+//! - During a roam, marked packets fall through Rules MARKED and SERVER (both
+//!   consult *main*, which has no route) and hit Rule MARKED_FALLBACK, which
+//!   returns `ENETUNREACH` to the caller.  The outside I/O callback already treats
+//!   this as a transient send failure, dropping the packet cleanly and preventing
+//!   the loop.
 
 use std::net::Ipv4Addr;
 
@@ -76,6 +77,25 @@ use anyhow::{Context, Result};
 // rtnetlink itself was built against.
 use rtnetlink::Handle;
 use rtnetlink::packet_route::rule::{RuleAction, RuleMessage};
+
+/// Prefix for all policy-routing names used by Lightway.
+///
+/// Each rule and the tunnel routing table get a distinct name under this prefix:
+///
+/// | Rule            | Name                                  | Visible in  |
+/// | --------------- | ------------------------------------- | ----------- |
+/// | MARKED          | `lightway-marked-0x<fwmark>`          | tracing log |
+/// | SERVER          | `lightway-server`                     | tracing log |
+/// | MARKED_FALLBACK | `lightway-marked-0x<fwmark>-fallback` | tracing log |
+/// | TUNNEL (table)  | `lightway-tunnel`                     | tracing log |
+const TABLE_PREFIX: &str = "lightway";
+
+/// Default firewall mark (`SO_MARK`) applied to the outside socket under `RouteMode::Fwmark` (Linux
+/// only).
+///
+/// Helium atomic symbol in Little-Endian byte order with padding
+/// number, an uncommon value unlikely to clash with other marks.
+pub const DEFAULT_FWMARK: u32 = 0x4865_0000;
 
 /// Priority of the rule matching the tunnel's own (marked) traffic.
 pub const RULE_PRIORITY_MARKED: u32 = 100;
@@ -89,10 +109,31 @@ pub const RULE_PRIORITY_SERVER: u32 = 105;
 ///
 /// Must be between [`RULE_PRIORITY_SERVER`] and [`RULE_PRIORITY_TUNNEL`].
 /// See the module-level documentation for a full explanation.
-pub const RULE_PRIORITY_FWMARK_FALLBACK: u32 = 107;
+pub const RULE_PRIORITY_MARKED_FALLBACK: u32 = 107;
 
 /// Priority of the rule sending everything else into the tunnel table.
 pub const RULE_PRIORITY_TUNNEL: u32 = 110;
+
+/// All fwmark policy-routing parameters bundled together.
+///
+/// Build one from [`crate::config::Config::fwmark_config`] and pass it to
+/// [`PolicyRouting::new`] to avoid threading five individual parameters through
+/// the call stack.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct FWMarkConfig {
+    /// Firewall mark (`SO_MARK`) set on the outside socket.
+    pub fwmark: u32,
+    /// Routing table id that holds the tunnel routes (must be 1..=252).
+    pub table: u8,
+    /// Priority of the tunnel-socket rule (must be < `rule_priority_marked_fallback`).
+    pub rule_priority_marked: u32,
+    /// Priority of the rp_filter-bypass rule (must be < `rule_priority_tunnel`).
+    pub rule_priority_server: u32,
+    /// Priority of the loop-breaker rule (must be < `rule_priority_tunnel`).
+    pub rule_priority_marked_fallback: u32,
+    /// Priority of the catch-all tunnel rule (must be > `rule_priority_marked` and `rule_priority_marked_fallback`).
+    pub rule_priority_tunnel: u32,
+}
 
 /// `main` routing table id.
 const RT_TABLE_MAIN: u32 = 254;
@@ -109,6 +150,10 @@ pub struct PolicyRouting {
     fwmark: u32,
     table: u8,
     server_ipv4: Option<Ipv4Addr>,
+    rule_priority_marked: u32,
+    rule_priority_server: u32,
+    rule_priority_marked_fallback: u32,
+    rule_priority_tunnel: u32,
 }
 
 impl PolicyRouting {
@@ -117,7 +162,7 @@ impl PolicyRouting {
     /// `server_ip` should be the VPN server's IPv4 address.  It is used to
     /// install the rp_filter-bypass rule (priority [`RULE_PRIORITY_SERVER`]).
     /// Pass `None` for IPv6-only servers where rp_filter handling is not needed.
-    pub fn new(fwmark: u32, table: u8, server_ip: std::net::IpAddr) -> Result<Self> {
+    pub fn new(cfg: FWMarkConfig, server_ip: std::net::IpAddr) -> Result<Self> {
         let server_ipv4 = match server_ip {
             std::net::IpAddr::V4(a) => Some(a),
             std::net::IpAddr::V6(_) => None,
@@ -131,9 +176,13 @@ impl PolicyRouting {
             handle,
             _conn: conn,
             installed: Vec::new(),
-            fwmark,
-            table,
+            fwmark: cfg.fwmark,
+            table: cfg.table,
             server_ipv4,
+            rule_priority_marked: cfg.rule_priority_marked,
+            rule_priority_server: cfg.rule_priority_server,
+            rule_priority_marked_fallback: cfg.rule_priority_marked_fallback,
+            rule_priority_tunnel: cfg.rule_priority_tunnel,
         })
     }
 
@@ -142,47 +191,73 @@ impl PolicyRouting {
     /// Call this *before* any tunnel route is installed, so that no traffic can
     /// be routed into the tunnel while only a subset of the rules exists.
     pub async fn install(&mut self) -> Result<()> {
-        // Rule 100: marked traffic (the tunnel socket) resolves via `main`.
-        self.add_rule(RULE_PRIORITY_MARKED, Some(self.fwmark), RT_TABLE_MAIN)
-            .await
-            .context("Failed to add fwmark rule")?;
+        let marked_name = format!("{TABLE_PREFIX}-marked-0x{:x}", self.fwmark);
+        let server_name = format!("{TABLE_PREFIX}-server");
+        let marked_fallback_name = format!("{TABLE_PREFIX}-marked-0x{:x}-fallback", self.fwmark);
+        let tunnel_name = format!("{TABLE_PREFIX}-tunnel");
 
-        // Rule 105: rp_filter fix — unmarked lookups for the server IP are
+        // Rule MARKED: marked traffic (the tunnel socket) resolves via `main`.
+        self.add_rule(
+            self.rule_priority_marked,
+            Some(self.fwmark),
+            RT_TABLE_MAIN,
+            &marked_name,
+        )
+        .await
+        .context("Failed to add fwmark rule")?;
+
+        // rp_filter fix — unmarked lookups for the server IP are
         // redirected to main so that strict rp_filter accepts the server's
         // reply packets (which arrive on the physical interface, not the tunnel).
         if let Some(server_ipv4) = self.server_ipv4 {
             self.add_rule_with_destination(
-                RULE_PRIORITY_SERVER,
+                self.rule_priority_server,
                 server_ipv4,
                 Ipv4Addr::BITS as u8,
                 RT_TABLE_MAIN,
+                &server_name,
             )
             .await
             .context("Failed to add server-IP rp_filter rule")?;
         }
 
-        // Rule 107: loop-breaker — if `main` has no route for marked traffic
+        // loop-breaker — if `main` has no route for marked traffic
         // (e.g. during a Wi-Fi roam when the default route is momentarily
         // absent), return ENETUNREACH instead of falling through to
-        // RULE_PRIORITY_TUNNEL and starting an encapsulation loop.
-        self.add_fwmark_unreachable_rule(RULE_PRIORITY_FWMARK_FALLBACK, self.fwmark)
-            .await
-            .context("Failed to add fwmark fallback rule")?;
+        // rule_priority_tunnel and starting an encapsulation loop.
+        self.add_fwmark_unreachable_rule(
+            self.rule_priority_marked_fallback,
+            self.fwmark,
+            &marked_fallback_name,
+        )
+        .await
+        .context("Failed to add fwmark fallback rule")?;
 
-        // Rule 110: everything else goes to the tunnel table.
-        self.add_rule(RULE_PRIORITY_TUNNEL, None, self.table as u32)
-            .await
-            .context("Failed to add tunnel table rule")?;
+        self.add_rule(
+            self.rule_priority_tunnel,
+            None,
+            self.table as u32,
+            &tunnel_name,
+        )
+        .await
+        .context("Failed to add tunnel table rule")?;
 
         tracing::info!(
             fwmark = self.fwmark,
-            table = self.table,
+            table = tunnel_name,
+            table_id = self.table,
             "Installed policy routing rules"
         );
         Ok(())
     }
 
-    async fn add_rule(&mut self, priority: u32, fwmark: Option<u32>, table: u32) -> Result<()> {
+    async fn add_rule(
+        &mut self,
+        priority: u32,
+        fwmark: Option<u32>,
+        table: u32,
+        rule_name: &str,
+    ) -> Result<()> {
         let mut req = self
             .handle
             .rule()
@@ -200,7 +275,7 @@ impl PolicyRouting {
         req.execute().await?;
         self.installed.push(message);
 
-        tracing::debug!(priority, ?fwmark, table, "Added ip rule");
+        tracing::debug!(priority, ?fwmark, table, rule_name, "Added ip rule");
         Ok(())
     }
 
@@ -210,6 +285,7 @@ impl PolicyRouting {
         destination: Ipv4Addr,
         prefix_len: u8,
         table: u32,
+        rule_name: &str,
     ) -> Result<()> {
         let mut req = self
             .handle
@@ -225,7 +301,7 @@ impl PolicyRouting {
         req.execute().await?;
         self.installed.push(message);
 
-        tracing::debug!(priority, %destination, prefix_len, table, "Added ip rule with destination");
+        tracing::debug!(priority, %destination, prefix_len, table, rule_name, "Added ip rule with destination");
         Ok(())
     }
 
@@ -233,7 +309,12 @@ impl PolicyRouting {
     ///
     /// The kernel maps `FR_ACT_UNREACHABLE` to `ENETUNREACH`, which the
     /// outside-IO send callback already handles as a transient failure.
-    async fn add_fwmark_unreachable_rule(&mut self, priority: u32, fwmark: u32) -> Result<()> {
+    async fn add_fwmark_unreachable_rule(
+        &mut self,
+        priority: u32,
+        fwmark: u32,
+        rule_name: &str,
+    ) -> Result<()> {
         let mut req = self
             .handle
             .rule()
@@ -247,7 +328,12 @@ impl PolicyRouting {
         req.execute().await?;
         self.installed.push(message);
 
-        tracing::debug!(priority, fwmark, "Added fwmark unreachable ip rule");
+        tracing::debug!(
+            priority,
+            fwmark,
+            rule_name,
+            "Added fwmark unreachable ip rule"
+        );
         Ok(())
     }
 

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -66,7 +66,30 @@ pub enum RouteMode {
     Default,
     Lan,
     NoExec,
+    /// Linux only: policy routing driven by a firewall mark.
+    ///
+    /// The tunnel's catch-all routes are installed in
+    /// [`FWMARK_ROUTE_TABLE`] instead of `main`, and no `/32` host route for
+    /// the server is created at all. The tunnel's own outbound packets are
+    /// steered by an `fwmark` rule (see [`crate::policy_routing`]) which
+    /// resolves via `main`, whose default route the kernel keeps current on its
+    /// own.
+    ///
+    /// This removes the window in which a network change can leave the server
+    /// unreachable except via the tunnel itself -- the condition that produces
+    /// an encapsulation loop.
+    ///
+    /// Requires `fwmark` to be set in the client config.
+    #[cfg(linux)]
+    Fwmark,
 }
+
+/// Routing table holding the tunnel routes under [`RouteMode::Fwmark`].
+///
+/// `route_manager` represents table ids as a `u8`, so this must be in `1..=252`
+/// to avoid the reserved `main` (254), `default` (253) and `local` (255) tables.
+#[cfg(linux)]
+pub const FWMARK_ROUTE_TABLE: u8 = 194;
 
 #[derive(Error, Debug)]
 pub enum RoutingTableError {
@@ -444,19 +467,32 @@ impl RouteManagerInner {
         let (default_interface_index, default_interface_gateway) =
             self.find_default_interface_index_and_gateway(&server_ip)?;
 
-        // Create server route with optional gateway - handles both direct routes (containers)
-        // and routed networks (host systems with gateways)
-        let prefix = host_prefix_len(&server_ip);
-        let server_route = Route::new(server_ip, prefix).with_if_index(default_interface_index);
-        let server_route = match default_interface_gateway {
-            Some(gateway) => server_route.with_gateway(gateway),
-            None => server_route,
-        };
+        // Under RouteMode::Fwmark the server is reached via the fwmark rule,
+        // which resolves through the `main` table. Installing a host route here
+        // would reintroduce the very dependency this mode exists to remove: a
+        // Lightway-managed route that can be transiently absent after a network
+        // change, during which server-bound traffic falls into the tunnel and
+        // loops.
+        #[cfg(linux)]
+        let skip_server_route = self.routing_mode == RouteMode::Fwmark;
+        #[cfg(not(target_os = "linux"))]
+        let skip_server_route = false;
 
-        #[cfg(windows)]
-        let server_route = server_route.with_metric(0);
+        if !skip_server_route {
+            // Create server route with optional gateway - handles both direct routes (containers)
+            // and routed networks (host systems with gateways)
+            let prefix = host_prefix_len(&server_ip);
+            let server_route = Route::new(server_ip, prefix).with_if_index(default_interface_index);
+            let server_route = match default_interface_gateway {
+                Some(gateway) => server_route.with_gateway(gateway),
+                None => server_route,
+            };
 
-        self.add_route_server(server_route).await?;
+            #[cfg(windows)]
+            let server_route = server_route.with_metric(0);
+
+            self.add_route_server(server_route).await?;
+        }
 
         if self.routing_mode == RouteMode::Lan {
             for (network, prefix) in LAN_NETWORKS {
@@ -483,6 +519,8 @@ impl RouteManagerInner {
             #[cfg(windows)]
             let tunnel_route = tunnel_route.with_metric(0);
 
+            let tunnel_route = self.apply_route_table(tunnel_route);
+
             self.add_route_vpn(tunnel_route).await?;
         }
 
@@ -493,13 +531,35 @@ impl RouteManagerInner {
         #[cfg(windows)]
         let dns_route = dns_route.with_metric(0);
 
+        let dns_route = self.apply_route_table(dns_route);
+
         self.add_route_vpn(dns_route).await?;
         Ok(())
+    }
+
+    /// Places tunnel-side routes in the dedicated table under
+    /// [`RouteMode::Fwmark`], and leaves them in `main` otherwise.
+    fn apply_route_table(&self, route: Route) -> Route {
+        #[cfg(linux)]
+        if self.routing_mode == RouteMode::Fwmark {
+            return route.with_table(FWMARK_ROUTE_TABLE);
+        }
+        route
     }
 
     /// Check if server route needs updating due to network changes. Returns
     /// whether the server route was actually replaced.
     async fn check_and_update_server_route(&mut self) -> Result<bool, RoutingTableError> {
+        // Under RouteMode::Fwmark there is no server host route to chase: the
+        // fwmark rule resolves via `main`, which the kernel updates itself when
+        // the default route changes. Doing nothing here is the correct and
+        // race-free behaviour.
+        #[cfg(linux)]
+        if self.routing_mode == RouteMode::Fwmark {
+            trace!("Fwmark mode: no server route to update");
+            return Ok(false);
+        }
+
         // Find the current default route to the server
         let server_ip = self.server_ip;
         let current_route = self.find_best_default_route(&server_ip)?;

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -86,10 +86,12 @@ pub enum RouteMode {
 
 /// Routing table holding the tunnel routes under [`RouteMode::Fwmark`].
 ///
-/// `route_manager` represents table ids as a `u8`, so this must be in `1..=252`
-/// to avoid the reserved `main` (254), `default` (253) and `local` (255) tables.
+/// Chosen as 2 — the atomic number of Helium — as a memorable low value that
+/// sits well below the reserved `main` (254), `default` (253) and `local` (255)
+/// tables. `route_manager` represents table ids as a `u8`, so this must be in
+/// `1..=252`.
 #[cfg(linux)]
-pub const FWMARK_ROUTE_TABLE: u8 = 194;
+pub const FWMARK_ROUTE_TABLE: u8 = 2;
 
 #[derive(Error, Debug)]
 pub enum RoutingTableError {
@@ -149,6 +151,8 @@ struct RouteManagerInner {
     vpn_routes: Vec<Route>,
     lan_routes: Vec<Route>,
     server_route: Option<Route>,
+    #[cfg(linux)]
+    fwmark_route_table: u8,
 }
 
 impl RouteManager {
@@ -158,6 +162,7 @@ impl RouteManager {
         tun_index: u32,
         tun_peer_ip: IpAddr,
         tun_dns_ip: IpAddr,
+        #[cfg(linux)] fwmark_route_table: u8,
     ) -> Result<Self, RoutingTableError> {
         let inner = Some(RouteManagerInner::new(
             routing_mode,
@@ -165,6 +170,8 @@ impl RouteManager {
             tun_index,
             tun_peer_ip,
             tun_dns_ip,
+            #[cfg(linux)]
+            fwmark_route_table,
         )?);
         Ok(Self { inner, task: None })
     }
@@ -224,6 +231,7 @@ impl RouteManagerInner {
         tun_index: u32,
         tun_peer_ip: IpAddr,
         tun_dns_ip: IpAddr,
+        #[cfg(linux)] fwmark_route_table: u8,
     ) -> Result<Self, RoutingTableError> {
         let route_manager =
             SyncRouteManager::new().map_err(RoutingTableError::RoutingManagerError)?;
@@ -240,6 +248,8 @@ impl RouteManagerInner {
             vpn_routes: Vec::with_capacity(TUNNEL_ROUTES.len() + 1),
             lan_routes: Vec::with_capacity(LAN_NETWORKS.len()),
             server_route: None,
+            #[cfg(linux)]
+            fwmark_route_table,
         })
     }
 
@@ -542,7 +552,7 @@ impl RouteManagerInner {
     fn apply_route_table(&self, route: Route) -> Route {
         #[cfg(linux)]
         if self.routing_mode == RouteMode::Fwmark {
-            return route.with_table(FWMARK_ROUTE_TABLE);
+            return route.with_table(self.fwmark_route_table);
         }
         route
     }
@@ -733,8 +743,15 @@ mod tests {
         }
 
         // Create RouteManagerInner directly for testing
-        let route_manager =
-            RouteManagerInner::new(route_mode, server_ip, tun_index, TUN_PEER_IP, TUN_DNS_IP)?;
+        let route_manager = RouteManagerInner::new(
+            route_mode,
+            server_ip,
+            tun_index,
+            TUN_PEER_IP,
+            TUN_DNS_IP,
+            #[cfg(linux)]
+            FWMARK_ROUTE_TABLE,
+        )?;
 
         // Return tuple - RouteManagerInner will be dropped first, then TUN device, RouteRestorer last
         Ok((restorer, tun_device, route_manager))
@@ -1026,8 +1043,16 @@ mod tests {
     #[serial_test::serial(route_manager)]
     #[ignore = "May falsely fail during development due to local route settings"]
     async fn test_route_manager_start_stop(route_mode: RouteMode) {
-        let mut route_manager =
-            RouteManager::new(route_mode, EXTERNAL_IP_V4, 0, TUN_PEER_IP, TUN_DNS_IP).unwrap();
+        let mut route_manager = RouteManager::new(
+            route_mode,
+            EXTERNAL_IP_V4,
+            0,
+            TUN_PEER_IP,
+            TUN_DNS_IP,
+            #[cfg(linux)]
+            FWMARK_ROUTE_TABLE,
+        )
+        .unwrap();
 
         // Test that we can start the route manager
         let start_result = route_manager.start().await;
@@ -1063,6 +1088,8 @@ mod tests {
             0,
             TUN_PEER_IP,
             TUN_DNS_IP,
+            #[cfg(linux)]
+            0,
         )
         .unwrap();
         let updater = route_manager.start().await.unwrap();
@@ -1086,8 +1113,15 @@ mod tests {
     #[tokio::test]
     async fn test_route_manager_inner_structure(route_mode: RouteMode) {
         // Test that RouteManagerInner can be created directly
-        let inner_result =
-            RouteManagerInner::new(route_mode, EXTERNAL_IP_V4, 0, TUN_PEER_IP, TUN_DNS_IP);
+        let inner_result = RouteManagerInner::new(
+            route_mode,
+            EXTERNAL_IP_V4,
+            0,
+            TUN_PEER_IP,
+            TUN_DNS_IP,
+            #[cfg(linux)]
+            FWMARK_ROUTE_TABLE,
+        );
         assert!(inner_result.is_ok());
 
         let inner = inner_result.unwrap();
@@ -1109,6 +1143,8 @@ mod tests {
             0,
             TUN_PEER_IP,
             TUN_DNS_IP,
+            #[cfg(linux)]
+            FWMARK_ROUTE_TABLE,
         )
         .unwrap();
 
@@ -1162,6 +1198,8 @@ mod tests {
             1,
             TUN_PEER_IP,
             TUN_DNS_IP,
+            #[cfg(linux)]
+            FWMARK_ROUTE_TABLE,
         )
         .unwrap();
 
@@ -1180,6 +1218,8 @@ mod tests {
             1,
             TUN_PEER_IP,
             TUN_DNS_IP,
+            #[cfg(linux)]
+            FWMARK_ROUTE_TABLE,
         );
         assert!(inner.is_ok());
 

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -62,7 +62,7 @@ const TUNNEL_ROUTES: [(IpAddr, u8); 2] = [
 #[serde(rename_all = "lowercase")]
 #[value(rename_all = "lowercase")]
 pub enum RouteMode {
-    #[default]
+    #[cfg_attr(not(linux), default)]
     Default,
     Lan,
     NoExec,
@@ -81,6 +81,7 @@ pub enum RouteMode {
     ///
     /// Requires `fwmark` to be set in the client config.
     #[cfg(linux)]
+    #[cfg_attr(linux, default)]
     Fwmark,
 }
 

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -1792,6 +1792,11 @@ impl<AppState: Send> Connection<AppState> {
 
         let outside_received_pending = &mut self.session.io_cb_mut().recv_buf;
         outside_received_pending.extend_from_slice(&buf[..]);
+        // Bytes handed to wolfSSL on this call. For datagram transport the
+        // recv_buf was cleared at the end of the previous call, so this equals
+        // the size of the current record.
+        #[cfg(feature = "debug")]
+        let fed_bytes = buf.len();
 
         let frame_read_count_result = match self.state {
             State::Connecting => match self.session.try_negotiate()? {
@@ -1825,6 +1830,30 @@ impl<AppState: Send> Connection<AppState> {
         if self.connection_type.is_datagram() {
             let outside_received_pending = &mut self.session.io_cb_mut().recv_buf;
             outside_received_pending.clear();
+        }
+
+        // DIAGNOSTIC (UDP roaming): a datagram carried bytes into wolfSSL but no
+        // frame came back out. For DTLS this is a *silent* drop inside wolfSSL
+        // (replay window or AEAD/MAC failure) surfacing as WANT_READ ->
+        // Poll::PendingRead -> Ok(0). This is exactly the path that blocks UDP
+        // session recovery ("float") after a NAT rebind: the server's udp.rs
+        // treats Ok(0) as a replay attempt and never updates the peer address.
+        // Log it so the drops can be counted and correlated with the address
+        // change. To learn *why* wolfSSL dropped it (replay vs bad MAC), enable
+        // the wolfSSL debug bridge (server: build with `--features debug` and set
+        // `tls_debug: true`; watch target `ssl_debug`).
+        #[cfg(feature = "debug")]
+        if self.connection_type.is_datagram()
+            && matches!(self.state, State::Online)
+            && fed_bytes > 0
+            && matches!(frame_read_count_result.as_ref(), Ok(&0))
+        {
+            debug!(
+                session = ?self.session_id,
+                peer = ?self.peer_addr(),
+                bytes_fed = fed_bytes,
+                "DTLS record decoded to 0 frames: silently dropped by wolfSSL (replay or bad MAC)"
+            );
         }
 
         frame_read_count_result

--- a/tests/e2e/Earthfile
+++ b/tests/e2e/Earthfile
@@ -5,9 +5,11 @@ build-container:
     COPY \
         docker-compose.yml \
         docker-compose.parallel_connect.yml \
+        docker-compose.wifi-switch.yml \
         run-with-compose-stack.sh \
         run-simple-test.sh \
         run-udp-floating-test.sh \
         run-parallel-connect-test.sh \
+        run-wifi-switch-test.sh \
         .
 

--- a/tests/e2e/docker-compose.wifi-switch.yml
+++ b/tests/e2e/docker-compose.wifi-switch.yml
@@ -1,0 +1,76 @@
+name: lightway-e2e
+
+networks:
+  frontend: # client <-> server (primary interface, initial VPN path)
+    driver: bridge
+    internal: true
+    ipam:
+      config:
+        - subnet: 192.168.200.0/24
+
+  frontend2: # client <-> server (secondary interface, post-switch VPN path)
+    driver: bridge
+    internal: true
+    ipam:
+      config:
+        - subnet: 192.168.201.0/24
+
+  backend: # server <-> The World
+    driver: bridge
+    internal: true
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.0.0.0/16
+
+services:
+  server:
+    image: lightway-test-server:latest
+    command: ${SERVER_ARGS}
+    stop_signal: SIGTERM
+    stop_grace_period: 10s
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - "/dev/net/tun:/dev/net/tun"
+    networks:
+      - frontend
+      - frontend2
+      - backend
+
+  nginx:
+    image: lightway-test-nginx:latest
+    networks:
+      backend:
+        ipv4_address: 10.0.0.42
+
+  iperf:
+    image: lightway-test-iperf:latest
+    networks:
+      backend:
+        ipv4_address: 10.0.0.43
+
+  client:
+    image: lightway-test-client:latest
+    command: ${CLIENT_ARGS}
+    stop_signal: SIGTERM
+    stop_grace_period: 10s
+    sysctls:
+      - net.ipv4.conf.all.promote_secondaries=1
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - "/dev/net/tun:/dev/net/tun"
+    depends_on:
+      server:
+        condition: service_healthy
+      nginx:
+        condition: service_healthy
+      iperf:
+        condition: service_healthy
+    networks:
+      - frontend
+      - frontend2
+    extra_hosts:
+      nginx: "10.0.0.42"
+      iperf: "10.0.0.43"

--- a/tests/e2e/run-wifi-switch-test.sh
+++ b/tests/e2e/run-wifi-switch-test.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo ""
+echo "====================================================================="
+echo "INITIAL CONNECTIVITY CHECK"
+echo "====================================================================="
+
+docker compose exec client ping -W 1 -c 3 nginx
+
+echo ""
+echo "====================================================================="
+echo "VERIFY VPN CONNECTIVITY BEFORE WIFI SWITCH"
+echo "====================================================================="
+
+docker compose exec client ping -W 1 -c 3 nginx
+
+tunnel_ip=$(docker compose exec client ip --json addr show lightway | jq -r '.[0].addr_info[0].local')
+echo "Tunnel IP: ${tunnel_ip}"
+
+# Identify the physical interface currently used to route to the server
+server_ip=$(docker compose exec client getent hosts server | awk '{print $1}' | head -1)
+active_iface=$(docker compose exec client ip --json route get "$server_ip" | jq -r '.[0].dev')
+active_ip=$(docker compose exec client ip --json addr show "$active_iface" | jq -r '.[0].addr_info[0].local')
+
+echo "Server IP: ${server_ip}"
+echo "Active interface: ${active_iface} (${active_ip})"
+
+echo ""
+docker compose exec client ip addr show
+echo ""
+docker compose exec client ip route show
+
+# ---------------------------------------------------------------------
+
+echo ""
+echo "====================================================================="
+echo "SIMULATING WIFI SWITCH: Deleting ${active_iface} (${active_ip})"
+echo "====================================================================="
+
+docker compose exec client ip link delete "${active_iface}"
+
+echo ""
+echo "Client interfaces after switch:"
+docker compose exec client ip addr show
+echo ""
+docker compose exec client ip route show
+
+# ---------------------------------------------------------------------
+
+echo ""
+echo "====================================================================="
+echo "WAITING FOR VPN TO RECONNECT VIA SECONDARY INTERFACE"
+echo "====================================================================="
+
+MAX_WAIT=60
+INTERVAL=5
+elapsed=0
+reconnected=false
+
+while [ "$elapsed" -lt "$MAX_WAIT" ]; do
+    if docker compose exec client ping -W 1 -c 1 nginx > /dev/null 2>&1; then
+        reconnected=true
+        echo "VPN reconnected after ${elapsed}s"
+        break
+    fi
+    echo "Waiting for reconnection... (${elapsed}/${MAX_WAIT}s)"
+    sleep "$INTERVAL"
+    elapsed=$(( elapsed + INTERVAL ))
+done
+
+if [ "$reconnected" != "true" ]; then
+    echo "VPN failed to reconnect within ${MAX_WAIT}s"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------
+
+echo ""
+echo "====================================================================="
+echo "VERIFY VPN CONNECTIVITY AFTER WIFI SWITCH"
+echo "====================================================================="
+
+docker compose exec client ping -W 1 -c 3 nginx
+
+REPLY=$(docker compose exec client curl --silent http://nginx)
+IP=$(<<< "$REPLY" jq -e -r '.ip // "fail"' || echo "invalid-json")
+
+echo ""
+echo "curl replied: $REPLY"
+echo "Server saw IP: $IP"
+echo ""
+
+case $IP in
+    "fail")
+        echo "Invalid response from nginx"
+        exit 1
+        ;;
+    "invalid-json")
+        echo "JSON response did not contain ip key"
+        exit 1
+        ;;
+    "${tunnel_ip}")
+        echo "nginx saw our real tunnel IP!"
+        exit 1
+        ;;
+    "10.0."*)
+        echo "nginx saw a backend network IP address -- VPN is masquerading correctly!"
+        ;;
+    *)
+        echo "nginx unexpectedly saw IP ${IP}"
+        exit 1
+        ;;
+esac
+
+new_iface=$(docker compose exec client ip --json route get "$server_ip" | jq -r '.[0].dev')
+new_ip=$(docker compose exec client ip --json addr show "$new_iface" | jq -r '.[0].addr_info[0].local')
+echo ""
+echo "VPN reconnected via: ${new_iface} (${new_ip})"
+
+echo ""
+echo "====================================================================="
+echo "WIFI SWITCH TEST PASSED"
+echo "====================================================================="


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Introduces `RouteMode::Fwmark` (Linux only) and makes it the default route mode on Linux. Instead of the reactive /32 host-route approach, four `ip rule` entries are installed before any tunnel route is added:

```
Rule MARKED:          fwmark <MARK>      → main         # tunnel socket → WAN
Rule SERVER:          to <SERVER_IP>/32  → main         # rp_filter fix
Rule MARKED_FALLBACK: fwmark <MARK>      → unreachable  # loop-breaker (roam guard)
Rule TUNNEL:          (no condition)     → <TABLE>      # all other traffic → tunnel
```

On Linux (non-mobile), the outside UDP socket is always stamped with `SO_MARK` when `fwmark != 0`, regardless of route mode. Under `RouteMode::Fwmark` this causes Rule MARKED to steer the socket's packets via `main`; because the kernel owns the main-table default route, no host route is installed and there is nothing to race against during a roam.  In `RouteMode::NoExec` the four ip rules are never installed, so the mark is present on the socket but has no routing effect, and in this mode `SO_MARK` can be overwriten and turn it off by `--fwmark=0` in command line.

Additional changes in this PR:

- **`FWMarkConfig` parameters are user-configurable** — `fwmark`, `fwmark_route_table`, `rule_priority_server`, `rule_priority_fwmark_fallback`, and `rule_priority_tunnel` are exposed as config file and CLI options. `Config::validate()` enforces that priorities are in the required ordering.
- **Tunnel table registered in `/etc/iproute2/rt_tables`** — `register_rt_table`/`unregister_rt_table` helpers register the tunnel routing table under the human-readable name `lightway-tunnel` so that `ip rule show` displays `from all lookup lightway-tunnel` instead of a bare numeric id. Registration failures are logged but do not abort rule installation.
- **DTLS debug log added** — a `debug` log in `lightway-core/src/connection.rs` surfaces silent DTLS record drops (0 frames decoded, treated as a replay attack) to aid diagnosis of UDP session recovery failures after NAT rebinds.
- **Documentation** — `docs/policy_routing.md` covers the race condition, the four ip rules and their roles, a full packet lifetime trace, `RouteMode` comparison, `FWMarkConfig` parameters, and initialization/shutdown ordering.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Without fwmark mode, the tunnel avoids routing its own encrypted packets back into itself via a Lightway-managed /32 host route for the VPN server. After a network change (Wi-Fi roam, NAT rebind) there is a window where that host route is gone but not yet replaced: the server IP matches the tunnel catch-all, packets are re-encapsulated each lap, and the link saturates.

`RouteMode::Fwmark` eliminates this race entirely — the ip rules are independent of route table state and require no teardown/reinstall during roams. Rule MARKED_FALLBACK additionally breaks any residual encapsulation loop during a roam when the main table has no route at all, returning `ENETUNREACH` and treating it as a transient send failure.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Verified `ip rule show` displays named table entries (`lightway-tunnel`) after connection, and that they are cleaned up on disconnect.
- Verified no encapsulation loop occurs during a simulated Wi-Fi roam (disconnect/reconnect) with `RouteMode::Fwmark` active.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
- [ ] Any update to `xenon/libxenon-src` is accompanied by a reference to the specific commit in the git changelog
