### PR TITLE
server: update peer address before announcing session rotation

### DIFF
--- a/lightway-server/src/io/outside/udp.rs
+++ b/lightway-server/src/io/outside/udp.rs
@@ -317,8 +317,10 @@ impl UdpServer {
                 // first
                 if update_peer_address {
                     metrics::udp_conn_recovered_via_session(session);
-                    conn.begin_session_id_rotation();
+                    // Address first: the rotation announce must go to the
+                    // address the client roamed to.
                     self.conn_manager.set_peer_addr(&conn, peer_addr);
+                    conn.begin_session_id_rotation();
                 }
             }
             Err(err) => {


### PR DESCRIPTION
## Description

When a UDP session floats to a new client address, the rotation announce keepalive is sent while the connection's peer address still points at the old network: `begin_session_id_rotation()` fires the announce inside `rotate_session_id()`, one step before `set_peer_addr()`. A roaming client therefore never receives the announce, and the rotation — designed to complete within one round trip — always waits for organic client traffic instead.

Update the peer address first, then start the rotation. Both steps stay behind the first successful decrypt, so the protection against redirecting a connection with a crafted session ID is unchanged. The pong replying to the packet that *triggered* the float is still misdirected — that is inherent to validating a packet before trusting its source address, and is covered client-side instead.

## Motivation and Context

Found while testing roams for #493: after every float the client saw only data packets stamped with the rotated session ID — never the announce ping or a pong — because both had been sent to the address it just left.

## How Has This Been Tested?

- `cargo test -p lightway-server`, `cargo clippy --all-targets` and `cargo fmt --check` clean.
- Tested on a new server with a macOS client that just roamed:
```
2026-08-04T10:33:09.207489Z DEBUG lightway_core::connection: event event=SessionIdRotationStarted { old: 352a0778b59d44d5, new: 97f011efb89e003d }
2026-08-04T10:33:09.207501Z DEBUG lightway_core::connection: Sending ping session=352a0778b59d44d5 payload_len=16
2026-08-04T10:33:09.207531Z TRACE lightway_server::metrics: Begin session rotation
...
2026-08-04T10:33:09.245369Z DEBUG lightway_core::connection: Received pong id=0 payload_len=16
2026-08-04T10:33:09.245375Z DEBUG lightway_core::connection: event event=KeepaliveReply
2026-08-04T10:33:09.245401Z DEBUG lightway_core::connection: Received packet with different session ID wire_session=97f011efb89e003d current_session=352a0778b59d44d5
2026-08-04T10:33:09.245406Z DEBUG lightway_core::connection: event event=SessionIdRotationAcknowledged { old: 352a0778b59d44d5, new: 97f011efb89e003d }
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
