### PR TITLE
client: use tokio::net::TcpSocket for outside TCP connection

### DIFF
--- a/lightway-client/src/io/outside/tcp.rs
+++ b/lightway-client/src/io/outside/tcp.rs
@@ -5,7 +5,6 @@ use tokio::net::TcpStream;
 
 use super::{OutsideIO, OutsideSocket};
 use lightway_core::{IOCallbackResult, OutsideIOSendCallback, OutsideIOSendCallbackArg};
-use socket2::{Domain, Protocol, Socket, Type};
 
 pub struct Tcp(tokio::net::TcpStream, SocketAddr);
 
@@ -28,37 +27,24 @@ impl Tcp {
                 s
             }
             None => {
-                let domain = if remote_addr.is_ipv6() {
-                    Domain::IPV6
+                let socket = if remote_addr.is_ipv6() {
+                    tokio::net::TcpSocket::new_v6()?
                 } else {
-                    Domain::IPV4
+                    tokio::net::TcpSocket::new_v4()?
                 };
 
-                let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
-                socket.set_nonblocking(true)?;
-
-                // Creates a TCP connection with SO_MARK set before connect() so that the
-                // SYN packet is also marked, ensuring all traffic (including connection
-                // setup) is subject to policy routing rules based on the mark.
+                // SO_MARK must be set before connect() so that the SYN packet is also
+                // marked, ensuring all traffic (including connection setup) is subject
+                // to policy routing rules based on the mark.
                 #[cfg(all(linux, not(feature = "mobile")))]
                 if fwmark != 0 {
-                    match socket.set_mark(fwmark) {
+                    match socket2::SockRef::from(&socket).set_mark(fwmark) {
                         Ok(_) => tracing::info!("Applied firewall mark to outside TCP socket"),
                         Err(e) => tracing::warn!("Failed to set SO_MARK on TCP socket: {}", e),
                     }
                 }
 
-                let addr: socket2::SockAddr = remote_addr.into();
-                match socket.connect(&addr) {
-                    Ok(()) => {}
-                    Err(e) if e.raw_os_error() == Some(libc::EINPROGRESS) => {}
-                    Err(e) => return Err(e.into()),
-                }
-
-                let std_stream: std::net::TcpStream = socket.into();
-                let stream = TcpStream::from_std(std_stream)?;
-                stream.writable().await?;
-                stream
+                socket.connect(remote_addr).await?
             }
         };
         sock.set_nodelay(true)?;


### PR DESCRIPTION
## Description

Simplify the outside TCP socket creation in the client by switching from `socket2::Socket` to Tokio's native `TcpSocket`.

`tokio::net::TcpSocket` handles non-blocking mode and the async connect internally, removing the need for the manual `EINPROGRESS` dance, the explicit `set_nonblocking(true)` call, and the `std::net::TcpStream` → `tokio::net::TcpStream` conversion. `SO_MARK` is still applied before `connect()` on Linux (non-mobile) via `socket2::SockRef::from(&socket).set_mark(fwmark)`, preserving the behaviour introduced in #497.

## Motivation and Context

The previous PR (#497) added `SO_MARK` support for outside TCP sockets using the full `socket2::Socket` lifecycle. Now that the feature is in place this PR simplifies the implementation by delegating socket creation and async connect to the Tokio layer, keeping `socket2` only for the narrow Linux-specific `set_mark` operation.

## How Has This Been Tested?

- [ ] Built on Linux with and without the `mobile` feature; confirmed `SO_MARK` is applied before `connect()` so SYN packets carry the mark
- [ ] Verified outside TCP connections succeed and `set_nodelay` is still applied post-connect
- [ ] Existing unit/integration test suite passes with no regressions

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)  There is [issue](https://github.com/xvpn/kp_lightway/actions/runs/30973385951/job/92202393694) to handle error with raw socket on Windows 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
- [ ] Any update to `xenon/libxenon-src` is accompanied by a reference to the specific commit in the git changelog
