### PR TITLE
client: apply SO_MARK to outside TCP socket on Linux

### DIFF
--- a/lightway-client/src/io/outside/tcp.rs
+++ b/lightway-client/src/io/outside/tcp.rs
@@ -5,14 +5,61 @@ use tokio::net::TcpStream;
 
 use super::{OutsideIO, OutsideSocket};
 use lightway_core::{IOCallbackResult, OutsideIOSendCallback, OutsideIOSendCallbackArg};
+use socket2::{Domain, Protocol, Socket, Type};
 
 pub struct Tcp(tokio::net::TcpStream, SocketAddr);
 
 impl Tcp {
-    pub async fn new(remote_addr: SocketAddr, maybe_sock: Option<TcpStream>) -> Result<Self> {
+    pub async fn new(
+        remote_addr: SocketAddr,
+        maybe_sock: Option<TcpStream>,
+        #[cfg(all(linux, not(feature = "mobile")))] fwmark: u32,
+    ) -> Result<Self> {
         let sock = match maybe_sock {
-            Some(s) => s,
-            None => tokio::net::TcpStream::connect(remote_addr).await?,
+            Some(s) => {
+                #[cfg(all(linux, not(feature = "mobile")))]
+                if fwmark != 0 {
+                    let socket = socket2::SockRef::from(&s);
+                    match socket.set_mark(fwmark) {
+                        Ok(_) => tracing::info!("Applied firewall mark to outside TCP socket"),
+                        Err(e) => tracing::warn!("Failed to set SO_MARK on TCP socket: {}", e),
+                    }
+                }
+                s
+            }
+            None => {
+                let domain = if remote_addr.is_ipv6() {
+                    Domain::IPV6
+                } else {
+                    Domain::IPV4
+                };
+
+                let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+                socket.set_nonblocking(true)?;
+
+                // Creates a TCP connection with SO_MARK set before connect() so that the
+                // SYN packet is also marked, ensuring all traffic (including connection
+                // setup) is subject to policy routing rules based on the mark.
+                #[cfg(all(linux, not(feature = "mobile")))]
+                if fwmark != 0 {
+                    match socket.set_mark(fwmark) {
+                        Ok(_) => tracing::info!("Applied firewall mark to outside TCP socket"),
+                        Err(e) => tracing::warn!("Failed to set SO_MARK on TCP socket: {}", e),
+                    }
+                }
+
+                let addr: socket2::SockAddr = remote_addr.into();
+                match socket.connect(&addr) {
+                    Ok(()) => {}
+                    Err(e) if e.raw_os_error() == Some(libc::EINPROGRESS) => {}
+                    Err(e) => return Err(e.into()),
+                }
+
+                let std_stream: std::net::TcpStream = socket.into();
+                let stream = TcpStream::from_std(std_stream)?;
+                stream.writable().await?;
+                stream
+            }
         };
         sock.set_nodelay(true)?;
         let peer_addr = sock.peer_addr()?;

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -1009,10 +1009,15 @@ pub async fn connect<
                 (ConnectionType::Datagram, Arc::new(sock))
             }
             ClientConnectionMode::Stream(maybe_sock) => {
-                let sock = io::outside::Tcp::new(server, maybe_sock)
-                    .await
-                    .inspect_err(|e| tracing::error!("Failed to create outside IO TCP socket: {e}"))
-                    .context("Outside IO TCP")?;
+                let sock = io::outside::Tcp::new(
+                    server,
+                    maybe_sock,
+                    #[cfg(all(linux, not(feature = "mobile")))]
+                    config.fwmark,
+                )
+                .await
+                .inspect_err(|e| tracing::error!("Failed to create outside IO TCP socket: {e}"))
+                .context("Outside IO TCP")?;
 
                 // On Linux/Windows, setting SO_SNDBUF/SO_RCVBUF disables TCP buffer
                 // autotuning, capping the bandwidth-delay product and throttling

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -171,6 +171,10 @@ run-token-auth-test:
 run-udp-fwmark-test:
     DO +TEST --MODE=udp --SERVER_PORT=27690 --CLIENT_EXTRA_ARGS="--fwmark=1698916352"
 
+# run-tcp-fwmark-test runs e2e test using TCP with fwmark set on the outside socket
+run-tcp-fwmark-test:
+    DO +TEST --MODE=tcp --SERVER_PORT=27690 --CLIENT_EXTRA_ARGS="--fwmark=1698916352"
+
 # run-all-tests runs all tests
 run-all-tests:
     BUILD +run-tcp-aes256-test
@@ -203,3 +207,4 @@ run-all-tests:
     BUILD +run-tcp-then-udp-parallel-connect-test
     BUILD +run-udp-then-tcp-parallel-connect-test
     BUILD +run-udp-fwmark-test
+    BUILD +run-tcp-fwmark-test


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Apply `SO_MARK` to the outside **TCP** socket on Linux (non-mobile), mirroring the UDP support added in #495.

For fresh connections the mark is set via `socket2` **before** `connect()` is called, so the SYN packet itself carries the mark — ensuring policy-routing rules take effect from the very start of the TCP handshake. For caller-supplied sockets the mark is applied immediately after hand-off.

An Earthfile `run-tcp-fwmark-test` target is added and included in `run-all-tests`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Without this change, using `--fwmark` in TCP mode left the outside socket unmarked, so policy-routing rules (e.g. those installed by `RouteMode::Fwmark`) had no effect on TCP tunnel traffic. The fix brings TCP to parity with UDP.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- `+run-tcp-fwmark-test` Earthly target exercises the new path end-to-end.
- Existing `+run-udp-fwmark-test` continues to pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
- [ ] Any update to `xenon/libxenon-src` is accompanied by a reference to the specific commit in the git changelog
