### PR TITLE
client: apply SO_MARK to outside UDP socket on Linux

### DIFF
--- a/lightway-client/src/config.rs
+++ b/lightway-client/src/config.rs
@@ -212,6 +212,19 @@ pub struct Config {
     #[schemars(extend("x-cfg" = "desktop"))]
     pub route_mode: RouteMode,
 
+    #[cfg(linux)]
+    #[patch(attribute(serde(default)))]
+    #[patch(attribute(clap(long)))]
+    #[patch(
+        attribute(doc = r#"Firewall mark (SO_MARK) applied to the outside socket.
+        The tunnel's own encrypted packets carry this mark so policy routing
+        rules can keep them out of the tunnel.
+        In Linux networking, a fwmark of 0 represents the default unmarked state
+        and will not apply SO_MARK to the socket."#)
+    )]
+    #[schemars(extend("x-cfg" = "linux"))]
+    pub fwmark: u32,
+
     #[cfg(desktop)]
     #[patch(attribute(clap(long, value_enum)))]
     #[patch(attribute(doc = r#"DNS configuration mode
@@ -491,6 +504,8 @@ impl Default for Config {
             enable_batch_receive: false,
             #[cfg(desktop)]
             route_mode: RouteMode::default(),
+            #[cfg(linux)]
+            fwmark: 0,
             #[cfg(desktop)]
             dns_config_mode: DnsConfigMode::default(),
             log_level: LogLevel::Info,

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -21,7 +21,11 @@ pub struct Udp {
 }
 
 impl Udp {
-    pub async fn new(remote_addr: SocketAddr, sock: Option<UdpSocket>) -> Result<Self> {
+    pub async fn new(
+        remote_addr: SocketAddr,
+        sock: Option<UdpSocket>,
+        #[cfg(all(linux, not(feature = "mobile")))] fwmark: u32,
+    ) -> Result<Self> {
         let peer_addr = tokio::net::lookup_host(remote_addr)
             .await?
             .next()
@@ -37,6 +41,19 @@ impl Udp {
             Some(s) => s,
             None => tokio::net::UdpSocket::bind((unspecified_ip, 0)).await?,
         };
+
+        // Apply the firewall mark *before* the socket is used for anything, so
+        // that no packet can escape unmarked and be captured by the tunnel's
+        // own routes.
+        #[cfg(all(linux, not(feature = "mobile")))]
+        if fwmark != 0 {
+            let socket = socket2::SockRef::from(&sock);
+            match socket.set_mark(fwmark) {
+                Ok(_) => tracing::info!("Applied firewall mark to outside socket"),
+                Err(e) => tracing::warn!("Fail to set so mark on socket: {}", e),
+            }
+        }
+
         let default_ip_pmtudisc = sockopt::get_ip_mtu_discover(&sock)?;
         // Check for the socket's writable ready status, so that it can be used
         // successfuly in TLS's `OutsideIOSendCallback` callback

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -204,6 +204,10 @@ pub struct ClientConfig<ExtAppState: Send + Sync> {
     #[cfg(desktop)]
     pub route_mode: RouteMode,
 
+    /// Firewall mark applied to the outside socket (Linux only).
+    #[cfg(linux)]
+    pub fwmark: u32,
+
     /// DNS configuration mode
     #[cfg(desktop)]
     pub dns_config_mode: DnsConfigMode,
@@ -338,6 +342,8 @@ impl<ExtAppState: Send + Sync> ClientConfig<ExtAppState> {
             enable_batch_receive: config.enable_batch_receive,
             #[cfg(desktop)]
             route_mode: config.route_mode,
+            #[cfg(linux)]
+            fwmark: config.fwmark,
             #[cfg(desktop)]
             dns_config_mode: config.dns_config_mode,
             enable_pmtud: config.enable_pmtud,
@@ -983,10 +989,15 @@ pub async fn connect<
         match mode {
             ClientConnectionMode::Datagram(maybe_sock) => {
                 #[cfg_attr(not(batch_receive), allow(unused_mut))]
-                let mut sock = io::outside::Udp::new(server, maybe_sock)
-                    .await
-                    .inspect_err(|e| tracing::error!("Failed to create outside IO UDP socket: {e}"))
-                    .context("Outside IO UDP")?;
+                let mut sock = io::outside::Udp::new(
+                    server,
+                    maybe_sock,
+                    #[cfg(all(linux, not(feature = "mobile")))]
+                    config.fwmark,
+                )
+                .await
+                .inspect_err(|e| tracing::error!("Failed to create outside IO UDP socket: {e}"))
+                .context("Outside IO UDP")?;
 
                 #[cfg(batch_receive)]
                 if config.enable_batch_receive {

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -167,6 +167,10 @@ run-udp-then-tcp-parallel-connect-test:
 run-token-auth-test:
     DO +TEST --MODE=udp --SERVER_PORT=27690 --CLIENT_EXTRA_ARGS="--token eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjQ4ODMxMTM0MTZ9.gb0U7xTwxl7GDeKftKSZvnkkIDnoz8NmzJ4etukCjtZWzA4kSNbt84iTKOE14paRZdfE67tLGfcLsqA9uh-zuA_-ecZbiC4znz2CVVjhD2CIrW_0LQbHRbzYlOozjc108pct-VivtiPr7SqcIgRTjH59HTCDXtgp0kELhhr3NNfYP0-6DtadXQ_Twn2tcC3A-rTpfjwo7HDqnc43niCALXFhqR0F4DkEC3amKuOiP9afQ6dFmWVAzWXWEpQ_kK-EsCeBZ6K89GaF5quIErrV3U_FSwbX8biFB7S8VhkLqCoyabRKKprwp_mi24e91URgGqNvbCrXs2zrJMat-1zUvw" --SERVER_EXTRA_ARGS="--token-rsa-pub-key-pem /token.pub"
 
+# run-udp-fwmark-test runs e2e test using UDP with fwmark set on the outside socket
+run-udp-fwmark-test:
+    DO +TEST --MODE=udp --SERVER_PORT=27690 --CLIENT_EXTRA_ARGS="--fwmark=1698916352"
+
 # run-all-tests runs all tests
 run-all-tests:
     BUILD +run-tcp-aes256-test
@@ -198,3 +202,4 @@ run-all-tests:
     BUILD +run-udp-parallel-connect-test
     BUILD +run-tcp-then-udp-parallel-connect-test
     BUILD +run-udp-then-tcp-parallel-connect-test
+    BUILD +run-udp-fwmark-test


### PR DESCRIPTION
## Description

This is a focused split from #492 that introduces only the `SO_MARK` socket support, without the `RouteMode::Fwmark` policy routing mode or the associated `ip rule` management.

Changes:
- `lightway-app-utils`: new `sockopt::set_so_mark` / `get_so_mark` wrappers around the Linux `SO_MARK` socket option (Linux only, `CAP_NET_ADMIN` required)
- `lightway-client`: adds an optional `fwmark: u32` field to both `Config` and `ClientConfig` (Linux only, defaults to unset with 0 as convention)
- `lightway-client`: applies the mark to the outside UDP socket before it is used for anything, so no packet can escape unmarked; tolerates `setsockopt` failure with a warning; verifies the mark was accepted in `debug` builds

## Motivation and Context

Without a firewall mark the tunnel's own encrypted packets are steered by the host route to the VPN server. That host route is managed by `route_manager` and can be transiently absent during a network change (e.g. Wi-Fi roam), leaving a window where the server's IP matches the tunnel's catch-all route, causing an encapsulation loop.

Marking the outside socket with `SO_MARK` lets a policy routing rule (`ip rule fwmark <mark> lookup main`) keep the tunnel's own traffic on the WAN interface regardless of whether a host route is present. This PR ships the socket primitive needed for that, as a self-contained, non-breaking change that can be merged and deployed independently while the full policy routing mode (#492) is still under review.

## How Has This Been Tested?

- Confirmed `SO_MARK` is applied and read back correctly on Linux with `CAP_NET_ADMIN`.
- Confirmed graceful fallback (warning log, tunnel establishes) when running without `CAP_NET_ADMIN`.
- Confirmed no behavioural change on non-Linux platforms or with `feature = "mobile"` (parameter compiles out entirely).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
