### PR TITLE
CVPN-2682: connected outside UDP socket on Apple platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android-build"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fc9904ad2ad097c3c1cfe2eacaaf0fc24710936fa9ed941cb310b7c6ed2ab7"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "android_log-sys"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +579,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -1416,6 +1435,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,6 +1622,7 @@ dependencies = [
  "libc",
  "lightway-core",
  "metrics",
+ "netwatcher",
  "pnet_packet",
  "regex",
  "route_manager",
@@ -1877,6 +1946,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "netconfig-rs"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,7 +1969,7 @@ dependencies = [
  "system-configuration-sys",
  "thiserror 2.0.18",
  "widestring",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -1939,6 +2014,20 @@ dependencies = [
  "bytes",
  "libc",
  "log",
+]
+
+[[package]]
+name = "netwatcher"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a73c134b9d8ca27ba209646851858cd112fb543b6ecf48019c64b29c91b3b18a"
+dependencies = [
+ "android-build",
+ "jni",
+ "ndk-context",
+ "nix 0.31.3",
+ "tokio",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -2604,6 +2693,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,6 +2725,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "saphyr-parser-bw"
@@ -2952,6 +3059,22 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -3758,6 +3881,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3859,6 +3992,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3870,11 +4012,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -3884,6 +4038,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3931,7 +4094,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -3979,6 +4153,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4012,6 +4196,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
@@ -4055,6 +4248,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/lightway-app-utils/Cargo.toml
+++ b/lightway-app-utils/Cargo.toml
@@ -47,6 +47,10 @@ tun-rs.workspace = true
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]
 route_manager.workspace = true
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Address-change watching (PF_ROUTE doorbell + getifaddrs snapshot diff).
+netwatcher = { version = "0.7.1", features = ["tokio"] }
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",

--- a/lightway-app-utils/src/lib.rs
+++ b/lightway-app-utils/src/lib.rs
@@ -5,6 +5,8 @@ pub mod args;
 #[cfg(apple)]
 pub mod recvmsg_x;
 pub mod sockopt;
+#[cfg(apple)]
+pub mod udp_disconnect;
 
 #[cfg(feature = "tokio")]
 mod connection_ticker;

--- a/lightway-app-utils/src/network_change_monitor.rs
+++ b/lightway-app-utils/src/network_change_monitor.rs
@@ -1,24 +1,40 @@
 //! Reusable network-change monitor.
 //!
-//! Spawns the platform route/address listeners and republishes their events as a coalescing
-//! [`tokio::sync::watch`] signal. Consumers can [`subscribe`](NetworkChangeMonitor::subscribe) to
-//! network changes
+//! Spawns the platform route/address listeners and republishes their events as
+//! two coalescing [`tokio::sync::watch`] signals: *routes* (an applicable
+//! default route changed — the trigger for route-table fixups) and
+//! *transitions* (the machine moved networks: on macOS an address change and
+//! an applicable route *arrival* — add or change, not delete — within a short
+//! window; on Windows any detected change, since route changes are not always
+//! published there; never fired on platforms without an address listener).
 
 #[cfg(windows)]
 mod addr_monitor;
 
 use anyhow::Result;
-use route_manager::{AsyncRouteListener, RouteChange};
+use route_manager::{AsyncRouteListener, Route, RouteChange};
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
 #[cfg(windows)]
 use addr_monitor::AsyncAddrListener;
 
-/// Monitors network changes (route and, on Windows, address changes) and
-/// publishes a notification each time one is detected.
+#[cfg(any(macos, test))]
+use std::time::{Duration, Instant};
+
+/// Generous pairing window: joining a network can assign the address seconds
+/// before the default route is installed.
+#[cfg(macos)]
+const TRANSITION_WINDOW: Duration = Duration::from_secs(15);
+
+/// Minimum spacing between transitions, collapsing event bursts into one.
+#[cfg(macos)]
+const TRANSITION_COOLDOWN: Duration = Duration::from_secs(3);
+
+/// Monitors network changes and publishes route and transition notifications.
 pub struct NetworkChangeMonitor {
-    rx: watch::Receiver<()>,
+    route_rx: watch::Receiver<()>,
+    transition_rx: watch::Receiver<()>,
     task: JoinHandle<()>,
 }
 
@@ -27,14 +43,15 @@ impl NetworkChangeMonitor {
     /// spawned task.
     ///
     /// `ignore_ips` lists local addresses (the tunnel's own address) that must
-    /// not be treated as network changes. On Windows the address listener uses
-    /// it to filter out the client's own TUN interface coming up; on other
-    /// platforms it is unused.
+    /// not be treated as network changes. The address listeners use it to
+    /// filter out the client's own TUN interface coming up; on platforms
+    /// without an address listener it is unused.
     pub fn spawn(ignore_ips: Vec<std::net::IpAddr>) -> Result<Self> {
-        let (tx, rx) = watch::channel(());
+        let (route_tx, route_rx) = watch::channel(());
+        let (transition_tx, transition_rx) = watch::channel(());
 
         let task = tokio::spawn(async move {
-            #[cfg(not(windows))]
+            #[cfg(not(any(windows, macos)))]
             let _ = ignore_ips;
 
             let mut route_listener = match AsyncRouteListener::new() {
@@ -59,10 +76,16 @@ impl NetworkChangeMonitor {
                 }
             };
 
-            #[cfg(not(windows))]
+            #[cfg(macos)]
+            let mut addr_listener = Some(spawn_macos_addr_listener(ignore_ips));
+
+            #[cfg(not(any(windows, macos)))]
             let (_sender, addr_listener) = tokio::sync::mpsc::unbounded_channel::<()>();
-            #[cfg(not(windows))]
+            #[cfg(not(any(windows, macos)))]
             let mut addr_listener = Some(addr_listener);
+
+            #[cfg(macos)]
+            let mut detector = TransitionDetector::new(TRANSITION_WINDOW, TRANSITION_COOLDOWN);
 
             tracing::info!("Started monitoring route/intf...");
             loop {
@@ -74,11 +97,22 @@ impl NetworkChangeMonitor {
                                let (RouteChange::Add(route)
                                | RouteChange::Delete(route)
                                | RouteChange::Change(route)) = &route_change;
-                               if route.prefix() == 0
-                                   && route.gateway().is_some_and(|gw| !gw.is_unspecified())
-                                   && tx.send(()).is_err() {
-                                   tracing::debug!("No network change receivers left, stopping monitor");
-                                   break;
+                               if is_applicable_route(route) {
+                                   let _ = route_tx.send(());
+                                   // Only a route *arriving* arms a transition:
+                                   // a machine moving networks is signalled by
+                                   // the new default route showing up, while
+                                   // the old one vanishing (the down-leg of a
+                                   // roam) leaves nothing to probe yet.
+                                   #[cfg(macos)]
+                                   if !matches!(route_change, RouteChange::Delete(_))
+                                       && detector.on_route(Instant::now())
+                                   {
+                                       tracing::info!("Network transition detected");
+                                       let _ = transition_tx.send(());
+                                   }
+                                   #[cfg(windows)]
+                                   let _ = transition_tx.send(());
                                }
                            }
                            Err(e) => {
@@ -91,29 +125,59 @@ impl NetworkChangeMonitor {
 
                    // On address/intf changes, notify too. This helps catch
                    // network transitions that don't trigger route changes.
-                   _ = async {
+                   addr_event = async {
                        if let Some(listener) = &mut addr_listener {
                            listener.recv().await
                        } else {
                            std::future::pending().await
                        }
                    } => {
-                       tracing::debug!("Address change detected");
-                       if tx.send(()).is_err() {
-                           tracing::debug!("No network change receivers left, stopping monitor");
-                           break;
+                       match addr_event {
+                           Some(_) => {
+                               tracing::debug!("Address change detected");
+                               #[cfg(macos)]
+                               if detector.on_addr(Instant::now()) {
+                                   tracing::info!("Network transition detected");
+                                   let _ = transition_tx.send(());
+                               }
+                               #[cfg(windows)]
+                               {
+                                   let _ = route_tx.send(());
+                                   let _ = transition_tx.send(());
+                               }
+                           }
+                           None => {
+                               // Source ended; park it rather than spinning.
+                               tracing::debug!("Address listener stopped");
+                               addr_listener = None;
+                           }
                        }
                    }
+                }
+
+                if route_tx.is_closed() && transition_tx.is_closed() {
+                    tracing::debug!("No network change receivers left, stopping monitor");
+                    break;
                 }
             }
         });
 
-        Ok(Self { rx, task })
+        Ok(Self {
+            route_rx,
+            transition_rx,
+            task,
+        })
     }
 
-    /// Get a receiver that fires whenever a network change is detected.
-    pub fn subscribe(&self) -> watch::Receiver<()> {
-        self.rx.clone()
+    /// Get a receiver that fires whenever an applicable route changed.
+    pub fn subscribe_routes(&self) -> watch::Receiver<()> {
+        self.route_rx.clone()
+    }
+
+    /// Get a receiver that fires on a network transition (see module docs for
+    /// the per-platform semantics).
+    pub fn subscribe_transitions(&self) -> watch::Receiver<()> {
+        self.transition_rx.clone()
     }
 }
 
@@ -123,16 +187,129 @@ impl Drop for NetworkChangeMonitor {
     }
 }
 
+/// A real default-route event: prefix 0 with a proper gateway, excluding
+/// macOS interface-scoped defaults (a non-primary service's churn is not a
+/// path change).
+fn is_applicable_route(route: &Route) -> bool {
+    // `Route::if_scope` only exists on macOS.
+    #[cfg(macos)]
+    if route.if_scope() {
+        return false;
+    }
+    route.prefix() == 0 && route.gateway().is_some_and(|gw| !gw.is_unspecified())
+}
+
+/// Bridge netwatcher's interface updates to a unit-event channel, diffing our
+/// own snapshot of the relevant address set rather than trusting the update's
+/// diff (which can be empty, e.g. on address reordering).
+#[cfg(macos)]
+fn spawn_macos_addr_listener(
+    ignore_ips: Vec<std::net::IpAddr>,
+) -> tokio::sync::mpsc::UnboundedReceiver<()> {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    tokio::spawn(async move {
+        let mut watcher =
+            match netwatcher::watch_interfaces_async::<netwatcher::async_adapter::Tokio>() {
+                Ok(w) => {
+                    tracing::info!("Started address change monitoring (macOS)...");
+                    w
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to start macOS address listener: {e}");
+                    return;
+                }
+            };
+
+        // The first `changed()` yields the initial snapshot; it only seeds.
+        let mut prev: Option<std::collections::BTreeSet<std::net::IpAddr>> = None;
+        loop {
+            let update = watcher.changed().await;
+            let now = relevant_addrs(
+                update
+                    .interfaces
+                    .values()
+                    .flat_map(|iface| iface.ips.iter().map(|record| record.ip)),
+                &ignore_ips,
+            );
+            let is_change = prev.as_ref().is_some_and(|p| *p != now);
+            prev = Some(now);
+            if is_change && tx.send(()).is_err() {
+                // Monitor dropped; returning drops the watcher.
+                break;
+            }
+        }
+    });
+    rx
+}
+
+/// Detects a network transition: an address change and an applicable route
+/// arrival (in either order) within `window` of each other, rate-limited by
+/// `cooldown`. An emitted pair is consumed. The caller filters route deletes
+/// out before feeding `on_route`.
+#[cfg(any(macos, test))]
+struct TransitionDetector {
+    window: Duration,
+    cooldown: Duration,
+    last_addr: Option<Instant>,
+    last_route: Option<Instant>,
+    last_emit: Option<Instant>,
+}
+
+#[cfg(any(macos, test))]
+impl TransitionDetector {
+    fn new(window: Duration, cooldown: Duration) -> Self {
+        Self {
+            window,
+            cooldown,
+            last_addr: None,
+            last_route: None,
+            last_emit: None,
+        }
+    }
+
+    /// Returns true when the event at `now` completes a transition.
+    fn on_addr(&mut self, now: Instant) -> bool {
+        self.last_addr = Some(now);
+        self.try_emit(now)
+    }
+
+    /// Returns true when the event at `now` completes a transition.
+    fn on_route(&mut self, now: Instant) -> bool {
+        self.last_route = Some(now);
+        self.try_emit(now)
+    }
+
+    fn try_emit(&mut self, now: Instant) -> bool {
+        let (Some(addr), Some(route)) = (self.last_addr, self.last_route) else {
+            return false;
+        };
+        let paired =
+            now.duration_since(addr) <= self.window && now.duration_since(route) <= self.window;
+        let cooled = self
+            .last_emit
+            .is_none_or(|e| now.duration_since(e) >= self.cooldown);
+        if paired && cooled {
+            // Consume the pair.
+            self.last_addr = None;
+            self.last_route = None;
+            self.last_emit = Some(now);
+            true
+        } else {
+            false
+        }
+    }
+}
+
 /// Reduce the system's unicast addresses to those whose appearance or
 /// disappearance constitutes a real network change.
 ///
 /// Loopback, link-local and unspecified addresses are configuration noise.
 /// `ignore` carries the local tunnel address(es) so the VPN's own interface
-/// coming up — which the Windows `NotifyAddrChange` API reports just like any
+/// coming up — which the platform address listeners report just like any
 /// other address change — is not mistaken for a path change. Comparing
 /// successive snapshots of this set lets the monitor signal only on genuine
 /// changes.
-#[cfg(any(windows, test))]
+#[cfg(any(windows, macos, test))]
 pub(crate) fn relevant_addrs(
     addrs: impl IntoIterator<Item = std::net::IpAddr>,
     ignore: &[std::net::IpAddr],
@@ -145,7 +322,7 @@ pub(crate) fn relevant_addrs(
         .collect()
 }
 
-#[cfg(any(windows, test))]
+#[cfg(any(windows, macos, test))]
 fn is_link_local(ip: &std::net::IpAddr) -> bool {
     match ip {
         std::net::IpAddr::V4(v4) => v4.is_link_local(),
@@ -197,5 +374,79 @@ mod tests {
             relevant_addrs([loopback, link_local, v6_link_local, nic], &[]),
             BTreeSet::from([nic])
         );
+    }
+
+    const WINDOW: Duration = Duration::from_secs(15);
+    const COOLDOWN: Duration = Duration::from_secs(3);
+
+    fn detector() -> (TransitionDetector, Instant) {
+        (TransitionDetector::new(WINDOW, COOLDOWN), Instant::now())
+    }
+
+    fn at(base: Instant, secs: u64) -> Instant {
+        base + Duration::from_secs(secs)
+    }
+
+    #[test]
+    fn route_churn_alone_is_not_a_transition() {
+        let (mut d, t0) = detector();
+        assert!(!d.on_route(at(t0, 0)));
+        assert!(!d.on_route(at(t0, 1)));
+        assert!(!d.on_route(at(t0, 30)));
+    }
+
+    #[test]
+    fn addr_change_alone_is_not_a_transition() {
+        let (mut d, t0) = detector();
+        assert!(!d.on_addr(at(t0, 0)));
+        assert!(!d.on_addr(at(t0, 20)));
+    }
+
+    #[test]
+    fn addr_then_route_within_window_is_a_transition() {
+        let (mut d, t0) = detector();
+        // Join sequence: DHCP address first, default route seconds later.
+        assert!(!d.on_addr(at(t0, 0)));
+        assert!(d.on_route(at(t0, 5)));
+    }
+
+    #[test]
+    fn route_then_addr_within_window_is_a_transition() {
+        let (mut d, t0) = detector();
+        // Leave sequence: route-delete and addr-delete land together.
+        assert!(!d.on_route(at(t0, 0)));
+        assert!(d.on_addr(at(t0, 1)));
+    }
+
+    #[test]
+    fn stale_pair_outside_window_is_not_a_transition() {
+        let (mut d, t0) = detector();
+        assert!(!d.on_addr(at(t0, 0)));
+        // Route arrives after the address evidence expired ...
+        assert!(!d.on_route(at(t0, 20)));
+        // ... but fresh address evidence pairs with the still-recent route.
+        assert!(d.on_addr(at(t0, 21)));
+    }
+
+    #[test]
+    fn emitted_pair_is_consumed() {
+        let (mut d, t0) = detector();
+        assert!(!d.on_addr(at(t0, 0)));
+        assert!(d.on_route(at(t0, 1)));
+        // Burst continues: single legs alone must not re-fire.
+        assert!(!d.on_route(at(t0, 2)));
+        assert!(!d.on_addr(at(t0, 30)));
+    }
+
+    #[test]
+    fn cooldown_suppresses_back_to_back_transitions() {
+        let (mut d, t0) = detector();
+        assert!(!d.on_addr(at(t0, 0)));
+        assert!(d.on_route(at(t0, 1)));
+        // A full new pair within the cooldown stays suppressed ...
+        assert!(!d.on_addr(at(t0, 2)));
+        assert!(!d.on_route(at(t0, 3)));
+        // ... and emits once the cooldown has passed (evidence still fresh).
+        assert!(d.on_addr(at(t0, 5)));
     }
 }

--- a/lightway-app-utils/src/udp_disconnect.rs
+++ b/lightway-app-utils/src/udp_disconnect.rs
@@ -1,0 +1,31 @@
+//! Dissolve a UDP socket's peer association (Apple platforms).
+#![allow(unsafe_code)]
+
+use std::io;
+use std::os::fd::AsRawFd;
+
+/// Dissolve the peer association of a `connect()`-ed UDP socket.
+///
+/// After this call the socket can be used with `send_to` again (`send_to` on a
+/// connected socket fails with `EISCONN`), and the implicitly bound local
+/// address is cleared, so the kernel re-selects the route and source address
+/// per packet. The local port is retained.
+///
+/// Dissolving an already-unconnected socket reports `ENOTCONN`.
+pub fn udp_disconnect(sock: &impl AsRawFd) -> io::Result<()> {
+    // SAFETY: `disconnectx` performs no memory access through its arguments;
+    // the fd is valid for the lifetime of `sock` and the wildcard association /
+    // connection ids are documented constants.
+    let rc = unsafe {
+        libc::disconnectx(
+            sock.as_raw_fd(),
+            libc::SAE_ASSOCID_ANY,
+            libc::SAE_CONNID_ANY,
+        )
+    };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}

--- a/lightway-client/src/config.rs
+++ b/lightway-client/src/config.rs
@@ -231,6 +231,18 @@ pub struct Config {
     #[patch(attribute(doc = "Enable Expresslane for [`ConnectionType::Udp`] connections"))]
     pub enable_expresslane: bool,
 
+    #[cfg(apple)]
+    #[patch(attribute(clap(long)))]
+    #[patch(empty_value = false)]
+    #[patch(attribute(serde(default)))]
+    #[patch(attribute(
+        doc = r#"Connect the outside UDP socket to the server (Apple platforms only).
+    Connecting the single-peer outside socket lets sends skip the per-packet
+    route lookup. The socket is re-connected on network changes."#
+    ))]
+    #[schemars(extend("x-cfg" = "apple"))]
+    pub enable_connected_udp: bool,
+
     #[patch(attribute(clap(long)))]
     #[patch(attribute(doc = "Interval between Expresslane key rotations"))]
     #[schemars(schema_with = "lightway_app_utils::args::duration_schema")]
@@ -495,6 +507,8 @@ impl Default for Config {
             dns_config_mode: DnsConfigMode::default(),
             log_level: LogLevel::Info,
             enable_expresslane: false,
+            #[cfg(apple)]
+            enable_connected_udp: false,
             expresslane_keys_rotation_interval: Duration::from_std_duration(
                 lightway_core::DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL,
             ),

--- a/lightway-client/src/io/outside.rs
+++ b/lightway-client/src/io/outside.rs
@@ -70,6 +70,16 @@ pub trait OutsideIO: Sync + Send {
 
     fn peer_addr(&self) -> SocketAddr;
 
+    /// Re-establish the socket's connected route after a network change.
+    ///
+    /// On Apple platforms the outside UDP socket is `connect()`-ed so each send can skip
+    /// the per-packet route lookup. When the network changes the cached route
+    /// and bound source address go stale, so the association has to be
+    /// refreshed. Default is a no-op for transports that don't use a connected
+    /// socket.
+    #[cfg(apple)]
+    fn reconnect(&self) {}
+
     /// Returns the underlying socket tagged with its transport type.
     fn socket(&self) -> OutsideSocket;
 }

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -16,6 +16,11 @@ pub struct Udp {
     sock: Arc<tokio::net::UdpSocket>,
     peer_addr: SocketAddr,
     default_ip_pmtudisc: sockopt::IpPmtudisc,
+    /// Whether the socket has been `connect()`-ed to `peer_addr` so that `send`
+    /// can be used in place of `send_to`. macOS only; see
+    /// [`Udp::enable_connected_send`].
+    #[cfg(apple)]
+    connected: bool,
     #[cfg(batch_receive)]
     batch_receive_enabled: bool,
 }
@@ -46,9 +51,34 @@ impl Udp {
             sock: Arc::new(sock),
             peer_addr,
             default_ip_pmtudisc,
+            #[cfg(apple)]
+            connected: false,
             #[cfg(batch_receive)]
             batch_receive_enabled: false,
         })
+    }
+
+    /// `connect()` the underlying socket to `peer_addr`.
+    ///
+    /// On a connected UDP socket the kernel resolves the route once, at connect
+    /// time, so each subsequent `send` skips the per-packet route lookup that
+    /// `send_to` performs.
+    #[cfg(apple)]
+    fn connect_socket(&self) -> std::io::Result<()> {
+        socket2::SockRef::from(&self.sock).connect(&self.peer_addr.into())
+    }
+
+    /// Switch this socket to connected-send mode for upload throughput on macOS.
+    ///
+    /// The cached route is bound to the current egress interface, so the caller
+    /// MUST invoke [`OutsideIO::reconnect`] on every network change — otherwise
+    /// a network change strands the socket on a dead route/source address.
+    #[cfg(apple)]
+    pub fn enable_connected_send(&mut self) -> std::io::Result<()> {
+        self.connect_socket()?;
+        self.connected = true;
+        tracing::info!("Outside UDP socket connected; using connected send");
+        Ok(())
     }
 
     #[cfg(batch_receive)]
@@ -153,6 +183,18 @@ impl OutsideIO for Udp {
         self.peer_addr()
     }
 
+    #[cfg(apple)]
+    fn reconnect(&self) {
+        // Only refresh the route if connected-send mode is actually in use.
+        if !self.connected {
+            return;
+        }
+        match self.connect_socket() {
+            Ok(()) => tracing::debug!("Reconnected outside UDP socket after network change"),
+            Err(e) => tracing::warn!("Failed to reconnect outside UDP socket: {e}"),
+        }
+    }
+
     fn socket(&self) -> OutsideSocket {
         #[cfg(unix)]
         use std::os::fd::AsRawFd;
@@ -168,7 +210,21 @@ impl OutsideIO for Udp {
 
 impl OutsideIOSendCallback for Udp {
     fn send(&self, buf: &[u8]) -> IOCallbackResult<usize> {
-        match self.sock.try_send_to(buf, self.peer_addr) {
+        // On a connected socket the destination is already known, so `send`
+        // skips the per-packet route lookup that `send_to` performs - a
+        // measurable upload throughput win on Apple platforms. Falls back to `send_to`
+        // when the socket isn't connected (e.g. no network change monitoring to
+        // refresh the cached route after a network change).
+        #[cfg(apple)]
+        let result = if self.connected {
+            self.sock.try_send(buf)
+        } else {
+            self.sock.try_send_to(buf, self.peer_addr)
+        };
+        #[cfg(not(macos))]
+        let result = self.sock.try_send_to(buf, self.peer_addr);
+
+        match result {
             Ok(nr) => IOCallbackResult::Ok(nr),
             Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
                 IOCallbackResult::WouldBlock
@@ -201,12 +257,23 @@ impl OutsideIOSendCallback for Udp {
             Err(err) if matches!(err.kind(), std::io::ErrorKind::PermissionDenied) => {
                 IOCallbackResult::Ok(buf.len())
             }
-            #[cfg(macos)]
+            #[cfg(apple)]
             Err(err) if matches!(err.kind(), std::io::ErrorKind::AddrNotAvailable) => {
                 // The source address is no longer valid (e.g. Switched WiFi hotspots)
                 // It should eventually recover by itself after a while.
                 // If the user has disconnected from the internet, keepalive should fail
                 // due to missed reply (`keepalive_timeout`).
+                IOCallbackResult::Ok(buf.len())
+            }
+            #[cfg(apple)]
+            Err(err)
+                if self.connected && matches!(err.kind(), std::io::ErrorKind::HostUnreachable) =>
+            {
+                // A connected socket can surface "no route to host" the moment a
+                // network change tears down the cached route. The reconnect on
+                // network change refreshes it; swallow so TLS does not enter an
+                // error state in the meantime. Only relevant when we explicitly
+                // use `send`; `send_to` should surface this error as before.
                 IOCallbackResult::Ok(buf.len())
             }
             Err(err) => {

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -4,7 +4,8 @@ use async_trait::async_trait;
 use lightway_app_utils::sockopt;
 use lightway_core::{IOCallbackResult, OutsideIOSendCallback, OutsideIOSendCallbackArg};
 #[cfg(apple)]
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::Arc,
@@ -29,6 +30,9 @@ pub struct Udp {
     /// [`OutsideIO::reconnect`] on the next network-change event.
     #[cfg(apple)]
     connected: AtomicBool,
+    /// Consecutive swallowed send errors, reset by a successful send; see
+    /// [`Udp::note_swallowed_send`].
+    swallowed_sends: AtomicU64,
     #[cfg(batch_receive)]
     batch_receive_enabled: bool,
 }
@@ -63,6 +67,7 @@ impl Udp {
             connect_requested: false,
             #[cfg(apple)]
             connected: AtomicBool::new(false),
+            swallowed_sends: AtomicU64::new(0),
             #[cfg(batch_receive)]
             batch_receive_enabled: false,
         })
@@ -90,7 +95,10 @@ impl Udp {
         self.connect_requested = true;
         self.connect_socket()?;
         self.connected.store(true, Ordering::Relaxed);
-        tracing::info!("Outside UDP socket connected; using connected send");
+        tracing::info!(
+            "Outside UDP socket connected; using connected send (local address {})",
+            local_addr_str(&self.sock)
+        );
         Ok(())
     }
 
@@ -104,6 +112,7 @@ impl Udp {
     /// network-change reconnect restores the fast path.
     #[cfg(apple)]
     fn downgrade(&self) {
+        let pinned = local_addr_str(&self.sock);
         // Flip first so concurrent senders switch to `send_to`; a send racing
         // the dissolve gets `EISCONN`/`ENOTCONN`, which `send` swallows.
         self.connected.store(false, Ordering::Relaxed);
@@ -117,8 +126,20 @@ impl Udp {
             }
         }
         tracing::info!(
-            "Outside UDP socket downgraded to unconnected send until next network change"
+            "Outside UDP socket (was pinned to {pinned}) downgraded to unconnected send until next network change"
         );
+    }
+
+    /// Send errors around a network change are expected and absorbed (DTLS
+    /// retransmission recovers), but a sustained stream of them means the
+    /// tunnel is down with no trace in the logs. Log the 1st, 2nd, 4th, ...
+    /// of each consecutive run, so onset and magnitude stay visible without
+    /// flooding.
+    fn note_swallowed_send(&self, err: &std::io::Error) {
+        let count = self.swallowed_sends.fetch_add(1, Ordering::Relaxed) + 1;
+        if count.is_power_of_two() {
+            tracing::debug!("Swallowing outside UDP send error ({count} consecutive): {err}");
+        }
     }
 
     #[cfg(batch_receive)]
@@ -246,10 +267,14 @@ impl OutsideIO for Udp {
         // socket lock (see soconnectlock in xnu's uipc_socket.c), so this both
         // refreshes the pinned route and re-selects the local address — on the
         // same fd and local port.
+        let before = local_addr_str(&self.sock);
         match self.connect_socket() {
             Ok(()) => {
                 self.connected.store(true, Ordering::Relaxed);
-                tracing::debug!("Reconnected outside UDP socket after network change");
+                tracing::debug!(
+                    "Reconnected outside UDP socket after network change, local address {before} -> {}",
+                    local_addr_str(&self.sock)
+                );
             }
             Err(e) => {
                 // Better a slow socket than a wedged one: drop to unconnected
@@ -293,7 +318,10 @@ impl OutsideIOSendCallback for Udp {
         let result = self.sock.try_send_to(buf, self.peer_addr);
 
         match result {
-            Ok(nr) => IOCallbackResult::Ok(nr),
+            Ok(nr) => {
+                self.swallowed_sends.store(0, Ordering::Relaxed);
+                IOCallbackResult::Ok(nr)
+            }
             Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
                 IOCallbackResult::WouldBlock
             }
@@ -310,19 +338,23 @@ impl OutsideIOSendCallback for Udp {
                 // Otherwise, TLS perceives that no data is sent and try
                 // to send the same data again, creating a live-lock until
                 // the network is reachable.
+                self.note_swallowed_send(&err);
                 IOCallbackResult::Ok(buf.len())
             }
             Err(err) if matches!(err.kind(), std::io::ErrorKind::NetworkUnreachable) => {
                 // This case indicates network unreachable error.
                 // Possibly there is a network change at the moment.
+                self.note_swallowed_send(&err);
                 IOCallbackResult::Ok(buf.len())
             }
             Err(err) if matches!(err.raw_os_error(), Some(libc::ENOBUFS)) => {
                 // No buffer space available
                 // UDP sockets may have this error when the system is overloaded.
+                self.note_swallowed_send(&err);
                 IOCallbackResult::Ok(buf.len())
             }
             Err(err) if matches!(err.kind(), std::io::ErrorKind::PermissionDenied) => {
+                self.note_swallowed_send(&err);
                 IOCallbackResult::Ok(buf.len())
             }
             #[cfg(apple)]
@@ -341,6 +373,7 @@ impl OutsideIOSendCallback for Udp {
                 if connected {
                     self.downgrade();
                 }
+                self.note_swallowed_send(&err);
                 IOCallbackResult::Ok(buf.len())
             }
             #[cfg(apple)]
@@ -350,6 +383,7 @@ impl OutsideIOSendCallback for Udp {
                 // network change refreshes it; swallow so TLS does not enter an
                 // error state in the meantime. Only relevant when we explicitly
                 // use `send`; `send_to` should surface this error as before.
+                self.note_swallowed_send(&err);
                 IOCallbackResult::Ok(buf.len())
             }
             #[cfg(apple)]
@@ -362,6 +396,7 @@ impl OutsideIOSendCallback for Udp {
                 // association (`send` on a just-dissolved socket, or `send_to`
                 // on a just-connected one). The next send takes the settled
                 // path; DTLS retransmission covers this packet.
+                self.note_swallowed_send(&err);
                 IOCallbackResult::Ok(buf.len())
             }
             Err(err) => {
@@ -386,6 +421,12 @@ impl OutsideIOSendCallback for Udp {
     fn disable_pmtud_probe(&self) -> std::io::Result<()> {
         sockopt::set_ip_mtu_discover(self.sock.as_ref(), self.default_ip_pmtudisc)
     }
+}
+
+#[cfg(apple)]
+fn local_addr_str(sock: &tokio::net::UdpSocket) -> String {
+    sock.local_addr()
+        .map_or_else(|e| e.to_string(), |a| a.to_string())
 }
 
 /// ICMP errors (port/host/net unreachable) are delivered asynchronously to a

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -3,6 +3,8 @@ use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use lightway_app_utils::sockopt;
 use lightway_core::{IOCallbackResult, OutsideIOSendCallback, OutsideIOSendCallbackArg};
+#[cfg(apple)]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::Arc,
@@ -16,11 +18,17 @@ pub struct Udp {
     sock: Arc<tokio::net::UdpSocket>,
     peer_addr: SocketAddr,
     default_ip_pmtudisc: sockopt::IpPmtudisc,
-    /// Whether the socket has been `connect()`-ed to `peer_addr` so that `send`
-    /// can be used in place of `send_to`. macOS only; see
-    /// [`Udp::enable_connected_send`].
+    /// Whether connected-send mode was requested; see
+    /// [`Udp::enable_connected_send`]. Set once during setup, before the socket
+    /// is shared. Apple platforms only.
     #[cfg(apple)]
-    connected: bool,
+    connect_requested: bool,
+    /// Whether the socket is currently `connect()`-ed to `peer_addr` so that
+    /// `send` can be used in place of `send_to`. Cleared by [`Udp::downgrade`]
+    /// when the pinned route/source address dies; restored by
+    /// [`OutsideIO::reconnect`] on the next network-change event.
+    #[cfg(apple)]
+    connected: AtomicBool,
     #[cfg(batch_receive)]
     batch_receive_enabled: bool,
 }
@@ -52,7 +60,9 @@ impl Udp {
             peer_addr,
             default_ip_pmtudisc,
             #[cfg(apple)]
-            connected: false,
+            connect_requested: false,
+            #[cfg(apple)]
+            connected: AtomicBool::new(false),
             #[cfg(batch_receive)]
             batch_receive_enabled: false,
         })
@@ -68,17 +78,47 @@ impl Udp {
         socket2::SockRef::from(&self.sock).connect(&self.peer_addr.into())
     }
 
-    /// Switch this socket to connected-send mode for upload throughput on macOS.
+    /// Switch this socket to connected-send mode for throughput on Apple platforms.
     ///
     /// The cached route is bound to the current egress interface, so the caller
     /// MUST invoke [`OutsideIO::reconnect`] on every network change — otherwise
     /// a network change strands the socket on a dead route/source address.
     #[cfg(apple)]
     pub fn enable_connected_send(&mut self) -> std::io::Result<()> {
+        // Requested before attempted: if this initial connect fails, a later
+        // network-change reconnect can still establish the fast path.
+        self.connect_requested = true;
         self.connect_socket()?;
-        self.connected = true;
+        self.connected.store(true, Ordering::Relaxed);
         tracing::info!("Outside UDP socket connected; using connected send");
         Ok(())
+    }
+
+    /// Drop back to unconnected sends on the same fd.
+    ///
+    /// `send_to` on a connected UDP socket fails with `EISCONN`, so the
+    /// association has to be dissolved before falling back. `disconnectx` also
+    /// resets the implicitly bound local address, so subsequent sends re-select
+    /// the route and source address per packet — correct on whatever network we
+    /// are now on, just without the connected-send saving. The next
+    /// network-change reconnect restores the fast path.
+    #[cfg(apple)]
+    fn downgrade(&self) {
+        // Flip first so concurrent senders switch to `send_to`; a send racing
+        // the dissolve gets `EISCONN`/`ENOTCONN`, which `send` swallows.
+        self.connected.store(false, Ordering::Relaxed);
+        match lightway_app_utils::udp_disconnect::udp_disconnect(self.sock.as_ref()) {
+            Ok(()) => {}
+            // NotConnected: already dissolved (e.g. a reconnect failed mid-way).
+            Err(e) if matches!(e.kind(), std::io::ErrorKind::NotConnected) => {}
+            Err(e) => {
+                tracing::warn!("Failed to dissolve outside UDP socket association: {e}");
+                return;
+            }
+        }
+        tracing::info!(
+            "Outside UDP socket downgraded to unconnected send until next network change"
+        );
     }
 
     #[cfg(batch_receive)]
@@ -136,6 +176,11 @@ impl OutsideIO for Udp {
             Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
                 IOCallbackResult::WouldBlock
             }
+            #[cfg(apple)]
+            Err(err) if self.connect_requested && is_icmp_derived_err(&err) => {
+                tracing::debug!("Ignoring ICMP-derived error on connected UDP recv: {err}");
+                IOCallbackResult::WouldBlock
+            }
             Err(err) => IOCallbackResult::Err(err),
         }
     }
@@ -170,6 +215,11 @@ impl OutsideIO for Udp {
                 // Interrupted means the syscall was interrupted by a signal and can be
                 // retried immediately without waiting for another readable event.
                 Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                #[cfg(apple)]
+                Err(e) if self.connect_requested && is_icmp_derived_err(&e) => {
+                    tracing::debug!("Ignoring ICMP-derived error on connected UDP recv: {e}");
+                    return IOCallbackResult::WouldBlock;
+                }
                 Err(e) => return IOCallbackResult::Err(e),
             }
         }
@@ -186,12 +236,28 @@ impl OutsideIO for Udp {
     #[cfg(apple)]
     fn reconnect(&self) {
         // Only refresh the route if connected-send mode is actually in use.
-        if !self.connected {
+        // Checked against the request, not the current state, so a downgraded
+        // socket is re-pinned once a network change lands.
+        if !self.connect_requested {
             return;
         }
+        // `connect()` on a connected datagram socket dissolves the old
+        // association and re-runs route and source-address selection under one
+        // socket lock (see soconnectlock in xnu's uipc_socket.c), so this both
+        // refreshes the pinned route and re-selects the local address — on the
+        // same fd and local port.
         match self.connect_socket() {
-            Ok(()) => tracing::debug!("Reconnected outside UDP socket after network change"),
-            Err(e) => tracing::warn!("Failed to reconnect outside UDP socket: {e}"),
+            Ok(()) => {
+                self.connected.store(true, Ordering::Relaxed);
+                tracing::debug!("Reconnected outside UDP socket after network change");
+            }
+            Err(e) => {
+                // Better a slow socket than a wedged one: drop to unconnected
+                // sends (per-packet route lookup always resolves the current
+                // network) and let a later network change restore the fast path.
+                tracing::warn!("Failed to reconnect outside UDP socket, using send_to: {e}");
+                self.downgrade();
+            }
         }
     }
 
@@ -212,16 +278,18 @@ impl OutsideIOSendCallback for Udp {
     fn send(&self, buf: &[u8]) -> IOCallbackResult<usize> {
         // On a connected socket the destination is already known, so `send`
         // skips the per-packet route lookup that `send_to` performs - a
-        // measurable upload throughput win on Apple platforms. Falls back to `send_to`
-        // when the socket isn't connected (e.g. no network change monitoring to
-        // refresh the cached route after a network change).
+        // measurable throughput win on Apple platforms. Falls back to `send_to` when the
+        // socket isn't connected (mode not enabled, or downgraded after the
+        // pinned route/source address died).
         #[cfg(apple)]
-        let result = if self.connected {
+        let connected = self.connected.load(Ordering::Relaxed);
+        #[cfg(apple)]
+        let result = if connected {
             self.sock.try_send(buf)
         } else {
             self.sock.try_send_to(buf, self.peer_addr)
         };
-        #[cfg(not(macos))]
+        #[cfg(not(apple))]
         let result = self.sock.try_send_to(buf, self.peer_addr);
 
         match result {
@@ -260,20 +328,40 @@ impl OutsideIOSendCallback for Udp {
             #[cfg(apple)]
             Err(err) if matches!(err.kind(), std::io::ErrorKind::AddrNotAvailable) => {
                 // The source address is no longer valid (e.g. Switched WiFi hotspots)
-                // It should eventually recover by itself after a while.
+                // An unconnected socket recovers by itself: the kernel re-selects
+                // the source address on every send.
                 // If the user has disconnected from the internet, keepalive should fail
                 // due to missed reply (`keepalive_timeout`).
+                //
+                // A connected socket is pinned to the dead address and will fail
+                // this way forever, so drop back to unconnected sends rather than
+                // waiting on a network-change event that may never come (e.g. a
+                // DHCP renewal that changes the address but not the default
+                // route). The next network change re-pins the fast path.
+                if connected {
+                    self.downgrade();
+                }
                 IOCallbackResult::Ok(buf.len())
             }
             #[cfg(apple)]
-            Err(err)
-                if self.connected && matches!(err.kind(), std::io::ErrorKind::HostUnreachable) =>
-            {
+            Err(err) if connected && matches!(err.kind(), std::io::ErrorKind::HostUnreachable) => {
                 // A connected socket can surface "no route to host" the moment a
                 // network change tears down the cached route. The reconnect on
                 // network change refreshes it; swallow so TLS does not enter an
                 // error state in the meantime. Only relevant when we explicitly
                 // use `send`; `send_to` should surface this error as before.
+                IOCallbackResult::Ok(buf.len())
+            }
+            #[cfg(apple)]
+            Err(err)
+                if self.connect_requested
+                    && (matches!(err.kind(), std::io::ErrorKind::NotConnected)
+                        || matches!(err.raw_os_error(), Some(libc::EISCONN))) =>
+            {
+                // A send raced a reconnect/downgrade transition of the
+                // association (`send` on a just-dissolved socket, or `send_to`
+                // on a just-connected one). The next send takes the settled
+                // path; DTLS retransmission covers this packet.
                 IOCallbackResult::Ok(buf.len())
             }
             Err(err) => {
@@ -297,5 +385,146 @@ impl OutsideIOSendCallback for Udp {
 
     fn disable_pmtud_probe(&self) -> std::io::Result<()> {
         sockopt::set_ip_mtu_discover(self.sock.as_ref(), self.default_ip_pmtudisc)
+    }
+}
+
+/// ICMP errors (port/host/net unreachable) are delivered asynchronously to a
+/// *connected* UDP socket and surface on the next syscall; an unconnected
+/// socket never sees them. They are transient from the tunnel's point of view
+/// (server restart, router mid-transition) and DTLS retransmission recovers
+/// once the peer is reachable again, so they must not tear the connection down.
+#[cfg(apple)]
+fn is_icmp_derived_err(err: &std::io::Error) -> bool {
+    matches!(
+        err.kind(),
+        std::io::ErrorKind::ConnectionRefused
+            | std::io::ErrorKind::HostUnreachable
+            | std::io::ErrorKind::NetworkUnreachable
+    )
+}
+
+#[cfg(all(test, apple))]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    async fn recv_str(peer: &UdpSocket) -> (String, SocketAddr) {
+        let mut buf = [0u8; 64];
+        let (n, from) = tokio::time::timeout(Duration::from_secs(2), peer.recv_from(&mut buf))
+            .await
+            .expect("timed out waiting for datagram")
+            .expect("peer recv failed");
+        (String::from_utf8_lossy(&buf[..n]).into_owned(), from)
+    }
+
+    #[tokio::test]
+    async fn connected_send_and_reconnect_keep_fd_and_port() {
+        let peer = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let peer_addr = peer.local_addr().unwrap();
+
+        let mut udp = Udp::new(peer_addr, None).await.unwrap();
+        udp.enable_connected_send().unwrap();
+        assert!(udp.connected.load(Ordering::Relaxed));
+        let local_before = udp.sock.local_addr().unwrap();
+
+        assert!(matches!(
+            OutsideIOSendCallback::send(&udp, b"one"),
+            IOCallbackResult::Ok(3)
+        ));
+        let (msg, from) = recv_str(&peer).await;
+        assert_eq!(msg, "one");
+        assert_eq!(from.port(), local_before.port());
+
+        // Reconnect re-runs route/source selection on the same fd: the local
+        // port must survive and the fast path must keep working.
+        OutsideIO::reconnect(&udp);
+        assert!(udp.connected.load(Ordering::Relaxed));
+        assert_eq!(udp.sock.local_addr().unwrap().port(), local_before.port());
+
+        assert!(matches!(
+            OutsideIOSendCallback::send(&udp, b"two"),
+            IOCallbackResult::Ok(3)
+        ));
+        let (msg, from) = recv_str(&peer).await;
+        assert_eq!(msg, "two");
+        assert_eq!(from.port(), local_before.port());
+    }
+
+    #[tokio::test]
+    async fn downgrade_falls_back_to_unconnected_send_and_reconnect_restores() {
+        let peer = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let peer_addr = peer.local_addr().unwrap();
+
+        let mut udp = Udp::new(peer_addr, None).await.unwrap();
+        udp.enable_connected_send().unwrap();
+        let port = udp.sock.local_addr().unwrap().port();
+
+        // Simulate the send path detecting a dead pin (EADDRNOTAVAIL).
+        udp.downgrade();
+        assert!(!udp.connected.load(Ordering::Relaxed));
+
+        // Sends must keep flowing via `send_to` on the same fd/port.
+        assert!(matches!(
+            OutsideIOSendCallback::send(&udp, b"slow"),
+            IOCallbackResult::Ok(4)
+        ));
+        let (msg, from) = recv_str(&peer).await;
+        assert_eq!(msg, "slow");
+        assert_eq!(from.port(), port);
+
+        // The next network-change reconnect restores the fast path.
+        OutsideIO::reconnect(&udp);
+        assert!(udp.connected.load(Ordering::Relaxed));
+        assert!(matches!(
+            OutsideIOSendCallback::send(&udp, b"fast"),
+            IOCallbackResult::Ok(4)
+        ));
+        let (msg, from) = recv_str(&peer).await;
+        assert_eq!(msg, "fast");
+        assert_eq!(from.port(), port);
+    }
+
+    #[tokio::test]
+    async fn reconnect_is_noop_when_not_requested() {
+        let peer = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let peer_addr = peer.local_addr().unwrap();
+
+        let udp = Udp::new(peer_addr, None).await.unwrap();
+        OutsideIO::reconnect(&udp);
+        assert!(!udp.connected.load(Ordering::Relaxed));
+
+        // Still sends via `send_to`.
+        assert!(matches!(
+            OutsideIOSendCallback::send(&udp, b"plain"),
+            IOCallbackResult::Ok(5)
+        ));
+        let (msg, _) = recv_str(&peer).await;
+        assert_eq!(msg, "plain");
+    }
+
+    #[tokio::test]
+    async fn icmp_unreachable_is_not_fatal_on_connected_recv() {
+        // Bind then drop a peer so the port is closed; sends to it generate
+        // ICMP port unreachable, which a connected socket surfaces as
+        // ECONNREFUSED on a following send or recv.
+        let peer = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let peer_addr = peer.local_addr().unwrap();
+        drop(peer);
+
+        let mut udp = Udp::new(peer_addr, None).await.unwrap();
+        udp.enable_connected_send().unwrap();
+
+        let mut buf = bytes::BytesMut::with_capacity(2048);
+        for _ in 0..3 {
+            // The send-side surfacing is swallowed (ConnectionRefused arm).
+            assert!(!matches!(
+                OutsideIOSendCallback::send(&udp, b"ping"),
+                IOCallbackResult::Err(_)
+            ));
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            // The recv side must map it to WouldBlock, never a fatal Err that
+            // would tear the connection down.
+            assert!(!matches!(udp.recv_buf(&mut buf), IOCallbackResult::Err(_)));
+        }
     }
 }

--- a/lightway-client/src/keepalive.rs
+++ b/lightway-client/src/keepalive.rs
@@ -186,10 +186,8 @@ async fn keepalive<CONFIG: SleepManager, CONNECTION: Connection>(
                         timeout.as_mut().set(None.into())
                     },
                     Message::NetworkChange => {
-                        if !matches!(state, State::Pending) {
-                            tracing::info!("sending keepalives because of {:?}", msg);
-                            state = State::Needed;
-                        }
+                        tracing::info!("sending keepalives because of {:?}", msg);
+                        state = State::Needed;
                         // Reset timeout to make sure we start again
                         // When there is a network interruption, mobile clients may send
                         // suspend to avoid keepalive dropping the connection.
@@ -432,6 +430,29 @@ mod tests {
             sleep(Duration::from_millis(10)).await;
             assert_eq!(connection.keepalive_count(), exp_start + i);
         }
+
+        drop(keepalive);
+        let result = task.await.unwrap().unwrap();
+        assert!(matches!(result, KeepaliveResult::Cancelled));
+    }
+
+    #[test_case(true; "continuous")]
+    #[test_case(false; "non-continuous")]
+    #[tokio::test]
+    async fn network_change_while_reply_pending_resends(continuous: bool) {
+        let (sleep_manager, connection) =
+            KeepaliveTestBuilder::new().continuous(continuous).build();
+
+        let (keepalive, task) = Keepalive::new(sleep_manager.clone(), connection.clone());
+        start_keepalives(&keepalive, &sleep_manager, continuous).await;
+        assert_eq!(connection.keepalive_count(), 1);
+
+        // No reply arrives (roam in progress, first ping lost). A later
+        // network change event must re-send immediately, not wait for the
+        // interval.
+        keepalive.network_changed().await;
+        sleep(Duration::from_millis(10)).await;
+        assert_eq!(connection.keepalive_count(), 2);
 
         drop(keepalive);
         let result = task.await.unwrap().unwrap();

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -42,7 +42,7 @@ use crate::debug::WiresharkKeyLogger;
 use crate::dns_manager::{DnsConfigMode, DnsManager, DnsManagerError, DnsSetup};
 use crate::keepalive::Config as KeepaliveConfig;
 #[cfg(desktop)]
-use crate::route_manager::{RouteManager, RouteMode};
+use crate::route_manager::{RouteManager, RouteMode, RouteUpdater};
 #[cfg(batch_receive)]
 use lightway_core::MAX_IO_BATCH_SIZE;
 pub use lightway_core::{
@@ -769,6 +769,36 @@ async fn handle_network_change<ExtAppState: Send + Sync>(
     ClientResult::UserDisconnect
 }
 
+/// Single consumer for network-change wake-ups. Reacts to each one with the
+/// steps in order: refresh the server route, then re-`connect()` the outside
+/// socket (Apple platforms). Owns the [`RouteUpdater`], so aborting the task removes
+/// the installed routes.
+#[cfg(desktop)]
+async fn network_event_coordinator(
+    mut route_updater: RouteUpdater,
+    mut route_rx: watch::Receiver<()>,
+    #[cfg(apple)] outside_io: Weak<dyn OutsideIO>,
+) {
+    tracing::info!("Reacting to network change events...");
+    loop {
+        if route_rx.changed().await.is_err() {
+            // Wake source gone; dropping the updater clears routes.
+            break;
+        }
+
+        if let Err(e) = route_updater.check_and_update_server_route().await {
+            tracing::warn!("Updating server route failed: {:?}", e);
+        }
+
+        // The connected outside socket pins the route resolved at connect()
+        // time; re-resolve it now that the routing table is up to date.
+        #[cfg(apple)]
+        if let Some(io) = outside_io.upgrade() {
+            io.reconnect();
+        }
+    }
+}
+
 pub async fn handle_encoded_pkt_send<ExtAppState: Send + Sync>(
     conn: Weak<Mutex<lightway_core::Connection<ConnectionState<ExtAppState>>>>,
     rx: Option<UnboundedReceiver<BytesMut>>,
@@ -902,13 +932,15 @@ impl<ExtAppState: Send + Sync> ClientConnection<ExtAppState> {
         }
     }
 
+    /// Install routes and spawn the network-event coordinator, which reacts
+    /// to `route_rx` wake-ups (see `network_event_coordinator`).
     #[cfg(desktop)]
     pub async fn initialize_routes(
         &mut self,
         route_mode: RouteMode,
         tun_peer_ip: IpAddr,
         tun_dns_ip: IpAddr,
-        network_change_rx: Option<watch::Receiver<()>>,
+        route_rx: watch::Receiver<()>,
     ) -> Result<()> {
         let server_ip = self.outside_io.peer_addr().ip();
         let tun_index = self.inside_io.if_index()?;
@@ -923,7 +955,16 @@ impl<ExtAppState: Send + Sync> ClientConnection<ExtAppState> {
         );
         let mut route_manager =
             RouteManager::new(route_mode, server_ip, tun_index, tun_peer_ip, tun_dns_ip)?;
-        route_manager.start(network_change_rx).await?;
+        let route_updater = route_manager.start().await?;
+
+        // A weak ref keeps the coordinator task from extending the outside
+        // socket's lifetime.
+        route_manager.set_task(tokio::spawn(network_event_coordinator(
+            route_updater,
+            route_rx,
+            #[cfg(apple)]
+            Arc::downgrade(&self.outside_io),
+        )));
 
         self.route_manager = Some(route_manager);
         info!("Routes configured");
@@ -1527,8 +1568,16 @@ pub async fn client<
 
     if let Some(mut network_change_signal) = config.network_change_signal.clone() {
         let connection_network_change_signal = connection.network_change_signal.clone();
+        #[cfg(apple)]
+        let outside_io = Arc::downgrade(&connection.outside_io);
         tokio::spawn(async move {
             while network_change_signal.changed().await.is_ok() {
+                // Re-pin the connected outside socket first so the keepalive
+                // probe rides the new path.
+                #[cfg(apple)]
+                if let Some(io) = outside_io.upgrade() {
+                    io.reconnect();
+                }
                 if let Err(e) = connection_network_change_signal.send(()).await {
                     tracing::error!("Failed to send network_change_signal: {e}");
                 }
@@ -1566,13 +1615,14 @@ pub async fn client<
     let mut network_change_monitor: Option<NetworkChangeMonitor> = None;
     #[cfg(desktop)]
     {
-        let rx = if let Some(ref rx) = config.network_change_signal {
+        // Wake source for the network-event coordinator.
+        let route_rx = if let Some(ref rx) = config.network_change_signal {
             rx.clone()
         } else {
             let monitor = NetworkChangeMonitor::spawn(vec![config.tun_local_ip.into()])?;
-            let rx = monitor.subscribe();
+            let route_rx = monitor.subscribe();
             network_change_monitor = Some(monitor);
-            rx
+            route_rx
         };
 
         connection
@@ -1580,7 +1630,7 @@ pub async fn client<
                 config.route_mode,
                 config.tun_peer_ip.into(),
                 config.tun_dns_ip.into(),
-                Some(rx),
+                route_rx,
             )
             .await?;
     }

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -770,24 +770,68 @@ async fn handle_network_change<ExtAppState: Send + Sync>(
 }
 
 /// Single consumer for network-change wake-ups. Reacts to each one with the
-/// steps in order: refresh the server route, then re-`connect()` the outside
-/// socket (Apple platforms). Owns the [`RouteUpdater`], so aborting the task removes
-/// the installed routes.
+/// steps in order: refresh the server route, re-`connect()` the outside
+/// socket (Apple platforms) and, when the wake-up represents a network transition,
+/// nudge the connection-level network-change handler. On Apple platforms the
+/// nudge also fires when the server route was actually replaced (Datagram
+/// wiring only). Owns the [`RouteUpdater`], so aborting the task removes the
+/// installed routes.
 #[cfg(desktop)]
 async fn network_event_coordinator(
     mut route_updater: RouteUpdater,
     mut route_rx: watch::Receiver<()>,
+    mut transition_rx: Option<watch::Receiver<()>>,
+    nudge_on_route_event: bool,
+    #[cfg(apple)] nudge_on_route_update: bool,
     #[cfg(apple)] outside_io: Weak<dyn OutsideIO>,
+    network_change_signal: mpsc::Sender<()>,
 ) {
     tracing::info!("Reacting to network change events...");
     loop {
-        if route_rx.changed().await.is_err() {
-            // Wake source gone; dropping the updater clears routes.
-            break;
+        let mut nudge = nudge_on_route_event;
+
+        tokio::select! {
+            changed = route_rx.changed() => {
+                if changed.is_err() {
+                    // Wake source gone; dropping the updater clears routes.
+                    break;
+                }
+                // Fold a transition that fired alongside the route event into
+                // this iteration instead of waking a second time.
+                if let Some(rx) = transition_rx.as_mut()
+                    && rx.has_changed().unwrap_or(false)
+                {
+                    rx.mark_unchanged();
+                    nudge = true;
+                }
+            }
+            changed = async {
+                match transition_rx.as_mut() {
+                    Some(rx) => rx.changed().await,
+                    None => std::future::pending().await,
+                }
+            } => {
+                if changed.is_err() {
+                    // Transition source gone; keep serving route events.
+                    transition_rx = None;
+                    continue;
+                }
+                nudge = true;
+                // A transition can complete on the address leg alone; consume
+                // any simultaneous route event so the pair is one iteration.
+                if route_rx.has_changed().unwrap_or(false) {
+                    route_rx.mark_unchanged();
+                }
+            }
         }
 
-        if let Err(e) = route_updater.check_and_update_server_route().await {
-            tracing::warn!("Updating server route failed: {:?}", e);
+        match route_updater.check_and_update_server_route().await {
+            // A replaced server route is ground truth that the path to the
+            // server moved; probe it so the session floats promptly.
+            #[cfg(apple)]
+            Ok(true) if nudge_on_route_update => nudge = true,
+            Ok(_) => {}
+            Err(e) => tracing::warn!("Updating server route failed: {:?}", e),
         }
 
         // The connected outside socket pins the route resolved at connect()
@@ -795,6 +839,10 @@ async fn network_event_coordinator(
         #[cfg(apple)]
         if let Some(io) = outside_io.upgrade() {
             io.reconnect();
+        }
+
+        if nudge && let Err(e) = network_change_signal.send(()).await {
+            tracing::error!("Failed to send network_change_signal: {e}");
         }
     }
 }
@@ -933,14 +981,23 @@ impl<ExtAppState: Send + Sync> ClientConnection<ExtAppState> {
     }
 
     /// Install routes and spawn the network-event coordinator, which reacts
-    /// to `route_rx` wake-ups (see `network_event_coordinator`).
+    /// to `route_rx`/`transition_rx` wake-ups (see
+    /// `network_event_coordinator`). Set `nudge_on_route_event` when
+    /// `route_rx` events are unclassified (an embedder-supplied signal) so
+    /// each one also nudges the connection's network-change handler;
+    /// `nudge_on_route_update` (Apple) nudges when the refresh actually
+    /// replaced the server route.
     #[cfg(desktop)]
+    #[allow(clippy::too_many_arguments)]
     pub async fn initialize_routes(
         &mut self,
         route_mode: RouteMode,
         tun_peer_ip: IpAddr,
         tun_dns_ip: IpAddr,
         route_rx: watch::Receiver<()>,
+        transition_rx: Option<watch::Receiver<()>>,
+        nudge_on_route_event: bool,
+        #[cfg(apple)] nudge_on_route_update: bool,
     ) -> Result<()> {
         let server_ip = self.outside_io.peer_addr().ip();
         let tun_index = self.inside_io.if_index()?;
@@ -962,8 +1019,13 @@ impl<ExtAppState: Send + Sync> ClientConnection<ExtAppState> {
         route_manager.set_task(tokio::spawn(network_event_coordinator(
             route_updater,
             route_rx,
+            transition_rx,
+            nudge_on_route_event,
+            #[cfg(apple)]
+            nudge_on_route_update,
             #[cfg(apple)]
             Arc::downgrade(&self.outside_io),
+            self.network_change_signal.clone(),
         )));
 
         self.route_manager = Some(route_manager);
@@ -1566,6 +1628,10 @@ pub async fn client<
         let _ = conn.stop_signal.take().unwrap().send(());
     }
 
+    // On desktop the network-event coordinator (see `initialize_routes`
+    // below) delivers the embedder signal's nudge after the route and socket
+    // refresh instead, so this forwarder only serves non-desktop builds.
+    #[cfg(not(desktop))]
     if let Some(mut network_change_signal) = config.network_change_signal.clone() {
         let connection_network_change_signal = connection.network_change_signal.clone();
         #[cfg(apple)]
@@ -1615,15 +1681,38 @@ pub async fn client<
     let mut network_change_monitor: Option<NetworkChangeMonitor> = None;
     #[cfg(desktop)]
     {
-        // Wake source for the network-event coordinator.
-        let route_rx = if let Some(ref rx) = config.network_change_signal {
-            rx.clone()
-        } else {
-            let monitor = NetworkChangeMonitor::spawn(vec![config.tun_local_ip.into()])?;
-            let route_rx = monitor.subscribe_routes();
-            network_change_monitor = Some(monitor);
-            route_rx
+        // Wake sources for the network-event coordinator. An embedder-supplied
+        // signal is unclassified, so every event serves as both the route hint
+        // and a transition; the internal monitor distinguishes the two.
+        let (route_rx, transition_rx, nudge_on_route_event) = match config.network_change_signal {
+            Some(ref rx) => (rx.clone(), None, true),
+            None => {
+                let monitor = NetworkChangeMonitor::spawn(vec![config.tun_local_ip.into()])?;
+                let route_rx = monitor.subscribe_routes();
+
+                // Network transitions drive the connection-level handler
+                // (keepalive burst); macOS only. Gated on keepalives being
+                // enabled, mirroring the embedder-signal validation.
+                #[cfg(macos)]
+                let transition_rx =
+                    (!config.keepalive_interval.is_zero()).then(|| monitor.subscribe_transitions());
+                #[cfg(not(macos))]
+                let transition_rx: Option<watch::Receiver<()>> = None;
+
+                network_change_monitor = Some(monitor);
+                (route_rx, transition_rx, false)
+            }
         };
+
+        // Probe after a server-route replacement - Datagram only: the Stream
+        // handler treats a nudge as a teardown, which a route-only change
+        // does not warrant.
+        #[cfg(apple)]
+        let nudge_on_route_update = !config.keepalive_interval.is_zero()
+            && matches!(
+                connection.conn.lock().unwrap().connection_type(),
+                ConnectionType::Datagram
+            );
 
         connection
             .initialize_routes(
@@ -1631,6 +1720,10 @@ pub async fn client<
                 config.tun_peer_ip.into(),
                 config.tun_dns_ip.into(),
                 route_rx,
+                transition_rx,
+                nudge_on_route_event,
+                #[cfg(apple)]
+                nudge_on_route_update,
             )
             .await?;
     }

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -1620,7 +1620,7 @@ pub async fn client<
             rx.clone()
         } else {
             let monitor = NetworkChangeMonitor::spawn(vec![config.tun_local_ip.into()])?;
-            let route_rx = monitor.subscribe();
+            let route_rx = monitor.subscribe_routes();
             network_change_monitor = Some(monitor);
             route_rx
         };

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -211,6 +211,12 @@ pub struct ClientConfig<ExtAppState: Send + Sync> {
     /// Enable Expresslane for Udp connections
     pub enable_expresslane: bool,
 
+    /// Connect the outside UDP socket to the server so sends skip the
+    /// per-packet route lookup (Apple platforms, Datagram only). The socket
+    /// is re-connected when the network changes.
+    #[cfg(apple)]
+    pub enable_connected_udp: bool,
+
     /// Interval between Expresslane key rotations
     pub expresslane_keys_rotation_interval: std::time::Duration,
 
@@ -324,6 +330,8 @@ impl<ExtAppState: Send + Sync> ClientConfig<ExtAppState> {
             #[cfg(feature = "postquantum")]
             keyshare: config.keyshare,
             enable_expresslane: config.enable_expresslane,
+            #[cfg(apple)]
+            enable_connected_udp: config.enable_connected_udp,
             expresslane_keys_rotation_interval: config.expresslane_keys_rotation_interval.into(),
             expresslane_cb: None,
             expresslane_metrics: None,
@@ -995,6 +1003,20 @@ pub async fn connect<
 
                 sock.set_send_buffer_size(config.sndbuf.as_u64().try_into()?)?;
                 sock.set_recv_buffer_size(config.rcvbuf.as_u64().try_into()?)?;
+
+                // On Apple platforms a connected UDP socket lets `send` skip
+                // the per-packet route lookup, improving throughput. Safe
+                // because a network change re-connects the socket: via the
+                // network-event coordinator on desktop (see
+                // `initialize_routes`), via the network-change signal
+                // forwarder elsewhere.
+                #[cfg(apple)]
+                if config.enable_connected_udp
+                    && let Err(e) = sock.enable_connected_send()
+                {
+                    tracing::warn!("Failed to connect outside UDP socket, using send_to: {e}");
+                }
+
                 (ConnectionType::Datagram, Arc::new(sock))
             }
             ClientConnectionMode::Stream(maybe_sock) => {

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -185,10 +185,10 @@ pub struct RouteUpdater {
 
 impl RouteUpdater {
     /// Refresh the server route if the default route changed (a no-op in
-    /// NoExec mode).
-    pub async fn check_and_update_server_route(&mut self) -> Result<(), RoutingTableError> {
+    /// NoExec mode). Returns whether the server route was actually replaced.
+    pub async fn check_and_update_server_route(&mut self) -> Result<bool, RoutingTableError> {
         if self.inner.routing_mode == RouteMode::NoExec {
-            return Ok(());
+            return Ok(false);
         }
         self.inner.check_and_update_server_route().await
     }
@@ -497,8 +497,9 @@ impl RouteManagerInner {
         Ok(())
     }
 
-    /// Check if server route needs updating due to network changes
-    async fn check_and_update_server_route(&mut self) -> Result<(), RoutingTableError> {
+    /// Check if server route needs updating due to network changes. Returns
+    /// whether the server route was actually replaced.
+    async fn check_and_update_server_route(&mut self) -> Result<bool, RoutingTableError> {
         // Find the current default route to the server
         let server_ip = self.server_ip;
         let current_route = self.find_best_default_route(&server_ip)?;
@@ -540,10 +541,11 @@ impl RouteManagerInner {
                 self.add_route_server(new_server_route).await?;
 
                 tracing::info!("Updated server route for network change");
+                return Ok(true);
             }
         }
 
-        Ok(())
+        Ok(false)
     }
 }
 
@@ -1079,7 +1081,7 @@ mod tests {
 
         // Test check_and_update_server_route when no change is needed
         let result = inner.check_and_update_server_route().await;
-        assert!(result.is_ok());
+        assert!(matches!(result, Ok(false)));
 
         // Server route should remain unchanged
         assert!(inner.server_route.is_some());
@@ -1202,7 +1204,7 @@ mod tests {
 
         // Test check_and_update_server_route when no change is needed
         let result = inner.check_and_update_server_route().await;
-        assert!(result.is_ok());
+        assert!(matches!(result, Ok(false)));
 
         // Server route should remain unchanged
         assert!(inner.server_route.is_some());

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -4,7 +4,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use thiserror::Error;
-use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tracing::{trace, warn};
 
@@ -147,16 +146,23 @@ impl RouteManager {
         Ok(Self { inner, task: None })
     }
 
-    pub async fn start(
-        &mut self,
-        network_change_rx: Option<watch::Receiver<()>>,
-    ) -> Result<(), RoutingTableError> {
-        let Some(inner) = self.inner.take() else {
+    /// Install the routes required to use the tunnel (NoExec installs
+    /// nothing) and hand back the per-event updater. The task that takes
+    /// ownership of the updater should be registered with [`Self::set_task`]
+    /// so [`Self::stop`] can abort it and await route cleanup.
+    pub async fn start(&mut self) -> Result<RouteUpdater, RoutingTableError> {
+        let Some(mut inner) = self.inner.take() else {
             return Err(RoutingTableError::InsufficientPermissions);
         };
 
-        self.task = inner.start(network_change_rx).await?;
-        Ok(())
+        inner.install_routes().await?;
+        Ok(RouteUpdater { inner })
+    }
+
+    /// Register the task owning the [`RouteUpdater`] returned by
+    /// [`Self::start`].
+    pub fn set_task(&mut self, task: JoinHandle<()>) {
+        self.task = Some(task);
     }
 
     pub async fn stop(&mut self) -> Result<(), RoutingTableError> {
@@ -168,6 +174,23 @@ impl RouteManager {
         }
 
         Ok(())
+    }
+}
+
+/// Owns the routes installed by [`RouteManager::start`]; dropping it removes
+/// them. Exposes the per-network-event maintenance step.
+pub struct RouteUpdater {
+    inner: RouteManagerInner,
+}
+
+impl RouteUpdater {
+    /// Refresh the server route if the default route changed (a no-op in
+    /// NoExec mode).
+    pub async fn check_and_update_server_route(&mut self) -> Result<(), RoutingTableError> {
+        if self.inner.routing_mode == RouteMode::NoExec {
+            return Ok(());
+        }
+        self.inner.check_and_update_server_route().await
     }
 }
 
@@ -472,40 +495,6 @@ impl RouteManagerInner {
 
         self.add_route_vpn(dns_route).await?;
         Ok(())
-    }
-
-    /// Install routes required to use tunnel and start monitoring route changes
-    /// to update the routes if needed (mostly during connection floating)
-    async fn start(
-        mut self,
-        network_change_rx: Option<watch::Receiver<()>>,
-    ) -> Result<Option<JoinHandle<()>>, RoutingTableError> {
-        if self.routing_mode == RouteMode::NoExec {
-            return Ok(None);
-        }
-
-        // Install all the required routes
-        self.install_routes().await?;
-
-        let task = tokio::spawn(async move {
-            let mut inner = self;
-            match network_change_rx {
-                Some(mut rx) => {
-                    tracing::info!("Reacting to network changes for route updates...");
-                    while rx.changed().await.is_ok() {
-                        if let Err(e) = inner.check_and_update_server_route().await {
-                            tracing::warn!("Updating server route failed: {:?}", e);
-                        }
-                    }
-                }
-                None => {
-                    // No monitor: keep routes installed until stop()/abort.
-                    std::future::pending::<()>().await;
-                }
-            }
-        });
-
-        Ok(Some(task))
     }
 
     /// Check if server route needs updating due to network changes
@@ -979,7 +968,7 @@ mod tests {
             RouteManager::new(route_mode, EXTERNAL_IP_V4, 0, TUN_PEER_IP, TUN_DNS_IP).unwrap();
 
         // Test that we can start the route manager
-        let start_result = route_manager.start(None).await;
+        let start_result = route_manager.start().await;
         if route_mode == RouteMode::NoExec {
             // NoExec mode should succeed but not actually do anything
             assert!(start_result.is_ok());
@@ -995,6 +984,39 @@ mod tests {
         // Test that stopping again is safe
         let stop_again_result = route_manager.stop().await;
         assert!(stop_again_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_stop_aborts_task_and_awaits_updater_drop() {
+        struct DropFlag(std::sync::Arc<std::sync::atomic::AtomicBool>);
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+
+        let mut route_manager = RouteManager::new(
+            RouteMode::NoExec,
+            EXTERNAL_IP_V4,
+            0,
+            TUN_PEER_IP,
+            TUN_DNS_IP,
+        )
+        .unwrap();
+        let updater = route_manager.start().await.unwrap();
+
+        let dropped = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let flag = DropFlag(dropped.clone());
+        route_manager.set_task(tokio::spawn(async move {
+            let (_updater, _flag) = (updater, flag);
+            std::future::pending::<()>().await;
+        }));
+
+        route_manager.stop().await.unwrap();
+
+        // stop() must have awaited the aborted task, so the updater (and with
+        // it the installed routes) is gone by the time it returns.
+        assert!(dropped.load(std::sync::atomic::Ordering::SeqCst));
     }
 
     #[test_case(RouteMode::Default)]
@@ -1029,14 +1051,13 @@ mod tests {
         .unwrap();
 
         // First start should succeed
-        assert!(route_manager.start(None).await.is_ok());
+        assert!(route_manager.start().await.is_ok());
 
         // Second start should fail since inner is already taken
-        let second_start_result = route_manager.start(None).await;
-        assert!(second_start_result.is_err());
+        let second_start_result = route_manager.start().await;
         assert!(matches!(
-            second_start_result.unwrap_err(),
-            RoutingTableError::InsufficientPermissions
+            second_start_result,
+            Err(RoutingTableError::InsufficientPermissions)
         ));
     }
 
@@ -1072,8 +1093,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_route_manager_start_with_noexec_mode() {
-        // Don't create TUN device for NoExec mode, just test RouteManagerInner directly
-        let inner = RouteManagerInner::new(
+        // Don't create a TUN device for NoExec mode; it needs no privileges
+        let mut route_manager = RouteManager::new(
             RouteMode::NoExec,
             EXTERNAL_IP_V4,
             1,
@@ -1082,10 +1103,10 @@ mod tests {
         )
         .unwrap();
 
-        // NoExec mode should return None (no monitoring task)
-        let monitor_task = inner.start(None).await;
-        assert!(monitor_task.is_ok());
-        assert!(monitor_task.unwrap().is_none());
+        // NoExec installs nothing and the per-event step is a no-op
+        let mut updater = route_manager.start().await.unwrap();
+        assert!(updater.check_and_update_server_route().await.is_ok());
+        assert!(updater.inner.server_route.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

Adds `--enable-connected-udp` (off by default, Apple platforms only): `connect()` the outside UDP socket to the server so sends and receives skip the per-packet route lookup and PCB work. The socket-side machinery is gated on `apple` (macOS, iOS/iPadOS incl. Mac Catalyst, tvOS); the transition monitoring below is macOS-specific.

A connected socket pins the route and source address chosen at connect time, so the series also covers recovery:

- Network-change reactions run in a single coordinator task, in order: refresh the /32 server route, re-`connect()` the socket (same fd and local port, so fds handed to embedders stay valid), then — on a genuine transition, or (Apple, Datagram) whenever the server route was actually replaced — trigger the network-change keepalives, so the probe rides the freshly pinned path instead of racing it.
- The network-change monitor publishes *route* and *transition* signals separately. On macOS a transition is an address change (watched via [`netwatcher`](https://crates.io/crates/netwatcher)) plus a default-route *arrival* (add/change — the down-leg delete of a roam leaves nothing to probe) within a short window, so route-only churn updates routes without firing keepalives.
- If a send reports `EADDRNOTAVAIL` or a re-connect fails, the socket drops back to unconnected `send_to` (dissolving the association with `disconnectx(2)`) until the next network change restores the fast path. ICMP-derived errors on a connected receive are treated as transient instead of tearing the connection down.
- Swallowed outside-send errors are now logged (rate-limited to one line per second), and connect/downgrade/reconnect log the pinned local address, so a silently dead path shows up in debug logs.

The option works in every route mode, including `none`: the coordinator drives the reconnect regardless. On targets without the desktop route manager (iOS and friends), the network-change signal forwarder re-pins the socket before the keepalive probe instead. The uniffi mobile wrapper does not wire the option yet.

## Motivation and Context

Connecting the single-peer outside socket is a measurable throughput win on macOS. Without the recovery work, a network switch would silently blackhole the pinned socket until keepalive timeout — so the feature ships together with it, and stays opt-in.

Stacked on `client-keepalive` (the base branch): its resend-on-network-change fix plus the ordered refresh-then-probe here is what lets roams recover promptly.

## How Has This Been Tested?

- Unit tests: connected send/recv round-trip, re-connect keeps fd/port, downgrade and restore, ICMP unreachable non-fatal on receive, transition-detector pairing and rate-limiting, coordinator lifecycle (routes cleared exactly once on stop).
- Kernel behaviour verified with standalone probes on macOS: re-`connect()` re-selects route and source address on the same fd/port; `send_to` on a connected socket fails `EISCONN`, hence the explicit dissolve on fallback.
- Real Ethernet↔Wi-Fi roams with debug logging pinned down the ordering race this series fixes (the post-transition keepalive going out before the re-pin and dying silently); a roam re-test of the final ordering is pending.
- `cargo test`, `cargo clippy --all-targets` and `cargo fmt --check` clean on macOS (aarch64); `cargo check` clean for `aarch64-apple-ios` (including `--features mobile`) and Mac Catalyst (`aarch64-apple-ios-macabi`). Every commit in the series compiles standalone.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
