### PR TITLE
ci: assign PR to requested reviewer

### DIFF
--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -1,0 +1,32 @@
+name: Assign requested reviewer
+
+# When GitHub's team code-review assignment picks an individual reviewer for a
+# PR, mirror that person into the assignee field so PR ownership is visible at a
+# glance. Team-level review requests are ignored; only individual reviewers
+# (which is what the auto-assignment produces) become assignees.
+
+on:
+  # pull_request_target is safe here because it only runs the pinned
+  # actions/github-script action.
+  pull_request_target:
+    types: [review_requested]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    if: github.event.requested_reviewer != null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign reviewer to PR
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const reviewer = context.payload.requested_reviewer.login;
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              assignees: [reviewer],
+            });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When individual reviewer is requested, also assign the PR to them.

We have to use `pull_request_target` so dependabot PRs will run with the right permissions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Make requested reviewer more visible

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This PR

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
- [ ] Any update to `xenon/libxenon-src` is accompanied by a reference to the specific commit in the git changelog
