### PR TITLE
ci: reduce time on nix build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -266,21 +266,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-linux-gnu
             os: ubuntu-latest
-            package_client: lightway-client
-            package_server: lightway-server
+            build_msrv: false
+          - target: x86_64-linux-gnu
+            os: ubuntu-latest
             build_msrv: true
-          - target: aarch64-apple-darwin
+          - target: aarch64-darwin
             os: macos-26
-            package_client: lightway-client
-            package_server: lightway-server
             build_msrv: false
           # Cross-compile x86_64 Darwin from Apple Silicon (much faster than Intel Mac)
-          - target: x86_64-apple-darwin
+          - target: x86_64-darwin
             os: macos-26
-            package_client: lightway-client-x86_64-darwin
-            package_server: lightway-server-x86_64-darwin
             build_msrv: false
     steps:
       - uses: actions/checkout@v4.3.1
@@ -295,33 +292,27 @@ jobs:
 
       - run: mkdir -p build/
 
-      - name: Build lightway client on MSRV version
+      - name: Build lightway server and client on MSRV version
         if: matrix.build_msrv
-        run: nix build .#lightway-client-msrv
+        run: nix build -j 2 --cores 2 .#lightway-client-${{ matrix.target }}-msrv .#lightway-server-${{ matrix.target }}-msrv --print-build-logs
 
-      - name: Build lightway server on MSRV version
-        if: matrix.build_msrv
-        run: nix build .#lightway-server-msrv
-
-      - name: Build lightway client
-        run: nix build .#${{ matrix.package_client }} -o result-client
-
-      - name: Build lightway server
-        run: nix build .#${{ matrix.package_server }} -o result-server
+      - name: Build lightway server and client
+        if: ${{ !matrix.build_msrv }}
+        run: nix build -j 2 --cores 2 .#lightway-client-${{ matrix.target }} .#lightway-server-${{ matrix.target }} --print-build-logs
 
       - name: Upload lightway-client artifact
-        if: matrix.target == 'aarch64-apple-darwin' || matrix.target == 'x86_64-apple-darwin'
+        if: matrix.target == 'aarch64-darwin' || matrix.target == 'x86_64-darwin'
         uses: actions/upload-artifact@v4.6.2
         with:
           name: lightway-client-${{ matrix.target }}
-          path: result-client/bin/lightway-client
+          path: result/bin/lightway-client
 
       - name: Upload lightway-server artifact
-        if: matrix.target == 'aarch64-apple-darwin' || matrix.target == 'x86_64-apple-darwin'
+        if: matrix.target == 'aarch64-darwin' || matrix.target == 'x86_64-darwin'
         uses: actions/upload-artifact@v4.6.2
         with:
           name: lightway-server-${{ matrix.target }}
-          path: result-server/bin/lightway-server
+          path: result/bin/lightway-server
 
   nix-tests:
     name: Nix tests (${{ matrix.os }})


### PR DESCRIPTION
## Description

Reduce CI wall-clock time for nix-build jobs by combining the client and server builds into a single `nix build` invocation per target.

Previously, each matrix target ran two separate `nix build` steps — one for `lightway-client` and one for `lightway-server` — along with an additional MSRV pair, totalling four build steps on Linux. These are now collapsed into one step per target using `nix build -j 2 --cores 2 .#lightway-client-<nix-target> .#lightway-server-<nix-target>`, which lets Nix parallelise shared dependency builds and avoids evaluating the flake twice.

The MSRV matrix row is also split out as a separate `x86_64-linux-gnu` entry with `build_msrv: true` instead of being an additional flag on the same row, keeping the conditional logic cleaner.

## Motivation and Context

Each nix-build CI run was burning two separate Nix evaluations and two separate daemon cold-starts per target. Combining the builds into a single invocation halves that overhead and makes better use of parallel CPU cores on the runner.

## How Has This Been Tested?

- [ ] CI pipeline observed to produce passing `nix-build` jobs with combined client+server steps
- [ ] Artifact upload paths (`result/bin/lightway-client`, `result/bin/lightway-server`) verified against the new default result symlink
- [ ] MSRV build confirmed to still run on `x86_64-unknown-linux-gnu` only

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] CI / infrastructure change (no production code affected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
- [ ] Any update to `xenon/libxenon-src` is accompanied by a reference to the specific commit in the git changelog
