### PR TITLE
Client TUN offload (2/3): refactorings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1563,6 +1563,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "internet-checksum"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6d6206008e25125b1f97fbe5d309eb7b85141cf9199d52dbd3729a1584dd16"
+
+[[package]]
 name = "io-uring"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1950,6 +1956,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "delegate",
+ "internet-checksum",
  "itertools 0.15.0",
  "lightway-app-utils",
  "lightway-boring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ ctrlc = { version = "3.4.6" }
 cfg_aliases = "0.2.2"
 delegate = "0.12.0"
 educe = { version = "0.6.0", default-features = false, features = ["Debug"] }
+internet-checksum = "0.2.1"
 ipnet = { version = "2.8.0", features = ["serde"]}
 libc = "0.2.152"
 lightway-app-utils = { path = "./lightway-app-utils" }

--- a/deny.toml
+++ b/deny.toml
@@ -56,3 +56,11 @@ allow-git = ["https://github.com/cloudflare/boring"]
 name = "ring"
 expression = "ISC AND MIT AND OpenSSL"
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+# internet-checksum (Fuchsia) ships a BSD-2-Clause LICENSE file but sets
+# no `license` field in its manifest, so cargo-deny cannot classify it
+# without this clarification.
+[[licenses.clarify]]
+name = "internet-checksum"
+expression = "BSD-2-Clause"
+license-files = [{ path = "LICENSE", hash = 0x336921c7 }]

--- a/lightway-app-utils/src/cmsg.rs
+++ b/lightway-app-utils/src/cmsg.rs
@@ -1,33 +1,37 @@
 //! Encapsulates the control message apis used with `recvmsg(2)`.
 #![allow(unsafe_code)]
+// Low-level control-message plumbing; the public items are self-describing
+// by name and covered by the module doc, so individual doc comments would
+// add noise without value.
+#![allow(missing_docs)]
 
 use bytes::BytesMut;
 
 #[cfg(target_vendor = "apple")]
-pub(crate) type LibcControlLen = libc::socklen_t;
+pub type LibcControlLen = libc::socklen_t;
 
 #[cfg(all(not(target_vendor = "apple"), target_env = "musl"))]
-pub(crate) type LibcControlLen = libc::socklen_t;
+pub type LibcControlLen = libc::socklen_t;
 
 #[cfg(all(not(target_vendor = "apple"), not(target_env = "musl")))]
-pub(crate) type LibcControlLen = libc::size_t;
+pub type LibcControlLen = libc::size_t;
 
-pub(crate) struct Buffer<const N: usize>(BytesMut);
+pub struct Buffer<const N: usize>(BytesMut);
 
 impl<const N: usize> Buffer<N> {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self(BytesMut::with_capacity(N))
     }
 
-    pub(crate) fn as_mut(&mut self) -> &mut [std::mem::MaybeUninit<u8>] {
+    pub fn as_mut(&mut self) -> &mut [std::mem::MaybeUninit<u8>] {
         self.0.spare_capacity_mut()
     }
 
-    pub(crate) fn capacity(&self) -> usize {
+    pub fn capacity(&self) -> usize {
         self.0.capacity()
     }
 
-    pub(crate) fn reset(&mut self) {
+    pub fn reset(&mut self) {
         self.0.clear();
         self.0.reserve(N);
     }
@@ -36,7 +40,7 @@ impl<const N: usize> Buffer<N> {
     ///
     /// `control_len` must have been set to the number of bytes of the
     /// buffer which have been initialized.
-    pub(crate) unsafe fn iter(&mut self, control_len: LibcControlLen) -> Iter<'_, N> {
+    pub unsafe fn iter(&mut self, control_len: LibcControlLen) -> Iter<'_, N> {
         // SAFETY: The outer function here has enforced this requirement already
         unsafe {
             // `LibcControlLen` is `size_t` on glibc but `socklen_t` on
@@ -75,13 +79,13 @@ pub enum Message<'a> {
 }
 
 impl Message<'_> {
-    pub(crate) const fn space<T>() -> usize {
+    pub const fn space<T>() -> usize {
         // SAFETY: CMSG_SPACE is always safe
         unsafe { libc::CMSG_SPACE(std::mem::size_of::<T>() as libc::c_uint) as usize }
     }
 }
 
-pub(crate) struct Iter<'a, const N: usize> {
+pub struct Iter<'a, const N: usize> {
     msghdr: libc::msghdr,
     cursor: *const libc::cmsghdr,
     // `msghdr` contains a raw pointer into the owning `Buffer` and
@@ -127,10 +131,10 @@ impl<'a, const N: usize> Iterator for Iter<'a, N> {
 }
 
 #[repr(C, align(16))] // Must be suitably aligned for a `libc::cmsghdr`.
-pub(crate) struct BufferMut<const N: usize>([u8; N]);
+pub struct BufferMut<const N: usize>([u8; N]);
 
 impl<const N: usize> BufferMut<N> {
-    pub(crate) fn zeroed() -> Self {
+    pub fn zeroed() -> Self {
         Self([0; N])
     }
 
@@ -145,7 +149,7 @@ impl<const N: usize> BufferMut<N> {
     ///
     /// Note that this is not mentioned in
     /// <https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/basedefs/sys_socket.h.html>.
-    pub(crate) fn builder(&mut self) -> BufferBuilder<'_, N> {
+    pub fn builder(&mut self) -> BufferBuilder<'_, N> {
         // Build a `msghdr` so we can use the `CMSG_*` functionality in
         // libc. We will only use the `CMSG_*` macros which only use
         // the `msg_control*` fields.
@@ -174,7 +178,7 @@ impl<const N: usize> BufferMut<N> {
     /// Mutable view of the raw buffer, for passing to `msg_control` in
     /// syscalls that need a mutable pointer.
     #[cfg(linux)]
-    pub(crate) fn as_mut_slice(&mut self) -> &mut [u8] {
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
         &mut self.0
     }
 }
@@ -185,7 +189,7 @@ impl<const N: usize> AsRef<[u8]> for BufferMut<N> {
     }
 }
 
-pub(crate) struct BufferBuilder<'a, const N: usize> {
+pub struct BufferBuilder<'a, const N: usize> {
     msghdr: libc::msghdr,
     cmsghdr: *mut libc::cmsghdr,
     // `msghdr` contains a raw pointer into the owning `Buffer` and
@@ -195,7 +199,7 @@ pub(crate) struct BufferBuilder<'a, const N: usize> {
 }
 
 impl<const N: usize> BufferBuilder<'_, N> {
-    pub(crate) fn fill_next<T>(
+    pub fn fill_next<T>(
         &mut self,
         cmsg_level: libc::c_int,
         cmsg_type: libc::c_int,
@@ -292,7 +296,6 @@ mod tests {
     #![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
     use super::*;
-    use more_asserts::*;
 
     #[test]
     fn success_single_pktinfo() {
@@ -327,7 +330,7 @@ mod tests {
     #[test]
     fn not_enough_room_for_first_header() {
         let mut cmsg = BufferMut::<4>::zeroed();
-        assert_lt!(cmsg.0.len(), std::mem::size_of::<libc::cmsghdr>());
+        assert!(cmsg.0.len() < std::mem::size_of::<libc::cmsghdr>());
 
         let mut builder = cmsg.builder();
         let err = builder.fill_next(0, 0, 0).unwrap_err();
@@ -370,8 +373,8 @@ mod tests {
         const SIZE: usize =
             std::mem::size_of::<libc::cmsghdr>() + std::mem::size_of::<libc::in_pktinfo>() - 1;
         let mut cmsg = BufferMut::<SIZE>::zeroed();
-        assert_gt!(cmsg.0.len(), std::mem::size_of::<libc::cmsghdr>());
-        assert_lt!(cmsg.0.len(), Message::space::<libc::in_pktinfo>());
+        assert!(cmsg.0.len() > std::mem::size_of::<libc::cmsghdr>());
+        assert!(cmsg.0.len() < Message::space::<libc::in_pktinfo>());
 
         let mut builder = cmsg.builder();
         let err = builder

--- a/lightway-app-utils/src/cmsg.rs
+++ b/lightway-app-utils/src/cmsg.rs
@@ -18,12 +18,18 @@ pub type LibcControlLen = libc::size_t;
 
 pub struct Buffer<const N: usize>(BytesMut);
 
+impl<const N: usize> Default for Buffer<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<const N: usize> Buffer<N> {
     pub fn new() -> Self {
         Self(BytesMut::with_capacity(N))
     }
 
-    pub fn as_mut(&mut self) -> &mut [std::mem::MaybeUninit<u8>] {
+    pub fn spare_capacity_mut(&mut self) -> &mut [std::mem::MaybeUninit<u8>] {
         self.0.spare_capacity_mut()
     }
 

--- a/lightway-app-utils/src/cmsg.rs
+++ b/lightway-app-utils/src/cmsg.rs
@@ -1,4 +1,5 @@
-//! Encapsulates the control message apis used with `recvmsg(2)`.
+//! Encapsulates the control message apis used with `recvmsg(2)` and
+//! `sendmsg(2)`.
 #![allow(unsafe_code)]
 // Low-level control-message plumbing; the public items are self-describing
 // by name and covered by the module doc, so individual doc comments would
@@ -35,6 +36,8 @@ impl<const N: usize> Buffer<N> {
 
     pub fn reset(&mut self) {}
 
+    /// Iterate over the control messages the kernel wrote.
+    ///
     /// # Safety
     ///
     /// `control_len` must have been set to the number of bytes of the
@@ -162,6 +165,8 @@ impl<const N: usize> BufferMut<N> {
         Self([0; N])
     }
 
+    /// A builder to fill the buffer with control messages.
+    ///
     /// # Safety
     ///
     /// From <https://man7.org/linux/man-pages/man3/cmsg.3.html>:

--- a/lightway-app-utils/src/cmsg.rs
+++ b/lightway-app-utils/src/cmsg.rs
@@ -5,8 +5,6 @@
 // add noise without value.
 #![allow(missing_docs)]
 
-use bytes::BytesMut;
-
 #[cfg(target_vendor = "apple")]
 pub type LibcControlLen = libc::socklen_t;
 
@@ -16,66 +14,54 @@ pub type LibcControlLen = libc::socklen_t;
 #[cfg(all(not(target_vendor = "apple"), not(target_env = "musl")))]
 pub type LibcControlLen = libc::size_t;
 
-pub struct Buffer<const N: usize>(BytesMut);
-
-impl<const N: usize> Default for Buffer<N> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+#[repr(C, align(16))] // Must be suitably aligned for a `libc::cmsghdr`.
+pub struct Buffer<const N: usize>([std::mem::MaybeUninit<u8>; N]);
 
 impl<const N: usize> Buffer<N> {
     pub fn new() -> Self {
-        Self(BytesMut::with_capacity(N))
+        const {
+            assert!(std::mem::align_of::<libc::cmsghdr>() <= 16);
+        }
+        Self([std::mem::MaybeUninit::uninit(); N])
     }
 
     pub fn spare_capacity_mut(&mut self) -> &mut [std::mem::MaybeUninit<u8>] {
-        self.0.spare_capacity_mut()
+        &mut self.0
     }
 
     pub fn capacity(&self) -> usize {
-        self.0.capacity()
+        N
     }
 
-    pub fn reset(&mut self) {
-        self.0.clear();
-        self.0.reserve(N);
-    }
+    pub fn reset(&mut self) {}
 
     /// # Safety
     ///
     /// `control_len` must have been set to the number of bytes of the
     /// buffer which have been initialized.
-    pub unsafe fn iter(&mut self, control_len: LibcControlLen) -> Iter<'_, N> {
-        // SAFETY: The outer function here has enforced this requirement already
-        unsafe {
-            // `LibcControlLen` is `size_t` on glibc but `socklen_t` on
-            // apple/musl, so the cast is a no-op on some targets only.
-            #[cfg_attr(linux, allow(clippy::unnecessary_cast))]
-            self.0.set_len(control_len as usize);
-        }
-        // Build a `msghdr` so we can use the `CMSG_*` functionality in
-        // libc. We will only use the `CMSG_*` macros which only use
-        // the `msg_control*` fields.
-        // SAFETY: We're initializing an msghdr struct with zeroed memory, which is safe
-        // as all fields will be explicitly set below before use
-        let mut msghdr: libc::msghdr = unsafe { std::mem::zeroed() };
-        msghdr.msg_name = std::ptr::null_mut();
-        msghdr.msg_namelen = 0;
-        msghdr.msg_iov = std::ptr::null_mut();
-        msghdr.msg_iovlen = 0;
-        msghdr.msg_control = self.0.as_ptr() as *mut _;
-        msghdr.msg_controllen = control_len;
-        msghdr.msg_flags = 0;
-        // SAFETY: We constructed a sufficiently valid `msghdr` above.
-        // `msg_control[..msg_controllen]` are valid initialized bytes
-        // per the safety requirements for calling this method.
-        let cursor = unsafe { libc::CMSG_FIRSTHDR(&msghdr) };
-        Iter {
-            msghdr,
-            cursor,
-            _phantom: std::marker::PhantomData,
-        }
+    pub unsafe fn iter(&mut self, control_len: LibcControlLen) -> Iter<'_> {
+        // `LibcControlLen` is `size_t` on glibc but `socklen_t` on
+        // apple/musl, so the cast is a no-op on some targets only.
+        #[allow(clippy::unnecessary_cast)]
+        let control_len = control_len as usize;
+        assert!(
+            control_len <= N,
+            "control_len ({control_len}) exceeds control buffer capacity ({N})"
+        );
+
+        // SAFETY: the caller guarantees the kernel initialized the first
+        // `control_len` bytes, and `MaybeUninit<u8>` has the same layout as
+        // `u8`.
+        let control =
+            unsafe { std::slice::from_raw_parts(self.0.as_ptr() as *const u8, control_len) };
+
+        iter_control(control)
+    }
+}
+
+impl<const N: usize> Default for Buffer<N> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -91,16 +77,48 @@ impl Message<'_> {
     }
 }
 
-pub struct Iter<'a, const N: usize> {
-    msghdr: libc::msghdr,
-    cursor: *const libc::cmsghdr,
-    // `msghdr` contains a raw pointer into the owning `Buffer` and
-    // `cursor` is within that buffer. Ensure it remains live longer
-    // than this iterator.
-    _phantom: std::marker::PhantomData<&'a Buffer<N>>,
+pub fn iter_control(control: &[u8]) -> Iter<'_> {
+    // Not a `debug_assert!`: `Iter::next` turns the `CMSG_*` pointers into
+    // `&libc::cmsghdr`, and a misaligned reference is UB. Keeping the check
+    // in release turns that into a clean panic, at the cost of one
+    // predictable branch per `recvmsg`.
+    assert!(
+        control.is_empty()
+            || control
+                .as_ptr()
+                .align_offset(std::mem::align_of::<libc::cmsghdr>())
+                == 0,
+        "control buffer must be aligned for cmsghdr"
+    );
+
+    // Build a `msghdr` referencing `control` purely so the `CMSG_*`
+    // macros can walk it — they read only `msg_control`/`msg_controllen`.
+    // SAFETY: a zeroed msghdr is valid; the two fields we use are set
+    // below and the buffer is never written through this pointer.
+    let mut msghdr: libc::msghdr = unsafe { std::mem::zeroed() };
+    msghdr.msg_control = control.as_ptr() as *mut _;
+    msghdr.msg_controllen = control.len() as LibcControlLen;
+
+    // SAFETY: `msghdr` is valid and `control` is initialized for its
+    // full length.
+    let cursor = unsafe { libc::CMSG_FIRSTHDR(&msghdr) };
+    Iter {
+        msghdr,
+        cursor,
+        _phantom: std::marker::PhantomData,
+    }
 }
 
-impl<'a, const N: usize> Iterator for Iter<'a, N> {
+pub struct Iter<'a> {
+    msghdr: libc::msghdr,
+    cursor: *const libc::cmsghdr,
+    // `msghdr` contains a raw pointer into the underlying control
+    // region and `cursor` is within that region. Ensure it remains
+    // live longer than this iterator.
+    _phantom: std::marker::PhantomData<&'a [u8]>,
+}
+
+impl<'a> Iterator for Iter<'a> {
     type Item = Message<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -112,7 +130,7 @@ impl<'a, const N: usize> Iterator for Iter<'a, N> {
             let item = unsafe { &*self.cursor };
 
             // SAFETY: `msghdr` was constructed as a sufficiently
-            // valid `msghdr` by `Buffer::iter()`. `cursor` is valid
+            // valid `msghdr` by `iter_control()`. `cursor` is valid
             // since it came from a prior `CMSG_FIRSTHDR` or
             // `CMSG_NXTHDR`.
             self.cursor = unsafe { libc::CMSG_NXTHDR(&self.msghdr, self.cursor) };
@@ -299,9 +317,26 @@ impl<const N: usize> BufferBuilder<'_, N> {
 
 #[cfg(test)]
 mod tests {
+
     #![allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
 
     use super::*;
+
+    #[test]
+    fn buffers_are_aligned_for_cmsghdr() {
+        let cmsghdr_align = std::mem::align_of::<libc::cmsghdr>();
+        assert!(std::mem::align_of::<Buffer<64>>() >= cmsghdr_align);
+        assert!(std::mem::align_of::<BufferMut<64>>() >= cmsghdr_align);
+
+        let mut buf = Buffer::<64>::new();
+        assert_eq!(
+            buf.spare_capacity_mut()
+                .as_ptr()
+                .align_offset(cmsghdr_align),
+            0,
+        );
+        assert_eq!(buf.capacity(), 64);
+    }
 
     #[test]
     fn success_single_pktinfo() {

--- a/lightway-app-utils/src/lib.rs
+++ b/lightway-app-utils/src/lib.rs
@@ -2,6 +2,8 @@
 #![warn(missing_docs)]
 
 pub mod args;
+#[cfg(unix)]
+pub mod cmsg;
 #[cfg(apple)]
 pub mod recvmsg_x;
 pub mod sockopt;

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -640,22 +640,22 @@ impl TunDirect {
 
     /// Try write from Tun
     pub fn try_send(&self, buf: BytesMut) -> IOCallbackResult<usize> {
-        let tun = self.tun.as_ref().unwrap();
         #[cfg(target_os = "linux")]
-        let res = if self.vnet_hdr {
-            // IFF_VNET_HDR requires a zeroed `virtio_net_hdr` prefix
-            // on every write (NEEDS_CSUM=0, GSO_NONE).
-            let hdr_len = tun_rs::VIRTIO_NET_HDR_LEN;
-            let mut prefixed = bytes::BytesMut::zeroed(hdr_len);
-            prefixed.extend_from_slice(&buf[..]);
-            tun.try_send(&prefixed[..])
-                .map(|n| n.saturating_sub(hdr_len))
-        } else {
-            tun.try_send(&buf[..])
-        };
-        #[cfg(not(target_os = "linux"))]
-        let res = tun.try_send(&buf[..]);
-        Self::map_send_result(res)
+        if self.vnet_hdr {
+            // IFF_VNET_HDR requires a zeroed `virtio_net_hdr` prefix on
+            // every write (NEEDS_CSUM=0, GSO_NONE). Send it vectored so the
+            // header is not copied onto the packet; the returned count
+            // excludes it to match a plain send.
+            let hdr = [0u8; tun_rs::VIRTIO_NET_HDR_LEN];
+            let chunks = [std::io::IoSlice::new(&hdr), std::io::IoSlice::new(&buf[..])];
+            return Self::map_send_result(
+                self.send_chunks(&chunks)
+                    .map(|n| n.saturating_sub(hdr.len())),
+            );
+        }
+
+        let tun = self.tun.as_ref().unwrap();
+        Self::map_send_result(tun.try_send(&buf[..]))
     }
 
     /// Map the result of a TUN write onto an [`IOCallbackResult`], shared by
@@ -670,6 +670,14 @@ impl TunDirect {
             }
             Err(err) => IOCallbackResult::Err(err),
         }
+    }
+
+    /// Write `chunks` to the TUN in one vectored send — no copy, no
+    /// allocation. Returns the total number of bytes written across all
+    /// chunks.
+    #[cfg(target_os = "linux")]
+    fn send_chunks(&self, chunks: &[std::io::IoSlice<'_>]) -> std::io::Result<usize> {
+        self.tun.as_ref().unwrap().try_send_vectored(chunks)
     }
 
     /// MTU of Tun

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -655,6 +655,14 @@ impl TunDirect {
         };
         #[cfg(not(target_os = "linux"))]
         let res = tun.try_send(&buf[..]);
+        Self::map_send_result(res)
+    }
+
+    /// Map the result of a TUN write onto an [`IOCallbackResult`], shared by
+    /// every send path. A full write queue is retried by the caller;
+    /// anything else is fatal. Mirrors `map_send_result` on the outside UDP
+    /// path.
+    fn map_send_result(res: std::io::Result<usize>) -> IOCallbackResult<usize> {
         match res {
             Ok(nr) => IOCallbackResult::Ok(nr),
             Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -208,6 +208,29 @@ impl Udp {
     fn peer_addr(&self) -> SocketAddr {
         self.peer_addr
     }
+
+    /// Run `f` under `try_io(READABLE)`, mapping the spurious
+    /// `WouldBlock` that `try_io` may report (so the caller waits for
+    /// the next readiness event) and retrying immediately when a
+    /// signal interrupts the syscall.
+    #[cfg(batch_receive)]
+    fn try_readable_io<T>(&self, mut f: impl FnMut() -> std::io::Result<T>) -> IOCallbackResult<T> {
+        loop {
+            match self.sock.try_io(tokio::io::Interest::READABLE, &mut f) {
+                Ok(n) => return IOCallbackResult::Ok(n),
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    return IOCallbackResult::WouldBlock;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                #[cfg(apple)]
+                Err(e) if self.connect_requested && is_icmp_derived_err(&e) => {
+                    tracing::debug!("Ignoring ICMP-derived error on connected UDP recv: {e}");
+                    return IOCallbackResult::WouldBlock;
+                }
+                Err(e) => return IOCallbackResult::Err(e),
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -273,27 +296,9 @@ impl OutsideIO for Udp {
 
         let fd = self.sock.as_raw_fd();
 
-        loop {
-            match self.sock.try_io(tokio::io::Interest::READABLE, || {
-                batch_receive::recv_multiple(fd, bufs, lightway_core::MAX_IO_BATCH_SIZE)
-            }) {
-                Ok(n) => return IOCallbackResult::Ok(n),
-                // try_io may return WouldBlock even if the socket isn't actually
-                // readable. Break with 0 to wait for another readable event emitted.
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                    return IOCallbackResult::WouldBlock;
-                }
-                // Interrupted means the syscall was interrupted by a signal and can be
-                // retried immediately without waiting for another readable event.
-                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-                #[cfg(apple)]
-                Err(e) if self.connect_requested && is_icmp_derived_err(&e) => {
-                    tracing::debug!("Ignoring ICMP-derived error on connected UDP recv: {e}");
-                    return IOCallbackResult::WouldBlock;
-                }
-                Err(e) => return IOCallbackResult::Err(e),
-            }
-        }
+        self.try_readable_io(|| {
+            batch_receive::recv_multiple(fd, bufs, lightway_core::MAX_IO_BATCH_SIZE)
+        })
     }
 
     fn into_io_send_callback(self: Arc<Self>) -> OutsideIOSendCallbackArg {

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -650,6 +650,95 @@ pub async fn outside_io_task<ExtAppState: Send + Sync>(
 
 const DEFAULT_TRACER_TRIGGER_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Tracks the tracer trigger for the inside IO loops: fires
+/// `tracer_delta_exceeded` when outside data has been stale for longer
+/// than the configured timeout, at most once per stale timestamp.
+struct TracerTrigger {
+    timeout: Duration,
+    last_fired_for: Option<Instant>,
+}
+
+impl TracerTrigger {
+    fn new(keepalive_config: &KeepaliveConfig) -> Self {
+        let timeout = if keepalive_config.continuous {
+            Duration::ZERO
+        } else {
+            keepalive_config
+                .tracer_trigger_timeout
+                .unwrap_or(DEFAULT_TRACER_TRIGGER_TIMEOUT)
+        };
+        Self {
+            timeout,
+            last_fired_for: None,
+        }
+    }
+
+    async fn tick(&mut self, keepalive: &Keepalive, last_outside_data_received: Instant) {
+        if self.timeout.is_zero() {
+            return;
+        }
+        let stale_for = Instant::now().duration_since(last_outside_data_received);
+        if stale_for > self.timeout
+            && self
+                .last_fired_for
+                .is_none_or(|x| x != last_outside_data_received)
+        {
+            self.last_fired_for = Some(last_outside_data_received);
+            keepalive.tracer_delta_exceeded().await;
+        }
+    }
+}
+
+/// Shared body of the inside IO loops: rewrite the source/DNS
+/// addresses, dispatch the packet into the connection and map the
+/// recoverable errors. Returns `Ok(Some(last_outside_data_received))`
+/// when the packet entered the pipeline, `Ok(None)` when it was
+/// dropped and the loop should just continue.
+fn process_inside_packet<ExtAppState: Send + Sync>(
+    conn: &Mutex<Connection<ConnectionState<ExtAppState>>>,
+    inside_io: &dyn io::inside::InsideIORecv<ExtAppState>,
+    tun_dns_ip: Ipv4Addr,
+    buf: &mut BytesMut,
+    dispatch: impl FnOnce(
+        &mut Connection<ConnectionState<ExtAppState>>,
+        &mut BytesMut,
+    ) -> std::result::Result<(), ConnectionError>,
+) -> Result<Option<Instant>> {
+    let mut conn = conn.lock().unwrap();
+
+    // Update source IP address to server assigned IP address
+    let ip_config = conn.app_state().ip_config;
+    if let Some(ip_config) = &ip_config {
+        ipv4_update_source(buf.as_mut(), ip_config.client_ip);
+
+        // Update TUN device DNS IP address to server provided DNS address
+        let packet = Ipv4Packet::new(buf.as_ref());
+        if let Some(packet) = packet
+            && packet.get_destination() == tun_dns_ip
+        {
+            ipv4_update_destination(buf.as_mut(), ip_config.dns_ip);
+        };
+    }
+
+    match dispatch(&mut conn, buf) {
+        Ok(()) => Ok(Some(conn.activity().last_outside_data_received)),
+        Err(ConnectionError::PluginDropWithReply(reply)) => {
+            // Send the reply packet to inside path
+            let _ = inside_io.try_send(reply, ip_config);
+            Ok(None)
+        }
+        // Ignore the packet till the connection is online, and ignore
+        // invalid inside packets
+        Err(ConnectionError::InvalidState) | Err(ConnectionError::InvalidInsidePacket(_)) => {
+            Ok(None)
+        }
+        Err(err) => {
+            // Fatal error
+            Err(err.into())
+        }
+    }
+}
+
 pub async fn inside_io_task<ExtAppState: Send + Sync>(
     conn: Arc<Mutex<Connection<ConnectionState<ExtAppState>>>>,
     inside_io: Arc<dyn io::inside::InsideIORecv<ExtAppState>>,
@@ -658,14 +747,7 @@ pub async fn inside_io_task<ExtAppState: Send + Sync>(
     keepalive_config: KeepaliveConfig,
     inside_pkt_codec_stall_timeout: Duration,
 ) -> Result<()> {
-    let tracer_trigger_timeout = if keepalive_config.continuous {
-        Duration::ZERO
-    } else {
-        keepalive_config
-            .tracer_trigger_timeout
-            .unwrap_or(DEFAULT_TRACER_TRIGGER_TIMEOUT)
-    };
-    let mut tracer_timeout_last_outside_data_rcvd: Option<Instant> = None;
+    let mut tracer = TracerTrigger::new(&keepalive_config);
     // `mtu + vnet_headroom` so a read from a TUN opened with offload is
     // not truncated by the length of the virtio header the kernel
     // prepends. Zero extra unless offload is in use.
@@ -683,76 +765,34 @@ pub async fn inside_io_task<ExtAppState: Send + Sync>(
             }
         };
 
-        let last_outside_data_received = {
-            let mut conn = conn.lock().unwrap();
-
-            // Update source IP address to server assigned IP address
-            let ip_config = conn.app_state().ip_config;
-            if let Some(ip_config) = &ip_config {
-                ipv4_update_source(buf.as_mut(), ip_config.client_ip);
-
-                // Update TUN device DNS IP address to server provided DNS address
-                let packet = Ipv4Packet::new(buf.as_ref());
-                if let Some(packet) = packet
-                    && packet.get_destination() == tun_dns_ip
-                {
-                    ipv4_update_destination(buf.as_mut(), ip_config.dns_ip);
-                };
-            }
-
-            match conn.inside_data_received(&mut buf) {
-                Ok(()) => {
-                    // If the inside packet codec has stalled the data plane, downgrade to
-                    // unencoded rather than tearing the tunnel down. Control frames bypass
-                    // the codec, so keepalive/tracer can't detect this on their own.
-                    match conn.downgrade_inside_pkt_codec_if_stalled(inside_pkt_codec_stall_timeout)
-                    {
-                        Ok(true) => {
-                            tracing::warn!(
-                                "inside packet codec data-plane stalled; disabling codec"
-                            )
-                        }
-                        Ok(false) => {}
-                        Err(e) => {
-                            tracing::error!(
-                                "failed to disable inside packet codec after stall: {e}"
-                            )
-                        }
+        let Some(last_outside_data_received) = process_inside_packet(
+            &conn,
+            inside_io.as_ref(),
+            tun_dns_ip,
+            &mut buf,
+            |conn, buf| {
+                conn.inside_data_received(buf)?;
+                // If the inside packet codec has stalled the data plane,
+                // downgrade to unencoded rather than tearing the tunnel down.
+                // Control frames bypass the codec, so keepalive/tracer can't
+                // detect this on their own.
+                match conn.downgrade_inside_pkt_codec_if_stalled(inside_pkt_codec_stall_timeout) {
+                    Ok(true) => {
+                        tracing::warn!("inside packet codec data-plane stalled; disabling codec")
                     }
-                    conn.activity().last_outside_data_received
+                    Ok(false) => {}
+                    Err(e) => {
+                        tracing::error!("failed to disable inside packet codec after stall: {e}")
+                    }
                 }
-                Err(ConnectionError::PluginDropWithReply(reply)) => {
-                    // Send the reply packet to inside path
-                    let _ = inside_io.try_send(reply, ip_config);
-                    continue;
-                }
-                Err(ConnectionError::InvalidState) => {
-                    // Ignore the packet till the connection is online
-                    continue;
-                }
-                Err(ConnectionError::InvalidInsidePacket(_)) => {
-                    // Ignore invalid inside packet
-                    continue;
-                }
-                Err(err) => {
-                    // Fatal error
-                    return Err(err.into());
-                }
-            }
+                Ok(())
+            },
+        )?
+        else {
+            continue;
         };
 
-        let now = Instant::now();
-        let duration_since_last_outside_data = now.duration_since(last_outside_data_received);
-
-        if !tracer_trigger_timeout.is_zero()
-            && duration_since_last_outside_data > tracer_trigger_timeout
-            && tracer_timeout_last_outside_data_rcvd.is_none_or(|x| x != last_outside_data_received)
-        {
-            {
-                tracer_timeout_last_outside_data_rcvd = Some(last_outside_data_received);
-                keepalive.tracer_delta_exceeded().await;
-            }
-        }
+        tracer.tick(&keepalive, last_outside_data_received).await;
     }
 }
 

--- a/lightway-core/Cargo.toml
+++ b/lightway-core/Cargo.toml
@@ -26,6 +26,7 @@ anyhow.workspace = true
 bitfield-struct = "0.13.0"
 bytes.workspace = true
 delegate.workspace = true
+internet-checksum.workspace = true
 lightway-expresslane = { version = "0.1.0", path = "../lightway-expresslane" }
 lru = "0.18.0"
 metrics.workspace = true

--- a/lightway-core/src/gso.rs
+++ b/lightway-core/src/gso.rs
@@ -102,7 +102,9 @@ impl VirtioNetHdr {
 
 /// IPv4/IPv6 protocol number for UDP, needed to decide whether the
 /// RFC 768 zero substitution applies.
-const IPPROTO_UDP: u8 = 17;
+const IPPROTO_UDP: u8 = pnet_packet::ip::IpNextHeaderProtocols::Udp.0;
+/// IPv4/IPv6 protocol number for TCP (see [`IPPROTO_UDP`]).
+const IPPROTO_TCP: u8 = pnet_packet::ip::IpNextHeaderProtocols::Tcp.0;
 
 /// Read the layer-4 protocol number out of the IP header at the start of
 /// `buf`.
@@ -160,53 +162,58 @@ pub fn gso_none_checksum(buf: &mut [u8], csum_start: u16, csum_offset: u16) {
 
     // Read the kernel-deposited pseudo-header partial, then zero the
     // field so it doesn't double-count when we sum the segment.
-    let initial = read_u16(&buf[at..at + 2]) as u64;
+    let partial = u16::from_be_bytes([buf[at], buf[at + 1]]);
     buf[at] = 0;
     buf[at + 1] = 0;
 
-    let csum = !checksum(&buf[start..], initial);
+    // Seed with the big-endian partial (one 16-bit word), then sum the
+    // transport bytes from `csum_start` with the field zeroed.
+    let mut c = internet_checksum::Checksum::new();
+    c.add_bytes(&partial.to_be_bytes());
+    c.add_bytes(&buf[start..]);
+    let csum = u16::from_be_bytes(c.checksum());
     // RFC 768: a computed UDP checksum of zero must go on the wire as
     // 0xFFFF, the same value in one's complement, because 0x0000 is the
     // IPv4 "no checksum computed" sentinel and is outright invalid over
     // IPv6 (RFC 8200 s8.1). Never for TCP, where 0x0000 is legal.
     let csum = if is_udp && csum == 0 { 0xFFFF } else { csum };
-    buf[at] = (csum >> 8) as u8;
-    buf[at + 1] = csum as u8;
+    buf[at..at + 2].copy_from_slice(&csum.to_be_bytes());
 }
 
-// Internet checksum used only by `gso_none_checksum` below — the
-// build_segment path uses pnet_packet's protocol-aware helpers.
+/// One's-complement transport checksum over a TCP/UDP pseudo-header
+/// (source address, destination address, zero-padded protocol byte, and
+/// transport length) plus the transport bytes, which must already have
+/// their checksum field zeroed. Works for IPv4 (4-byte) and IPv6 (16-byte)
+/// addresses; returns the host-order value to store via `set_checksum`.
+///
+/// Matches `pnet_packet::{tcp,udp}::ipv{4,6}_checksum` — pnet skips the
+/// checksum word while we zero it, and a zeroed word contributes 0. pnet
+/// does not apply the RFC 768 substitution, so UDP output differs from
+/// pnet's only for the ~1-in-65536 zero case, where pnet is wrong.
 #[inline]
-fn read_u16(b: &[u8]) -> u16 {
-    u16::from_be_bytes(b[..2].try_into().unwrap())
-}
-
-// One's-complement folded checksum with a kernel-seeded initial value.
-// The inner loop unrolls to read 8 bytes per iteration; on x86_64
-// release LLVM auto-vectorizes the resulting straight-line code.
-#[inline]
-fn checksum(mut b: &[u8], initial: u64) -> u16 {
-    let mut acc = initial;
-    while b.len() >= 8 {
-        acc += u32::from_be_bytes(b[..4].try_into().unwrap()) as u64;
-        acc += u32::from_be_bytes(b[4..8].try_into().unwrap()) as u64;
-        b = &b[8..];
+fn transport_checksum(src: &[u8], dst: &[u8], proto: u8, transport: &[u8]) -> u16 {
+    // The pseudo-header length field is 16 bits; a longer slice would wrap
+    // it and silently produce a wrong checksum. Unreachable from
+    // `build_segment`, whose slices are bounded by `gso_size`.
+    debug_assert!(
+        transport.len() <= u16::MAX as usize,
+        "transport too long for pseudo-header"
+    );
+    let transport_len = transport.len() as u16;
+    let mut c = internet_checksum::Checksum::new();
+    c.add_bytes(src);
+    c.add_bytes(dst);
+    // [zero, proto, len_hi, len_lo] — the big-endian pseudo-header trailer.
+    c.add_bytes(&[0, proto, (transport_len >> 8) as u8, transport_len as u8]);
+    c.add_bytes(transport);
+    let csum = u16::from_be_bytes(c.checksum());
+    // Same RFC 768 substitution `gso_none_checksum` applies; here the
+    // protocol is a parameter so it needs no sniffing.
+    if proto == IPPROTO_UDP && csum == 0 {
+        0xFFFF
+    } else {
+        csum
     }
-    if b.len() >= 4 {
-        acc += u32::from_be_bytes(b[..4].try_into().unwrap()) as u64;
-        b = &b[4..];
-    }
-    if b.len() >= 2 {
-        acc += read_u16(&b[..2]) as u64;
-        b = &b[2..];
-    }
-    if let Some(&byte) = b.first() {
-        acc += (byte as u64) << 8;
-    }
-    while acc > 0xFFFF {
-        acc = (acc >> 16) + (acc & 0xFFFF);
-    }
-    acc as u16
 }
 
 /// GSO type: TCP segmentation aggregate over IPv4.
@@ -366,6 +373,7 @@ pub(crate) fn build_segment(
     gso_idx: usize,
     out: &mut bytes::BytesMut,
 ) -> Result<(), GsoSegError> {
+    use pnet_packet::Packet;
     use pnet_packet::ipv4::{Ipv4Packet, MutableIpv4Packet};
     use pnet_packet::ipv6::{Ipv6Packet, MutableIpv6Packet};
     use pnet_packet::tcp::{MutableTcpPacket, TcpFlags};
@@ -419,7 +427,8 @@ pub(crate) fn build_segment(
         ip.set_checksum(csum);
     }
 
-    // Transport-layer fixups.
+    // Transport-layer fixups. See [`transport_checksum`] for the pseudo-
+    // header + zeroed-field formula and its pnet equivalence.
     if hdr.is_tcp() {
         let mut tcp =
             MutableTcpPacket::new(&mut out[csum_start..out_len]).ok_or(GsoSegError::Tcp)?;
@@ -436,10 +445,10 @@ pub(crate) fn build_segment(
         tcp.set_checksum(0);
         let csum = match (v4_addrs, v6_addrs) {
             (Some((src, dst)), None) => {
-                pnet_packet::tcp::ipv4_checksum(&tcp.to_immutable(), &src, &dst)
+                transport_checksum(&src.octets(), &dst.octets(), IPPROTO_TCP, tcp.packet())
             }
             (None, Some((src, dst))) => {
-                pnet_packet::tcp::ipv6_checksum(&tcp.to_immutable(), &src, &dst)
+                transport_checksum(&src.octets(), &dst.octets(), IPPROTO_TCP, tcp.packet())
             }
             _ => unreachable!(),
         };
@@ -451,10 +460,10 @@ pub(crate) fn build_segment(
         udp.set_checksum(0);
         let csum = match (v4_addrs, v6_addrs) {
             (Some((src, dst)), None) => {
-                pnet_packet::udp::ipv4_checksum(&udp.to_immutable(), &src, &dst)
+                transport_checksum(&src.octets(), &dst.octets(), IPPROTO_UDP, udp.packet())
             }
             (None, Some((src, dst))) => {
-                pnet_packet::udp::ipv6_checksum(&udp.to_immutable(), &src, &dst)
+                transport_checksum(&src.octets(), &dst.octets(), IPPROTO_UDP, udp.packet())
             }
             _ => unreachable!(),
         };
@@ -494,6 +503,67 @@ mod tests {
         assert!(ecn.is_gso_none());
     }
 
+    /// The same RFC 768 rule on the `build_segment` path, where the
+    /// protocol is a parameter rather than sniffed from the IP header.
+    ///
+    /// The protocol number is itself part of the pseudo-header, so a
+    /// payload that folds to zero under one protocol does not under the
+    /// other; each case is searched separately against a local reference
+    /// fold rather than against the function under test.
+    #[test]
+    fn transport_checksum_substitutes_zero_for_udp_only() {
+        /// Plain one's-complement fold of the pseudo-header + transport,
+        /// independent of the implementation being tested.
+        fn reference(src: &[u8], dst: &[u8], proto: u8, t: &[u8]) -> u16 {
+            let len = t.len() as u16;
+            let mut words: Vec<u8> = Vec::new();
+            words.extend_from_slice(src);
+            words.extend_from_slice(dst);
+            words.extend_from_slice(&[0, proto, (len >> 8) as u8, len as u8]);
+            words.extend_from_slice(t);
+            if words.len() % 2 == 1 {
+                words.push(0);
+            }
+            let mut sum: u32 = 0;
+            for c in words.chunks(2) {
+                sum += u16::from_be_bytes([c[0], c[1]]) as u32;
+                sum = (sum & 0xFFFF) + (sum >> 16);
+            }
+            !(sum as u16)
+        }
+
+        let src = [10u8, 0, 0, 1];
+        let dst = [96u8, 0, 0, 4];
+        let payload_for = |proto: u8| {
+            (0u32..=0xFFFF)
+                .map(|n| {
+                    let mut t = vec![0u8; 12];
+                    t[8..10].copy_from_slice(&(n as u16).to_be_bytes());
+                    t
+                })
+                .find(|t| reference(&src, &dst, proto, t) == 0)
+                .expect("some payload folds to a zero checksum")
+        };
+
+        // UDP: the zero is substituted.
+        let udp = payload_for(IPPROTO_UDP);
+        assert_eq!(reference(&src, &dst, IPPROTO_UDP, &udp), 0);
+        assert_eq!(
+            transport_checksum(&src, &dst, IPPROTO_UDP, &udp),
+            0xFFFF,
+            "UDP zero checksum must be transmitted as 0xFFFF"
+        );
+
+        // TCP: 0x0000 is legal and must be left alone.
+        let tcp = payload_for(IPPROTO_TCP);
+        assert_eq!(reference(&src, &dst, IPPROTO_TCP, &tcp), 0);
+        assert_eq!(
+            transport_checksum(&src, &dst, IPPROTO_TCP, &tcp),
+            0x0000,
+            "0x0000 is a legal TCP checksum and must be left unchanged"
+        );
+    }
+
     /// RFC 768 / RFC 8200 s8.1: a computed UDP checksum of zero must be
     /// transmitted as `0xFFFF`, and TCP must be left alone because
     /// `0x0000` is a legal TCP checksum.
@@ -521,16 +591,17 @@ mod tests {
         };
 
         // Find the kernel-deposited partial for which the completed
-        // checksum folds to zero. Exhaustive over a 16-bit field.
+        // checksum folds to zero. Derived by asking the function under
+        // test, on a TCP packet where no substitution applies, so a
+        // 0x0000 result means the fold really was zero. The sum covers
+        // only the transport bytes from `csum_start`, so a seed found
+        // for TCP is equally valid for UDP.
         let seed = (0u32..=0xFFFF)
             .map(|c| c as u16)
             .find(|&c| {
-                let mut p = build(IPPROTO_UDP, c);
-                let at = START + OFFSET;
-                let initial = read_u16(&p[at..at + 2]) as u64;
-                p[at] = 0;
-                p[at + 1] = 0;
-                !checksum(&p[START..], initial) == 0
+                let mut p = build(IPPROTO_TCP, c);
+                gso_none_checksum(&mut p, START as u16, OFFSET as u16);
+                p[START + OFFSET..START + OFFSET + 2] == [0x00, 0x00]
             })
             .expect("some 16-bit seed folds to a zero checksum");
 
@@ -543,8 +614,8 @@ mod tests {
             "UDP zero checksum must be transmitted as 0xFFFF"
         );
 
-        // Identical bytes and seed, protocol 6: left as 0x0000.
-        let mut tcp = build(6, seed);
+        // Identical bytes and seed, TCP: left as 0x0000.
+        let mut tcp = build(IPPROTO_TCP, seed);
         gso_none_checksum(&mut tcp, START as u16, OFFSET as u16);
         assert_eq!(
             &tcp[START + OFFSET..START + OFFSET + 2],

--- a/lightway-server/src/io/outside/udp.rs
+++ b/lightway-server/src/io/outside/udp.rs
@@ -1,5 +1,5 @@
 mod batch_receive;
-mod cmsg;
+use lightway_app_utils::cmsg;
 pub(crate) mod send_queue;
 
 use anyhow::Result;

--- a/lightway-server/src/io/outside/udp.rs
+++ b/lightway-server/src/io/outside/udp.rs
@@ -486,7 +486,7 @@ fn read_single_from_socket(
     let mut msg = MsgHdrMut::new()
         .with_addr(&mut peer_sock_addr)
         .with_buffers(&mut raw_buf)
-        .with_control(control.as_mut());
+        .with_control(control.spare_capacity_mut());
 
     let len = sock.recvmsg(&mut msg, 0)?;
 

--- a/lightway-server/src/io/outside/udp.rs
+++ b/lightway-server/src/io/outside/udp.rs
@@ -1,11 +1,11 @@
 mod batch_receive;
-use lightway_app_utils::cmsg;
 pub(crate) mod send_queue;
 
 use anyhow::Result;
 use async_trait::async_trait;
 use bytes::BytesMut;
 use bytesize::ByteSize;
+use lightway_app_utils::cmsg;
 #[cfg(target_os = "linux")]
 use lightway_app_utils::sockopt;
 use lightway_app_utils::sockopt::socket_enable_pktinfo;
@@ -417,8 +417,8 @@ impl Server for UdpServer {
     }
 }
 
-fn find_pktinfo_from_iter<const N: usize>(
-    mut iter: cmsg::Iter<'_, N>,
+fn find_pktinfo_from_iter(
+    mut iter: cmsg::Iter<'_>,
     local_port: u16,
 ) -> Option<(SocketAddr, libc::in_pktinfo)> {
     iter.find_map(|cmsg| {

--- a/lightway-server/src/io/outside/udp/batch_receive.rs
+++ b/lightway-server/src/io/outside/udp/batch_receive.rs
@@ -6,9 +6,9 @@
 //!   `0.0.0.0`). Fills source address and a caller-provided control buffer in
 //!   addition to the data.
 
-use crate::io::outside::udp::cmsg;
-use crate::io::outside::udp::cmsg::LibcControlLen;
 use bytes::BytesMut;
+use lightway_app_utils::cmsg;
+use lightway_app_utils::cmsg::LibcControlLen;
 use lightway_core::MAX_IO_BATCH_SIZE;
 use std::io;
 use std::net::SocketAddr;
@@ -158,7 +158,7 @@ pub(crate) fn recv_multiple_with_metadata<const CONTROL_SIZE: usize>(
 
 #[cfg(macos)]
 mod apple {
-    use crate::io::outside::udp::cmsg::LibcControlLen;
+    use lightway_app_utils::cmsg::LibcControlLen;
     use lightway_app_utils::recvmsg_x::{msghdr_x, recvmsg_x};
     use lightway_core::{MAX_IO_BATCH_SIZE, MAX_OUTSIDE_MTU};
     use std::{io, mem};
@@ -249,7 +249,7 @@ mod apple {
 
 #[cfg(linux)]
 mod linux {
-    use crate::io::outside::udp::cmsg::LibcControlLen;
+    use lightway_app_utils::cmsg::LibcControlLen;
     use lightway_core::{MAX_IO_BATCH_SIZE, MAX_OUTSIDE_MTU};
     use std::{io, mem};
 

--- a/lightway-server/src/io/outside/udp/batch_receive.rs
+++ b/lightway-server/src/io/outside/udp/batch_receive.rs
@@ -201,7 +201,8 @@ mod apple {
                 hdr.msg_namelen = slot.peer_addr_len;
 
                 if let Some(control) = &mut slot.control {
-                    hdr.msg_control = control.as_mut().as_mut_ptr() as *mut libc::c_void;
+                    hdr.msg_control =
+                        control.spare_capacity_mut().as_mut_ptr() as *mut libc::c_void;
                     hdr.msg_controllen = control.capacity() as LibcControlLen;
                 }
             }
@@ -291,7 +292,8 @@ mod linux {
                 hdr.msg_hdr.msg_namelen = slot.peer_addr_len;
 
                 if let Some(control) = &mut slot.control {
-                    hdr.msg_hdr.msg_control = control.as_mut().as_mut_ptr() as *mut libc::c_void;
+                    hdr.msg_hdr.msg_control =
+                        control.spare_capacity_mut().as_mut_ptr() as *mut libc::c_void;
                     hdr.msg_hdr.msg_controllen = control.capacity() as LibcControlLen;
                 }
             }


### PR DESCRIPTION
## Part 2 of 3 — refactorings

Second of a three-PR stack that adds client-side TUN GSO/GRO offload.
**Base this on part 1 (bug fixes).** This part is pure refactoring — no
behaviour change — to prepare the ground for the feature work in part 3:
hoisting shared cmsg handling, extracting the TUN send/receive syscall
plumbing into reusable helpers, and switching GSO checksums to the
`internet-checksum` crate. Reviewing it separately keeps the feature diff
focused on new behaviour.

No functional change. Each commit is independently buildable; the full
stack passes `cargo clippy --workspace --all-targets` (0 diagnostics) and
`cargo test --workspace`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CI and Manually tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`