### PR TITLE
Client TUN offload (3/3): client GSO/GRO offload implementation

### DIFF
--- a/lightway-app-utils/src/cmsg.rs
+++ b/lightway-app-utils/src/cmsg.rs
@@ -68,6 +68,8 @@ impl<const N: usize> Default for Buffer<N> {
 
 pub enum Message<'a> {
     IpPktinfo(&'a libc::in_pktinfo),
+    #[cfg(linux)]
+    UdpGroSegment(libc::c_int),
     Unknown(#[allow(dead_code)] &'a libc::cmsghdr),
 }
 
@@ -110,6 +112,14 @@ pub fn iter_control(control: &[u8]) -> Iter<'_> {
     }
 }
 
+#[cfg(linux)]
+pub fn first_udp_gro_segment(control: &[u8]) -> Option<u16> {
+    iter_control(control).find_map(|m| match m {
+        Message::UdpGroSegment(seg) => Some(seg as u16),
+        _ => None,
+    })
+}
+
 pub struct Iter<'a> {
     msghdr: libc::msghdr,
     cursor: *const libc::cmsghdr,
@@ -147,10 +157,22 @@ impl<'a> Iterator for Iter<'a> {
                 let data = unsafe { libc::CMSG_DATA(item) as *const libc::in_pktinfo };
                 // SAFETY: we constructed `data` above
                 let pi = unsafe { &*data };
-                Some(Message::IpPktinfo(pi))
-            } else {
-                Some(Message::Unknown(item))
+                return Some(Message::IpPktinfo(pi));
             }
+
+            #[cfg(linux)]
+            if item.cmsg_level == libc::SOL_UDP && item.cmsg_type == libc::UDP_GRO {
+                // SAFETY: `item` is a valid `cmsghdr` from a prior call
+                // to `CMSG_FIRSTHDR` or `CMSG_NXTHDR`.
+                let data = unsafe { libc::CMSG_DATA(item) as *const libc::c_int };
+                // SAFETY: a `UDP_GRO` cmsg carries a `c_int` and
+                // `CMSG_DATA` returns a pointer aligned for it within the
+                // cmsg.
+                let seg = unsafe { *data };
+                return Some(Message::UdpGroSegment(seg));
+            }
+
+            Some(Message::Unknown(item))
         }
     }
 }
@@ -357,6 +379,40 @@ mod tests {
                 },
             )
             .unwrap();
+    }
+
+    /// `first_udp_gro_segment` extracts the segment size from a raw
+    /// (aligned) control buffer built with `SOL_UDP`/`UDP_GRO`, and
+    /// returns `None` when no such message is present.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn first_udp_gro_segment_parses_raw_control() {
+        const SIZE: usize = Message::space::<libc::c_int>();
+        let mut out = BufferMut::<SIZE>::zeroed();
+        out.builder()
+            .fill_next(libc::SOL_UDP, libc::UDP_GRO, 1400 as libc::c_int)
+            .unwrap();
+        // BufferMut is `#[repr(align(16))]`, so `as_ref()` is aligned.
+        assert_eq!(first_udp_gro_segment(out.as_ref()), Some(1400));
+
+        // A buffer with an unrelated (pktinfo) message yields None.
+        const PSIZE: usize = Message::space::<libc::in_pktinfo>();
+        let mut other = BufferMut::<PSIZE>::zeroed();
+        other
+            .builder()
+            .fill_next(
+                libc::SOL_IP,
+                libc::IP_PKTINFO,
+                libc::in_pktinfo {
+                    ipi_ifindex: 0,
+                    ipi_spec_dst: libc::in_addr { s_addr: 0 },
+                    ipi_addr: libc::in_addr { s_addr: 0 },
+                },
+            )
+            .unwrap();
+        assert_eq!(first_udp_gro_segment(other.as_ref()), None);
+
+        assert_eq!(first_udp_gro_segment(&[]), None);
     }
 
     #[test]

--- a/lightway-app-utils/src/sockopt.rs
+++ b/lightway-app-utils/src/sockopt.rs
@@ -4,7 +4,11 @@
 mod ip_mtu_discover;
 #[cfg(unix)]
 mod ip_pktinfo;
+#[cfg(linux)]
+mod udp_gro;
 
 pub use ip_mtu_discover::*;
 #[cfg(unix)]
 pub use ip_pktinfo::*;
+#[cfg(linux)]
+pub use udp_gro::*;

--- a/lightway-app-utils/src/sockopt/udp_gro.rs
+++ b/lightway-app-utils/src/sockopt/udp_gro.rs
@@ -1,0 +1,30 @@
+#![allow(unsafe_code)]
+
+use std::os::fd::AsRawFd;
+
+/// Enable the `UDP_GRO` sockopt (Linux 5.0+).
+///
+/// The kernel then coalesces trains of equal-size datagrams from the
+/// same flow into a single buffer per `recvmsg(2)`, reporting the
+/// per-segment size via a `UDP_GRO` control message. Callers that
+/// enable this MUST receive with control-message space and split on
+/// the reported boundary — a plain `recv(2)` would silently merge
+/// separate datagrams.
+pub fn socket_enable_udp_gro(sock: &impl AsRawFd) -> std::io::Result<()> {
+    // SAFETY: `setsockopt` requires a valid fd and a valid buffer of `c_int` size
+    let res = unsafe {
+        libc::setsockopt(
+            sock.as_raw_fd(),
+            libc::SOL_UDP,
+            libc::UDP_GRO,
+            &1 as *const libc::c_int as *const libc::c_void,
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+
+    if res == -1 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -402,6 +402,26 @@ impl Tun {
         }
     }
 
+    /// Send a packet with an explicit virtio header (e.g. a TSO
+    /// superpacket assembled by userspace GRO). Requires the device to
+    /// have been opened with offload ([`TunConfig::offload`]). Only the
+    /// direct backend supports this; the `IoUring` backend reports
+    /// [`std::io::ErrorKind::Unsupported`].
+    #[cfg(target_os = "linux")]
+    pub fn try_send_gso(
+        &self,
+        buf: BytesMut,
+        hdr: &lightway_core::VirtioNetHdr,
+    ) -> IOCallbackResult<usize> {
+        match self {
+            Tun::Direct(t) => t.try_send_gso(buf, hdr),
+            #[cfg(feature = "io-uring")]
+            Tun::IoUring(_) => {
+                IOCallbackResult::Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+            }
+        }
+    }
+
     /// MTU of `Tun` interface
     pub fn mtu(&self) -> usize {
         match self {
@@ -710,6 +730,31 @@ impl TunDirect {
             }
             Err(err) => IOCallbackResult::Err(err),
         }
+    }
+
+    /// Send a packet with an explicit virtio header (e.g. a TSO
+    /// superpacket assembled by userspace GRO). Requires the device to
+    /// have been opened with offload ([`TunConfig::offload`]).
+    #[cfg(target_os = "linux")]
+    pub fn try_send_gso(
+        &self,
+        buf: BytesMut,
+        hdr: &lightway_core::VirtioNetHdr,
+    ) -> IOCallbackResult<usize> {
+        if !self.vnet_hdr {
+            debug_assert!(false, "try_send_gso called on a Tun opened without offload");
+            // The device won't accept a virtio header; fall back to a
+            // plain write rather than corrupt traffic in release builds.
+            return self.try_send(buf);
+        }
+
+        // The returned count excludes the virtio header to match a plain send.
+        let hdr = hdr.to_bytes();
+        let chunks = [std::io::IoSlice::new(&hdr), std::io::IoSlice::new(&buf[..])];
+        Self::map_send_result(
+            self.send_chunks(&chunks)
+                .map(|n| n.saturating_sub(hdr.len())),
+        )
     }
 
     /// Write `chunks` to the TUN in one vectored send — no copy, no

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -486,6 +486,27 @@ impl TunDirect {
         // This currently is not supported for Android and IOS
         #[cfg(mobile)]
         let mtu = 1350;
+
+        // Reflect the capability the device negotiated, not what was
+        // requested: `build_async` succeeds even when the kernel rejects
+        // `TUNSETOFFLOAD` (tun-rs only warns), and `tcp_gso()` then reports
+        // false. Note this tracks TSO/USO capability, not IFF_VNET_HDR
+        // framing: tun-rs runs TUNSETIFF first and leaves the flag set on a
+        // later TUNSETOFFLOAD failure, so the fd keeps vnet framing while
+        // this flag says false. Harmless because supports_gso() returns this
+        // flag and the as_gso() startup check aborts before traffic moves.
+        #[cfg(target_os = "linux")]
+        let vnet_hdr = {
+            let negotiated = tun_device.tcp_gso();
+            if config.offload && !negotiated {
+                tracing::warn!(
+                    "TUN offload requested but the kernel did not negotiate IFF_VNET_HDR; \
+                     continuing without GSO/GRO offload"
+                );
+            }
+            negotiated
+        };
+
         let tun = Some(tun_device);
 
         Ok(TunDirect {
@@ -496,7 +517,7 @@ impl TunDirect {
             #[cfg(unix)]
             close_fd_on_drop: config.close_fd_on_drop,
             #[cfg(target_os = "linux")]
-            vnet_hdr: config.offload,
+            vnet_hdr,
         })
     }
 

--- a/lightway-client/src/config.rs
+++ b/lightway-client/src/config.rs
@@ -284,6 +284,13 @@ pub struct Config {
     #[patch(attribute(clap(long)))]
     #[patch(empty_value = false)]
     #[patch(attribute(serde(default)))]
+    #[patch(attribute(doc = "Enable TUN offload (GSO/GRO) for batch packet processing"))]
+    #[schemars(extend("x-cfg" = "linux"))]
+    pub enable_tun_offload: bool,
+
+    #[patch(attribute(clap(long)))]
+    #[patch(empty_value = false)]
+    #[patch(attribute(serde(default)))]
     #[patch(attribute(doc = "Enable IO-uring interface for Tunnel"))]
     #[schemars(extend("x-cfg" = "linux"))]
     pub enable_tun_iouring: bool,
@@ -569,6 +576,7 @@ impl Default for Config {
             ),
             enable_pmtud: false,
             pmtud_base_mtu: None,
+            enable_tun_offload: false,
             enable_tun_iouring: false,
             iouring_entry_count: 1024,
             iouring_sqpoll_idle_time: Duration::from_std_duration(StdDuration::from_millis(100)),

--- a/lightway-client/src/io/inside.rs
+++ b/lightway-client/src/io/inside.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 pub use tun::Tun;
 
 use async_trait::async_trait;
+#[cfg(linux)]
+use lightway_core::VirtioNetHdr;
 use lightway_core::{
     IOCallbackResult, InsideIOSendCallback, InsideIOSendCallbackArg, InsideIpConfig,
 };
@@ -33,9 +35,43 @@ pub trait InsideIORecv<ExtAppState: Send + Sync>: Send + Sync {
         0
     }
 
+    /// Upgrade to the GSO-capable interface, when this instance supports
+    /// GSO reads. Default: not supported. Capability is per-instance —
+    /// a TUN opened without offload returns `None`.
+    #[cfg(linux)]
+    fn as_gso(self: Arc<Self>) -> Option<Arc<dyn InsideIORecvGso<ExtAppState>>> {
+        None
+    }
+
     fn into_io_send_callback(
         self: Arc<Self>,
     ) -> InsideIOSendCallbackArg<ConnectionState<ExtAppState>>;
+}
+
+/// Inside IO backends that can receive GSO superpackets. Obtained from
+/// [`InsideIORecv::as_gso`]; the GSO inside loop only accepts this type,
+/// so the capability check happens once at startup.
+///
+/// Implementers must also override [`InsideIORecv::as_gso`] to return
+/// `Some(self)` — the default `None` hides the capability.
+#[cfg(linux)]
+#[async_trait]
+pub trait InsideIORecvGso<ExtAppState: Send + Sync>: InsideIORecv<ExtAppState> {
+    /// Receive a GSO superpacket into `buf`.
+    ///
+    /// Implementations write into `buf.spare_capacity_mut()` so the
+    /// caller can reuse one allocation across iterations with no
+    /// zero-init cost. On `Ok((n, hdr))`, the virtio header has been
+    /// parsed (`hdr`), `set_len` + `advance(VIRTIO_NET_HDR_LEN)` have
+    /// run, and `buf` holds exactly the IP packet (`n == buf.len()`).
+    /// Caller must ensure `buf.capacity()` is large enough for one
+    /// virtio header plus the largest expected aggregate.
+    ///
+    /// Returns `WouldBlock` on EAGAIN, on a short read that didn't
+    /// contain a full virtio header, or when the virtio header
+    /// itself fails to decode (each cause is logged + metered
+    /// inside the impl). Returns `Err` on IO errors.
+    async fn recv_gso(&self, buf: &mut BytesMut) -> IOCallbackResult<(usize, VirtioNetHdr)>;
 }
 
 /// Trait for InsideIO

--- a/lightway-client/src/io/inside.rs
+++ b/lightway-client/src/io/inside.rs
@@ -43,6 +43,18 @@ pub trait InsideIORecv<ExtAppState: Send + Sync>: Send + Sync {
         None
     }
 
+    /// Open a GRO coalescing window on the send path. Until the matching
+    /// [`Self::gro_flush`], packets delivered via the inside send callback
+    /// may be coalesced into TSO superpackets instead of written
+    /// individually. Backends without TUN offload leave this a no-op.
+    #[cfg(linux)]
+    fn gro_open(&self) {}
+
+    /// Flush any coalesced packets and close the window opened by
+    /// [`Self::gro_open`].
+    #[cfg(linux)]
+    fn gro_flush(&self) {}
+
     fn into_io_send_callback(
         self: Arc<Self>,
     ) -> InsideIOSendCallbackArg<ConnectionState<ExtAppState>>;

--- a/lightway-client/src/io/inside/tun.rs
+++ b/lightway-client/src/io/inside/tun.rs
@@ -1,3 +1,8 @@
+#[cfg(linux)]
+use std::sync::{
+    Mutex,
+    atomic::{AtomicBool, Ordering},
+};
 #[cfg(feature = "io-uring")]
 use std::time::Duration;
 use std::{net::Ipv4Addr, sync::Arc};
@@ -10,6 +15,8 @@ use pnet_packet::ipv4::Ipv4Packet;
 use lightway_app_utils::{Tun as AppUtilsTun, TunConfig};
 #[cfg(linux)]
 use lightway_core::VirtioNetHdr;
+#[cfg(linux)]
+use lightway_core::gro::TcpGroTable;
 use lightway_core::{
     IOCallbackResult, InsideIOSendCallback, InsideIOSendCallbackArg, InsideIpConfig,
     ipv4_update_destination, ipv4_update_source,
@@ -23,12 +30,14 @@ pub struct Tun {
     tun: AppUtilsTun,
     ip: Ipv4Addr,
     dns_ip: Ipv4Addr,
+    #[cfg(linux)]
+    gro: Gro,
 }
 
 impl Tun {
     pub async fn new(tun: &TunConfig, ip: Ipv4Addr, dns_ip: Ipv4Addr) -> Result<Self> {
         let tun = AppUtilsTun::direct(tun).await?;
-        Ok(Tun { tun, ip, dns_ip })
+        Ok(Self::from_app_utils_tun(tun, ip, dns_ip))
     }
 
     #[cfg(feature = "io-uring")]
@@ -40,7 +49,17 @@ impl Tun {
         iouring_sqpoll_idle_time: Duration,
     ) -> Result<Self> {
         let tun = AppUtilsTun::iouring(tun, iouring_ring_size, iouring_sqpoll_idle_time).await?;
-        Ok(Tun { tun, ip, dns_ip })
+        Ok(Self::from_app_utils_tun(tun, ip, dns_ip))
+    }
+
+    fn from_app_utils_tun(tun: AppUtilsTun, ip: Ipv4Addr, dns_ip: Ipv4Addr) -> Self {
+        Tun {
+            tun,
+            ip,
+            dns_ip,
+            #[cfg(linux)]
+            gro: Gro::new(),
+        }
     }
 
     pub fn if_index(&self) -> std::io::Result<u32> {
@@ -50,6 +69,165 @@ impl Tun {
     fn name(&self) -> std::io::Result<String> {
         self.tun.name()
     }
+
+    /// Write one already-address-rewritten packet to the device,
+    /// through the GRO coalescer when a window is open.
+    #[cfg(linux)]
+    fn send_packet(&self, buf: BytesMut) -> IOCallbackResult<usize> {
+        self.gro.send(&self.tun, buf)
+    }
+
+    /// Write one already-address-rewritten packet to the device. No
+    /// coalescing off Linux — `virtio_net_hdr` writes are a Linux TUN
+    /// feature.
+    #[cfg(not(linux))]
+    fn send_packet(&self, buf: BytesMut) -> IOCallbackResult<usize> {
+        self.tun.try_send(buf)
+    }
+}
+
+/// The device writes the GRO coalescer performs. Implemented for
+/// [`AppUtilsTun`] in production; tests substitute a fake that records
+/// every write in call order, which is the only way to observe the
+/// ordering guarantee [`Gro::coalesce_send`] relies on.
+#[cfg(linux)]
+trait TunSend {
+    /// Whether the device negotiated `IFF_VNET_HDR`, i.e. whether it
+    /// can accept a segmentation-offload write at all.
+    fn supports_gso(&self) -> bool;
+
+    /// Write one packet with no offload metadata.
+    fn try_send(&self, buf: BytesMut) -> IOCallbackResult<usize>;
+
+    /// Write one packet behind `hdr` as a `virtio_net_hdr` prefix.
+    fn try_send_gso(&self, buf: BytesMut, hdr: &VirtioNetHdr) -> IOCallbackResult<usize>;
+}
+
+#[cfg(linux)]
+impl TunSend for AppUtilsTun {
+    // Spelled as associated-function calls so these forward to the
+    // inherent methods and cannot recurse into the trait impl.
+    fn supports_gso(&self) -> bool {
+        AppUtilsTun::supports_gso(self)
+    }
+
+    fn try_send(&self, buf: BytesMut) -> IOCallbackResult<usize> {
+        AppUtilsTun::try_send(self, buf)
+    }
+
+    fn try_send_gso(&self, buf: BytesMut, hdr: &VirtioNetHdr) -> IOCallbackResult<usize> {
+        AppUtilsTun::try_send_gso(self, buf, hdr)
+    }
+}
+
+/// Receive-side coalescing state: the window flag and the flow table
+/// it gates.
+#[cfg(linux)]
+struct Gro {
+    /// Whether a GRO coalescing window is open (see
+    /// [`InsideIORecv::gro_open`]/[`InsideIORecv::gro_flush`]). Kept outside
+    /// the table mutex so the disabled path pays only a relaxed load; opens,
+    /// sends and flushes all run on the outside IO task, so a relaxed
+    /// ordering suffices.
+    open: AtomicBool,
+    table: Mutex<TcpGroTable>,
+}
+
+#[cfg(linux)]
+impl Gro {
+    fn new() -> Self {
+        Self {
+            open: AtomicBool::new(false),
+            table: Mutex::new(TcpGroTable::new()),
+        }
+    }
+
+    /// Open a coalescing window. A device without `IFF_VNET_HDR` could
+    /// not be handed a superpacket, so the window never opens there and
+    /// every send stays on the direct write path.
+    fn open(&self, tun: &impl TunSend) {
+        if !tun.supports_gso() {
+            return;
+        }
+        self.open.store(true, Ordering::Relaxed);
+    }
+
+    /// Close the window and write every superpacket the table still
+    /// holds.
+    fn flush(&self, tun: &impl TunSend) {
+        self.open.store(false, Ordering::Relaxed);
+        let mut table = self.table.lock().unwrap();
+        for (pkt, hdr) in table.drain() {
+            write_super(tun, pkt, hdr);
+        }
+    }
+
+    /// Send one packet. Outside an open window the table is not even
+    /// locked and the packet goes straight to the device.
+    fn send(&self, tun: &impl TunSend, buf: BytesMut) -> IOCallbackResult<usize> {
+        if !self.open.load(Ordering::Relaxed) {
+            return tun.try_send(buf);
+        }
+        let mut table = self.table.lock().unwrap();
+        Self::coalesce_send(tun, &mut table, buf)
+    }
+
+    /// Route a packet through the GRO coalescer. Returns `Ok(len)`
+    /// whenever the table consumed the packet — core treats that as
+    /// sent.
+    fn coalesce_send(
+        tun: &impl TunSend,
+        table: &mut TcpGroTable,
+        buf: BytesMut,
+    ) -> IOCallbackResult<usize> {
+        let len = buf.len();
+        let result = table.append(&buf);
+        // Any flushed superpackets must reach the TUN before this
+        // packet to preserve within-flow delivery order. Pinned by
+        // `flushed_superpackets_are_written_before_the_direct_write`.
+        for (pkt, hdr) in result.flushes {
+            write_super(tun, pkt, hdr);
+        }
+        if result.consumed {
+            IOCallbackResult::Ok(len)
+        } else {
+            tun.try_send(buf)
+        }
+    }
+}
+
+/// Write one coalesced superpacket to the TUN. Failures are logged and
+/// dropped (datagram semantics — the absorbed sends already reported
+/// success). The log carries the segment count (one dropped superpacket is
+/// up to 64 segments), so the loss amplification is visible. A
+/// single-segment batch carries a default header, which `try_send_gso`
+/// writes as the usual zeroed prefix.
+#[cfg(linux)]
+fn write_super(tun: &impl TunSend, pkt: BytesMut, hdr: VirtioNetHdr) {
+    let segments = superpacket_segments(pkt.len(), &hdr);
+    match tun.try_send_gso(pkt, &hdr) {
+        IOCallbackResult::Ok(_) => {}
+        IOCallbackResult::WouldBlock => {
+            tracing::warn!("Dropping coalesced GRO batch of {segments} segments: TUN would block");
+        }
+        IOCallbackResult::Err(err) => {
+            tracing::warn!("Dropping coalesced GRO batch of {segments} segments: {err}");
+        }
+    }
+}
+
+/// How many segments a superpacket expands to on the wire (the gap the
+/// local TCP stack sees if the write is dropped). `gso_size == 0` is one
+/// segment; otherwise the payload beyond `hdr_len` splits into `gso_size`
+/// chunks.
+#[cfg(linux)]
+fn superpacket_segments(len: usize, hdr: &VirtioNetHdr) -> u64 {
+    let gso_size = hdr.gso_size as usize;
+    if gso_size == 0 {
+        return 1;
+    }
+    let payload = len.saturating_sub(hdr.hdr_len as usize);
+    payload.div_ceil(gso_size).max(1) as u64
 }
 
 #[async_trait]
@@ -95,6 +273,16 @@ impl<ExtAppState: Send + Sync> InsideIORecv<ExtAppState> for Tun {
         }
     }
 
+    #[cfg(linux)]
+    fn gro_open(&self) {
+        self.gro.open(&self.tun);
+    }
+
+    #[cfg(linux)]
+    fn gro_flush(&self) {
+        self.gro.flush(&self.tun);
+    }
+
     fn into_io_send_callback(
         self: Arc<Self>,
     ) -> InsideIOSendCallbackArg<ConnectionState<ExtAppState>> {
@@ -129,7 +317,10 @@ impl<ExtAppState: Send + Sync> InsideIOSendCallback<ConnectionState<ExtAppState>
             };
         }
 
-        self.tun.try_send(buf)
+        // Inside an open GRO window, TCP segments are coalesced into
+        // TSO superpackets instead of written individually; outside
+        // one this is a direct device write.
+        self.send_packet(buf)
     }
 
     fn mtu(&self) -> usize {
@@ -142,5 +333,357 @@ impl<ExtAppState: Send + Sync> InsideIOSendCallback<ConnectionState<ExtAppState>
 
     fn name(&self) -> std::io::Result<String> {
         self.name()
+    }
+}
+
+#[cfg(all(test, linux))]
+mod tests {
+    use super::*;
+    use pnet_packet::ipv4::MutableIpv4Packet;
+    use pnet_packet::tcp::{MutableTcpPacket, TcpFlags};
+    use std::collections::VecDeque;
+
+    const IPV4_HDR_LEN: usize = 20;
+    const TCP_HDR_LEN: usize = 20;
+    const HDR_LEN: usize = IPV4_HDR_LEN + TCP_HDR_LEN;
+    /// Payload bytes per segment; also the batch's `gso_size`.
+    const MSS: usize = 100;
+    /// `lightway_core::gro::MAX_GRO_FLOWS` — the table's slot count.
+    const MAX_GRO_FLOWS: usize = 8;
+    const SRC: [u8; 4] = [10, 0, 0, 1];
+    const DST: [u8; 4] = [10, 0, 0, 2];
+
+    /// Which write path a packet took to the device.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum Kind {
+        /// [`TunSend::try_send`] — a plain write.
+        Plain,
+        /// [`TunSend::try_send_gso`] — a coalesced superpacket.
+        Super,
+    }
+
+    /// One recorded device write.
+    struct Write {
+        kind: Kind,
+        bytes: Vec<u8>,
+        hdr: VirtioNetHdr,
+    }
+
+    /// TUN stand-in that records `(bytes, VirtioNetHdr)` for every
+    /// write in call order, so relative ordering of superpacket and
+    /// plain writes is observable.
+    struct FakeTun {
+        supports_gso: bool,
+        /// Results handed out in order; once drained every write
+        /// succeeds with the byte count.
+        results: Mutex<VecDeque<IOCallbackResult<usize>>>,
+        writes: Mutex<Vec<Write>>,
+    }
+
+    impl FakeTun {
+        fn new() -> Self {
+            Self {
+                supports_gso: true,
+                results: Mutex::new(VecDeque::new()),
+                writes: Mutex::new(Vec::new()),
+            }
+        }
+
+        /// A device that never negotiated `IFF_VNET_HDR`.
+        fn without_gso() -> Self {
+            Self {
+                supports_gso: false,
+                ..Self::new()
+            }
+        }
+
+        /// A device whose first writes return `results`.
+        fn with_results(results: Vec<IOCallbackResult<usize>>) -> Self {
+            Self {
+                results: Mutex::new(results.into()),
+                ..Self::new()
+            }
+        }
+
+        fn record(&self, kind: Kind, buf: &BytesMut, hdr: VirtioNetHdr) -> IOCallbackResult<usize> {
+            self.writes.lock().unwrap().push(Write {
+                kind,
+                bytes: buf.to_vec(),
+                hdr,
+            });
+            match self.results.lock().unwrap().pop_front() {
+                Some(r) => r,
+                None => IOCallbackResult::Ok(buf.len()),
+            }
+        }
+
+        /// The write kinds, in call order.
+        fn kinds(&self) -> Vec<Kind> {
+            self.writes.lock().unwrap().iter().map(|w| w.kind).collect()
+        }
+
+        /// `(bytes, gso_size)` of the `n`th write.
+        fn write(&self, n: usize) -> (Vec<u8>, u16) {
+            let writes = self.writes.lock().unwrap();
+            let w = &writes[n];
+            (w.bytes.clone(), w.hdr.gso_size)
+        }
+    }
+
+    impl TunSend for FakeTun {
+        fn supports_gso(&self) -> bool {
+            self.supports_gso
+        }
+
+        fn try_send(&self, buf: BytesMut) -> IOCallbackResult<usize> {
+            self.record(Kind::Plain, &buf, VirtioNetHdr::default())
+        }
+
+        fn try_send_gso(&self, buf: BytesMut, hdr: &VirtioNetHdr) -> IOCallbackResult<usize> {
+            self.record(Kind::Super, &buf, *hdr)
+        }
+    }
+
+    /// One IPv4/TCP segment of flow `src_port` carrying `payload_len`
+    /// bytes at `seq`. Checksums are real, so the bytes are a
+    /// plausible decrypted inside packet.
+    fn seg(src_port: u16, seq: u32, payload_len: usize, flags: u8) -> BytesMut {
+        let total = HDR_LEN + payload_len;
+        let mut pkt = vec![0u8; total];
+        pkt[0] = 0x45; // version 4, IHL 5
+        pkt[2..4].copy_from_slice(&(total as u16).to_be_bytes());
+        pkt[6] = 0x40; // DF
+        pkt[8] = 64; // TTL
+        pkt[9] = 6; // TCP
+        pkt[12..16].copy_from_slice(&SRC);
+        pkt[16..20].copy_from_slice(&DST);
+        pkt[20..22].copy_from_slice(&src_port.to_be_bytes());
+        pkt[22..24].copy_from_slice(&5678u16.to_be_bytes());
+        pkt[24..28].copy_from_slice(&seq.to_be_bytes());
+        pkt[32] = ((TCP_HDR_LEN / 4) as u8) << 4; // data offset
+        pkt[33] = flags;
+        pkt[34..36].copy_from_slice(&0xFFFFu16.to_be_bytes()); // window
+        for (i, b) in pkt[HDR_LEN..].iter_mut().enumerate() {
+            *b = (i % 251) as u8;
+        }
+        {
+            let mut ip = MutableIpv4Packet::new(&mut pkt[..IPV4_HDR_LEN]).unwrap();
+            let csum = pnet_packet::ipv4::checksum(&ip.to_immutable());
+            ip.set_checksum(csum);
+        }
+        {
+            let mut tcp = MutableTcpPacket::new(&mut pkt[IPV4_HDR_LEN..]).unwrap();
+            let csum = pnet_packet::tcp::ipv4_checksum(
+                &tcp.to_immutable(),
+                &Ipv4Addr::from(SRC),
+                &Ipv4Addr::from(DST),
+            );
+            tcp.set_checksum(csum);
+        }
+        BytesMut::from(&pkt[..])
+    }
+
+    /// A coalescable, full-MSS data segment.
+    fn data(src_port: u16, seq: u32) -> BytesMut {
+        seg(src_port, seq, MSS, TcpFlags::ACK)
+    }
+
+    /// A pure ACK: same flow, but never coalescable — it forces the
+    /// held batch out and is then written directly.
+    fn pure_ack(src_port: u16, seq: u32) -> BytesMut {
+        seg(src_port, seq, 0, TcpFlags::ACK)
+    }
+
+    /// Fresh instances of both failure modes of a TUN write.
+    fn failures() -> Vec<IOCallbackResult<usize>> {
+        vec![
+            IOCallbackResult::WouldBlock,
+            IOCallbackResult::Err(std::io::Error::other("tun write failed")),
+        ]
+    }
+
+    /// The ordering guarantee `coalesce_send` documents: a superpacket
+    /// displaced by a packet must be written *before* that packet's
+    /// direct write, or the flow's bytes reach the kernel out of order.
+    /// Swapping the two blocks in `coalesce_send` fails only this.
+    #[test]
+    fn flushed_superpackets_are_written_before_the_direct_write() {
+        let tun = FakeTun::new();
+        let mut table = TcpGroTable::new();
+
+        // Two in-order full-MSS segments coalesce and stay pending.
+        for seq in [0, MSS as u32] {
+            let pkt = data(1234, seq);
+            let len = pkt.len();
+            let r = Gro::coalesce_send(&tun, &mut table, pkt);
+            assert!(matches!(r, IOCallbackResult::Ok(n) if n == len));
+        }
+        assert!(
+            tun.kinds().is_empty(),
+            "a pending batch must not be written before something forces it out"
+        );
+
+        // A same-flow pure ACK cannot join the batch: the batch is
+        // flushed and the ACK written directly.
+        let ack = pure_ack(1234, 2 * MSS as u32);
+        let ack_bytes = ack.to_vec();
+        let r = Gro::coalesce_send(&tun, &mut table, ack);
+        assert!(matches!(r, IOCallbackResult::Ok(n) if n == ack_bytes.len()));
+
+        assert_eq!(
+            tun.kinds(),
+            vec![Kind::Super, Kind::Plain],
+            "the flushed superpacket must reach the TUN before the packet that displaced it"
+        );
+        let (sup, gso_size) = tun.write(0);
+        assert_eq!(sup.len(), HDR_LEN + 2 * MSS);
+        assert_eq!(gso_size, MSS as u16);
+        assert_eq!(tun.write(1).0, ack_bytes);
+    }
+
+    /// `gro_open` is a no-op without `IFF_VNET_HDR`: a device that
+    /// cannot take a `virtio_net_hdr` write must never have a window
+    /// opened on it.
+    #[test]
+    fn gro_open_is_a_no_op_without_gso_support() {
+        let gro = Gro::new();
+        gro.open(&FakeTun::without_gso());
+        assert!(!gro.open.load(Ordering::Relaxed));
+
+        // Same call against a capable device does open the window.
+        gro.open(&FakeTun::new());
+        assert!(gro.open.load(Ordering::Relaxed));
+    }
+
+    /// `gro_flush` empties *every* occupied slot, not just the first —
+    /// a partial drain would strand segments until the next window
+    /// closed, or forever.
+    #[test]
+    fn gro_flush_drains_every_occupied_slot() {
+        let tun = FakeTun::new();
+        let gro = Gro::new();
+        gro.open(&tun);
+
+        // One pending two-segment batch per slot.
+        for flow in 0..MAX_GRO_FLOWS {
+            let port = 1000 + flow as u16;
+            for seq in [0, MSS as u32] {
+                let pkt = data(port, seq);
+                let len = pkt.len();
+                let r = gro.send(&tun, pkt);
+                assert!(matches!(r, IOCallbackResult::Ok(n) if n == len));
+            }
+        }
+        assert!(tun.kinds().is_empty(), "nothing should have flushed yet");
+
+        gro.flush(&tun);
+
+        assert_eq!(tun.kinds(), vec![Kind::Super; MAX_GRO_FLOWS]);
+        for n in 0..MAX_GRO_FLOWS {
+            let (bytes, gso_size) = tun.write(n);
+            assert_eq!(bytes.len(), HDR_LEN + 2 * MSS);
+            assert_eq!(gso_size, MSS as u16);
+        }
+        assert!(gro.table.lock().unwrap().is_empty());
+        assert!(!gro.open.load(Ordering::Relaxed), "flush closes the window");
+    }
+
+    /// With no window open the packet bypasses the table entirely: a
+    /// plain write, and nothing left buffered for a later flush.
+    #[test]
+    fn send_outside_a_window_bypasses_the_table() {
+        let tun = FakeTun::new();
+        let gro = Gro::new();
+
+        let pkt = data(1234, 0);
+        let bytes = pkt.to_vec();
+        let r = gro.send(&tun, pkt);
+
+        assert!(matches!(r, IOCallbackResult::Ok(n) if n == bytes.len()));
+        assert_eq!(tun.kinds(), vec![Kind::Plain]);
+        assert_eq!(tun.write(0).0, bytes);
+        assert!(
+            gro.table.lock().unwrap().is_empty(),
+            "a closed window must not buffer anything"
+        );
+
+        // Consequently a later flush has nothing to write.
+        gro.flush(&tun);
+        assert_eq!(tun.kinds(), vec![Kind::Plain]);
+    }
+
+    /// A superpacket write that fails inside `coalesce_send` is
+    /// invisible to the caller: the segments it carried were already
+    /// reported as sent, so the consumed packet still returns `Ok`.
+    #[test]
+    fn superpacket_write_failure_does_not_reach_the_caller() {
+        for fail in failures() {
+            // The first write is the superpacket flush; it fails.
+            let tun = FakeTun::with_results(vec![fail]);
+            let gro = Gro::new();
+            gro.open(&tun);
+
+            let seed = data(1234, 0);
+            assert!(matches!(gro.send(&tun, seed), IOCallbackResult::Ok(_)));
+
+            // PSH ends the train, so this segment is absorbed and the
+            // batch flushed in the same call.
+            let psh = seg(1234, MSS as u32, MSS, TcpFlags::ACK | TcpFlags::PSH);
+            let len = psh.len();
+            let r = gro.send(&tun, psh);
+
+            assert!(
+                matches!(r, IOCallbackResult::Ok(n) if n == len),
+                "a consumed packet reports success even when the superpacket write fails"
+            );
+            assert_eq!(tun.kinds(), vec![Kind::Super]);
+            assert!(gro.table.lock().unwrap().is_empty());
+        }
+    }
+
+    /// The same for a failure during `gro_flush`, which returns `()`
+    /// and must not panic or leave the batch stuck in its slot.
+    #[test]
+    fn flush_write_failure_is_swallowed_and_still_drains() {
+        for fail in failures() {
+            let tun = FakeTun::with_results(vec![fail]);
+            let gro = Gro::new();
+            gro.open(&tun);
+
+            for seq in [0, MSS as u32] {
+                assert!(matches!(
+                    gro.send(&tun, data(1234, seq)),
+                    IOCallbackResult::Ok(_)
+                ));
+            }
+
+            gro.flush(&tun);
+
+            assert_eq!(tun.kinds(), vec![Kind::Super]);
+            assert!(
+                gro.table.lock().unwrap().is_empty(),
+                "a failed write still frees the slot"
+            );
+        }
+    }
+
+    /// The segment count the drop metrics record — the amplification
+    /// factor over a single-packet drop.
+    #[test]
+    fn segment_accounting_matches_the_superpacket_shape() {
+        // Single-segment batch: default header, `gso_size` zero.
+        assert_eq!(superpacket_segments(1400, &VirtioNetHdr::default()), 1);
+
+        let hdr = VirtioNetHdr {
+            hdr_len: 40,
+            gso_size: 1350,
+            ..Default::default()
+        };
+        assert_eq!(superpacket_segments(40 + 1350 * 3, &hdr), 3);
+        // A short trailing segment still costs a segment.
+        assert_eq!(superpacket_segments(40 + 1350 * 3 + 7, &hdr), 4);
+        // A full 64KiB superpacket — the worst case the metric exists
+        // to expose.
+        assert_eq!(superpacket_segments(65535, &hdr), 49);
     }
 }

--- a/lightway-client/src/io/inside/tun.rs
+++ b/lightway-client/src/io/inside/tun.rs
@@ -8,11 +8,15 @@ use bytes::BytesMut;
 use pnet_packet::ipv4::Ipv4Packet;
 
 use lightway_app_utils::{Tun as AppUtilsTun, TunConfig};
+#[cfg(linux)]
+use lightway_core::VirtioNetHdr;
 use lightway_core::{
     IOCallbackResult, InsideIOSendCallback, InsideIOSendCallbackArg, InsideIpConfig,
     ipv4_update_destination, ipv4_update_source,
 };
 
+#[cfg(linux)]
+use crate::io::inside::InsideIORecvGso;
 use crate::{ConnectionState, io::inside::InsideIORecv};
 
 pub struct Tun {
@@ -82,10 +86,27 @@ impl<ExtAppState: Send + Sync> InsideIORecv<ExtAppState> for Tun {
         self.tun.vnet_headroom()
     }
 
+    #[cfg(linux)]
+    fn as_gso(self: Arc<Self>) -> Option<Arc<dyn InsideIORecvGso<ExtAppState>>> {
+        if self.tun.supports_gso() {
+            Some(self)
+        } else {
+            None
+        }
+    }
+
     fn into_io_send_callback(
         self: Arc<Self>,
     ) -> InsideIOSendCallbackArg<ConnectionState<ExtAppState>> {
         self
+    }
+}
+
+#[cfg(linux)]
+#[async_trait]
+impl<ExtAppState: Send + Sync> InsideIORecvGso<ExtAppState> for Tun {
+    async fn recv_gso(&self, buf: &mut BytesMut) -> IOCallbackResult<(usize, VirtioNetHdr)> {
+        self.tun.recv_gso(buf).await
     }
 }
 

--- a/lightway-client/src/io/outside.rs
+++ b/lightway-client/src/io/outside.rs
@@ -66,6 +66,16 @@ pub trait OutsideIO: Sync + Send {
         }
     }
 
+    /// Upgrade to the GRO-aware batched receive interface, when this
+    /// instance routes receives through it. Default: not supported.
+    /// Capability is per-instance but does not require the `UDP_GRO`
+    /// sockopt to have stuck — the batched loop degrades to plain
+    /// single-datagram slots when the kernel does not coalesce.
+    #[cfg(linux)]
+    fn as_gro(self: Arc<Self>) -> Option<Arc<dyn OutsideIORecvGro>> {
+        None
+    }
+
     fn into_io_send_callback(self: Arc<Self>) -> OutsideIOSendCallbackArg;
 
     fn peer_addr(&self) -> SocketAddr;
@@ -83,4 +93,40 @@ pub trait OutsideIO: Sync + Send {
     /// Returns the underlying socket tagged with its transport type.
     /// `None` when the transport has no single OS socket to name.
     fn socket(&self) -> Option<OutsideSocket>;
+}
+
+/// Outside IO backends that can receive GRO aggregates. Obtained from
+/// [`OutsideIO::as_gro`]; the GRO outside loop only accepts this type,
+/// so the capability check happens once at startup.
+///
+/// Implementers must also override [`OutsideIO::as_gro`] to return
+/// `Some(self)` — the default `None` hides the capability.
+#[cfg(linux)]
+pub trait OutsideIORecvGro: OutsideIO {
+    /// Fill up to `MAX_IO_BATCH_SIZE` datagrams in a single `recvmmsg`,
+    /// writing each datagram's GRO segment size into `gro_sizes[i]`
+    /// (`None` if the kernel did not coalesce that message). Returns the
+    /// datagram count (`>= 1` on `Ok`).
+    ///
+    /// Each datagram may itself be a GRO aggregate of many wire packets:
+    /// when `gro_sizes[i]` is `Some(gro_size)`, every wire packet in
+    /// `bufs[i]` is exactly `gro_size` bytes except a possibly-shorter
+    /// final one; `None` means `bufs[i]` holds a single wire packet.
+    ///
+    /// Read-side batching that cuts one `recvmsg` per datagram down to one
+    /// syscall per batch. It stacks with the kernel's socket-read
+    /// coalescing, driven by the `UDP_GRO` sockopt (valid peer checksums are
+    /// necessary but not sufficient). A zero-checksum peer is skipped by the
+    /// GRO engine, so every `gro_sizes[i]` is `None` and each slot holds one
+    /// wire packet — costing socket-read coalescing only; the independent
+    /// TUN-write coalescing is unaffected.
+    ///
+    /// Caller must ensure each buffer has spare capacity for a
+    /// maximum-size aggregate (64KiB) or the tail of the aggregate is
+    /// truncated.
+    fn recv_gro_batch(
+        &self,
+        bufs: &mut [bytes::BytesMut; MAX_IO_BATCH_SIZE],
+        gro_sizes: &mut [Option<u16>; MAX_IO_BATCH_SIZE],
+    ) -> IOCallbackResult<usize>;
 }

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -232,6 +232,42 @@ impl Udp {
             }
         }
     }
+
+    /// Map the result of the GSO `sendmsg` into an [`IOCallbackResult`],
+    /// swallowing the same transient errors the per-datagram `send` path
+    /// does so the TLS socket does not enter the error state. `len` is the
+    /// batch's total byte count, reported as "sent" for the swallowed
+    /// cases — the aggregate is treated as delivered and DTLS
+    /// retransmission covers it rather than live-locking the TLS record.
+    #[cfg(linux)]
+    fn map_send_result(res: std::io::Result<usize>, len: usize) -> IOCallbackResult<usize> {
+        match res {
+            Ok(nr) => IOCallbackResult::Ok(nr),
+            Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
+                IOCallbackResult::WouldBlock
+            }
+            // Server may not be listening yet; swallow so DTLS retransmits
+            // rather than live-locking the TLS record on repeated resends.
+            Err(err) if matches!(err.kind(), std::io::ErrorKind::ConnectionRefused) => {
+                IOCallbackResult::Ok(len)
+            }
+            // Transient around a network change.
+            Err(err) if matches!(err.kind(), std::io::ErrorKind::NetworkUnreachable) => {
+                IOCallbackResult::Ok(len)
+            }
+            // Send buffer momentarily full under load.
+            Err(err) if matches!(err.raw_os_error(), Some(libc::ENOBUFS)) => {
+                IOCallbackResult::Ok(len)
+            }
+            Err(err) if matches!(err.kind(), std::io::ErrorKind::PermissionDenied) => {
+                IOCallbackResult::Ok(len)
+            }
+            Err(err) => {
+                tracing::warn!("Outside IO GSO send failed: {err:?}");
+                IOCallbackResult::Err(err)
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -484,6 +520,39 @@ impl OutsideIOSendCallback for Udp {
         }
     }
 
+    /// Send concatenated wire packets in one `sendmsg` with a
+    /// `UDP_SEGMENT` control message; the kernel splits the payload
+    /// into `gso_size`-byte datagrams.
+    #[cfg(linux)]
+    fn send_gso(&self, bufs: &[std::io::IoSlice<'_>], gso_size: u16) -> IOCallbackResult<usize> {
+        use lightway_app_utils::cmsg;
+        use socket2::{MsgHdr, SockRef};
+        use tokio::io::Interest;
+
+        const CMSG_SIZE: usize = cmsg::Message::space::<u16>();
+
+        let total_len: usize = bufs.iter().map(|b| b.len()).sum();
+        let peer_addr = socket2::SockAddr::from(self.peer_addr);
+
+        let res = self.sock.try_io(Interest::WRITABLE, || {
+            let sock = SockRef::from(self.sock.as_ref());
+
+            let mut cmsg = cmsg::BufferMut::<CMSG_SIZE>::zeroed();
+            let mut builder = cmsg.builder();
+            builder.fill_next(libc::SOL_UDP, libc::UDP_SEGMENT, gso_size)?;
+
+            let msghdr = MsgHdr::new()
+                .with_addr(&peer_addr)
+                .with_buffers(bufs)
+                .with_control(cmsg.as_ref());
+
+            sock.sendmsg(&msghdr, 0)
+        });
+
+        Self::map_send_result(res, total_len)
+    }
+
+    #[cfg(not(linux))]
     fn send_gso(&self, _bufs: &[std::io::IoSlice<'_>], _gso_size: u16) -> IOCallbackResult<usize> {
         IOCallbackResult::Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
     }

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -50,6 +50,11 @@ pub struct Udp {
     batch_receive_enabled: bool,
     #[cfg(linux)]
     gro_enabled: bool,
+    /// Latched `true` (for the socket's lifetime) once a `UDP_SEGMENT`
+    /// send is rejected with a capability error; read via
+    /// [`OutsideIOSendCallback::gso_enabled`].
+    #[cfg(linux)]
+    gso_broken: std::sync::atomic::AtomicBool,
 }
 
 impl Udp {
@@ -109,6 +114,8 @@ impl Udp {
             batch_receive_enabled: false,
             #[cfg(linux)]
             gro_enabled: false,
+            #[cfg(linux)]
+            gso_broken: std::sync::atomic::AtomicBool::new(false),
         })
     }
 
@@ -296,6 +303,33 @@ impl Udp {
                 tracing::warn!("Outside IO GSO send failed: {err:?}");
                 IOCallbackResult::Err(err)
             }
+        }
+    }
+
+    /// Errno families where the egress path can't do UDP GSO at all, as
+    /// opposed to a transient condition. `EIO` is the kernel refusing a
+    /// `UDP_SEGMENT` send when the device lacks TX checksum offload (the
+    /// dominant cause); `EINVAL`/`EOPNOTSUPP` cover other outright
+    /// rejections. Transient errors (`ENOBUFS`, `ECONNREFUSED`, ...) and
+    /// the sizing error `EMSGSIZE` are handled elsewhere and must not latch.
+    #[cfg(linux)]
+    fn is_gso_unsupported(err: &std::io::Error) -> bool {
+        matches!(
+            err.raw_os_error(),
+            Some(libc::EIO) | Some(libc::EINVAL) | Some(libc::EOPNOTSUPP)
+        )
+    }
+
+    /// Latch the GSO-unsupported flag when a send error shows the device
+    /// cannot segment. Logs once, on the false→true transition only.
+    #[cfg(linux)]
+    fn note_gso_send_error(&self, err: &std::io::Error) {
+        if Self::is_gso_unsupported(err) && !self.gso_broken.swap(true, Ordering::Release) {
+            tracing::warn!(
+                "kernel rejected UDP_SEGMENT send ({err}); the egress device likely lacks \
+                 TX checksum offload. Disabling GSO on this socket and falling back to \
+                 per-datagram sends"
+            );
         }
     }
 }
@@ -597,6 +631,12 @@ impl OutsideIOSendCallback for Udp {
             sock.sendmsg(&msghdr, 0)
         });
 
+        // Latch off on a capability error so the connection drops to the
+        // per-segment fallback instead of failing here on every batch.
+        if let Err(ref err) = res {
+            self.note_gso_send_error(err);
+        }
+
         // Note `map_send_result` swallows several transient errors as
         // `Ok(len)` so TLS does not live-lock resending the same record.
         // That contract was written for a single datagram; applied here
@@ -607,6 +647,18 @@ impl OutsideIOSendCallback for Udp {
     #[cfg(not(linux))]
     fn send_gso(&self, _bufs: &[std::io::IoSlice<'_>], _gso_size: u16) -> IOCallbackResult<usize> {
         IOCallbackResult::Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+    }
+
+    fn gso_enabled(&self) -> bool {
+        #[cfg(linux)]
+        {
+            !self.gso_broken.load(Ordering::Acquire)
+        }
+        // Non-Linux has no `UDP_SEGMENT`; `send_gso` is unsupported.
+        #[cfg(not(linux))]
+        {
+            false
+        }
     }
 
     fn peer_addr(&self) -> SocketAddr {
@@ -626,6 +678,73 @@ impl OutsideIOSendCallback for Udp {
 fn local_addr_str(sock: &tokio::net::UdpSocket) -> String {
     sock.local_addr()
         .map_or_else(|e| e.to_string(), |a| a.to_string())
+}
+
+#[cfg(all(test, linux))]
+mod linux_tests {
+    use super::*;
+    use std::io::Error;
+
+    async fn make_udp() -> Udp {
+        // No server is needed: these tests exercise the latch bookkeeping,
+        // not an actual send. `peer_addr` just has to be a valid address.
+        let peer_addr: SocketAddr = "127.0.0.1:9".parse().unwrap();
+        // `new` takes an fwmark arg on non-mobile Linux only.
+        #[cfg(not(feature = "mobile"))]
+        let udp = Udp::new(peer_addr, None, 0).await.unwrap();
+        #[cfg(feature = "mobile")]
+        let udp = Udp::new(peer_addr, None).await.unwrap();
+        udp
+    }
+
+    #[test]
+    fn classifies_capability_errors() {
+        for errno in [libc::EIO, libc::EINVAL, libc::EOPNOTSUPP] {
+            assert!(
+                Udp::is_gso_unsupported(&Error::from_raw_os_error(errno)),
+                "errno {errno} should latch GSO off"
+            );
+        }
+    }
+
+    #[test]
+    fn ignores_transient_and_sizing_errors() {
+        for errno in [
+            libc::ENOBUFS,
+            libc::ECONNREFUSED,
+            libc::ENETUNREACH,
+            libc::EPERM,
+            libc::EAGAIN,
+            libc::EMSGSIZE,
+        ] {
+            assert!(
+                !Udp::is_gso_unsupported(&Error::from_raw_os_error(errno)),
+                "errno {errno} must not latch GSO off"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn latches_gso_off_on_capability_error() {
+        let udp = make_udp().await;
+        // Enabled by default.
+        assert!(OutsideIOSendCallback::gso_enabled(&udp));
+
+        // A capability error latches it off for good.
+        udp.note_gso_send_error(&Error::from_raw_os_error(libc::EIO));
+        assert!(!OutsideIOSendCallback::gso_enabled(&udp));
+
+        // Idempotent: staying off after a repeat.
+        udp.note_gso_send_error(&Error::from_raw_os_error(libc::EIO));
+        assert!(!OutsideIOSendCallback::gso_enabled(&udp));
+    }
+
+    #[tokio::test]
+    async fn transient_error_keeps_gso_enabled() {
+        let udp = make_udp().await;
+        udp.note_gso_send_error(&Error::from_raw_os_error(libc::ENOBUFS));
+        assert!(OutsideIOSendCallback::gso_enabled(&udp));
+    }
 }
 
 /// ICMP errors (port/host/net unreachable) are delivered asynchronously to a

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -1,3 +1,5 @@
+#[cfg(linux)]
+use super::OutsideIORecvGro;
 use super::{OutsideIO, OutsideSocket};
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
@@ -46,6 +48,8 @@ pub struct Udp {
     swallowed_sends: AtomicU64,
     #[cfg(batch_receive)]
     batch_receive_enabled: bool,
+    #[cfg(linux)]
+    gro_enabled: bool,
 }
 
 impl Udp {
@@ -103,6 +107,8 @@ impl Udp {
             swallowed_sends: AtomicU64::new(0),
             #[cfg(batch_receive)]
             batch_receive_enabled: false,
+            #[cfg(linux)]
+            gro_enabled: false,
         })
     }
 
@@ -190,6 +196,30 @@ impl Udp {
         let count = self.swallowed_sends.fetch_add(1, Ordering::Relaxed) + 1;
         if count.is_power_of_two() {
             tracing::debug!("Swallowing outside UDP send error ({count} consecutive): {err}");
+        }
+    }
+
+    /// Switch this socket to the GRO receive path and ask the kernel to
+    /// coalesce trains of equal-size datagrams into one buffer per
+    /// `recvmsg`. The receive path moves to
+    /// [`OutsideIORecvGro::recv_gro_batch`] unconditionally; the
+    /// `UDP_GRO` sockopt is best-effort, and on failure (kernel < 5.0)
+    /// this logs and continues, with that path degrading to one wire
+    /// packet per slot.
+    #[cfg(linux)]
+    pub fn enable_gro(&mut self) {
+        // Route receives through `recv_gro_batch` whenever offload is
+        // requested, not only when the sockopt succeeds: socket-read
+        // coalescing (the `UDP_GRO` sockopt) is what makes the kernel
+        // coalesce, but the path degrades to single-datagram slots when it
+        // does not (old kernel, or a zero-checksum peer the GRO engine
+        // skips), and the independent TUN-write coalescing still applies.
+        self.gro_enabled = true;
+        match lightway_app_utils::sockopt::socket_enable_udp_gro(self.sock.as_ref()) {
+            Ok(()) => tracing::info!("UDP GRO enabled on outside socket"),
+            Err(e) => tracing::warn!(
+                "UDP_GRO sockopt unavailable ({e}); using per-datagram receive with userspace TUN coalescing"
+            ),
         }
     }
 
@@ -338,6 +368,11 @@ impl OutsideIO for Udp {
         })
     }
 
+    #[cfg(linux)]
+    fn as_gro(self: Arc<Self>) -> Option<Arc<dyn OutsideIORecvGro>> {
+        if self.gro_enabled { Some(self) } else { None }
+    }
+
     fn into_io_send_callback(self: Arc<Self>) -> OutsideIOSendCallbackArg {
         self
     }
@@ -388,6 +423,19 @@ impl OutsideIO for Udp {
         #[cfg(windows)]
         let handle = self.sock.as_raw_socket();
         Some(OutsideSocket::Udp(handle))
+    }
+}
+
+#[cfg(linux)]
+impl OutsideIORecvGro for Udp {
+    fn recv_gro_batch(
+        &self,
+        bufs: &mut [bytes::BytesMut; lightway_core::MAX_IO_BATCH_SIZE],
+        gro_sizes: &mut [Option<u16>; lightway_core::MAX_IO_BATCH_SIZE],
+    ) -> IOCallbackResult<usize> {
+        use std::os::fd::AsRawFd;
+        let fd = self.sock.as_raw_fd();
+        self.try_readable_io(|| batch_receive::recv_multiple_gro(fd, bufs, gro_sizes))
     }
 }
 
@@ -549,6 +597,10 @@ impl OutsideIOSendCallback for Udp {
             sock.sendmsg(&msghdr, 0)
         });
 
+        // Note `map_send_result` swallows several transient errors as
+        // `Ok(len)` so TLS does not live-lock resending the same record.
+        // That contract was written for a single datagram; applied here
+        // it reports an entire discarded batch as fully sent.
         Self::map_send_result(res, total_len)
     }
 

--- a/lightway-client/src/io/outside/udp/batch_receive.rs
+++ b/lightway-client/src/io/outside/udp/batch_receive.rs
@@ -30,6 +30,19 @@ pub(crate) fn recv_multiple(
     PlatformBatchRecv::recv_multiple(fd, recv_bufs, max_batch_size)
 }
 
+/// Batched GRO receive (Linux): one `recvmmsg` fills up to
+/// [`MAX_IO_BATCH_SIZE`] datagrams, and for each we parse the
+/// per-message `UDP_GRO` control message so a datagram the kernel
+/// coalesced is reported with its segment size in `gro_sizes[i]`
+/// (`None` when the kernel did not coalesce that message — e.g. an old
+/// kernel or a server that sends zero-checksum UDP). Returns the
+/// datagram count.
+///
+/// This replaces one `recvmsg` per datagram on the download path with
+/// one syscall per batch, independent of whether the kernel coalesces.
+#[cfg(linux)]
+pub(crate) use linux::recv_multiple_gro;
+
 #[cfg(apple)]
 mod apple {
     use bytes::BytesMut;
@@ -117,6 +130,103 @@ mod linux {
     use bytes::BytesMut;
     use lightway_core::MAX_IO_BATCH_SIZE;
     use std::{io, mem};
+
+    /// Control buffer space for one `UDP_GRO` cmsg.
+    #[cfg(linux)]
+    const CTRL_LEN: usize = lightway_app_utils::cmsg::Message::space::<libc::c_int>();
+
+    /// Per-message control buffer for one `UDP_GRO` cmsg, aligned for
+    /// `cmsghdr` as the `CMSG_*` macros require. Stack-allocated and
+    /// reused per call — no heap traffic on the receive hot path.
+    #[cfg(linux)]
+    #[repr(C, align(16))]
+    struct GroControl([u8; CTRL_LEN]);
+
+    /// One `recvmmsg` with per-message `UDP_GRO` control parsing,
+    /// always over the full [`MAX_IO_BATCH_SIZE`] slots (the array
+    /// types fix the bound).
+    #[cfg(linux)]
+    #[allow(unsafe_code)]
+    pub(crate) fn recv_multiple_gro(
+        fd: libc::c_int,
+        recv_bufs: &mut [BytesMut; MAX_IO_BATCH_SIZE],
+        gro_sizes: &mut [Option<u16>; MAX_IO_BATCH_SIZE],
+    ) -> io::Result<usize> {
+        use lightway_app_utils::cmsg;
+
+        let msg_count = MAX_IO_BATCH_SIZE;
+
+        // SAFETY: a zeroed iovec is valid (null pointer + zero length).
+        let mut iovecs = unsafe { mem::zeroed::<[libc::iovec; MAX_IO_BATCH_SIZE]>() };
+        // SAFETY: a zeroed mmsghdr is valid (null pointers + zero lengths).
+        let mut hdrs = unsafe { mem::zeroed::<[libc::mmsghdr; MAX_IO_BATCH_SIZE]>() };
+        // Aligned, zeroed control area per message (see `GroControl`).
+        let mut ctrls: [GroControl; MAX_IO_BATCH_SIZE] =
+            std::array::from_fn(|_| GroControl([0u8; CTRL_LEN]));
+
+        for i in 0..msg_count {
+            // Advertise only the buffer's spare capacity so the kernel
+            // can never write past the allocation; oversized datagrams
+            // are truncated, matching the non-batch recv path.
+            let spare = recv_bufs[i].spare_capacity_mut();
+            iovecs[i].iov_base = spare.as_mut_ptr() as *mut libc::c_void;
+            iovecs[i].iov_len = spare.len();
+            hdrs[i].msg_hdr.msg_iov = &mut iovecs[i];
+            hdrs[i].msg_hdr.msg_iovlen = 1;
+            hdrs[i].msg_hdr.msg_control = ctrls[i].0.as_mut_ptr() as *mut libc::c_void;
+            hdrs[i].msg_hdr.msg_controllen = CTRL_LEN as _;
+        }
+
+        // SAFETY: hdrs/iovecs/ctrls are valid for msg_count entries and
+        // outlive the call; fd is a valid borrowed socket.
+        let n = unsafe {
+            libc::recvmmsg(
+                fd,
+                hdrs.as_mut_ptr(),
+                msg_count as _,
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let count = (n as usize).min(msg_count);
+        let mut truncated = 0usize;
+        for i in 0..count {
+            let len = hdrs[i].msg_len as usize;
+            let recv_buf = &mut recv_bufs[i];
+            let new_len = recv_buf.len() + len;
+            // SAFETY: the kernel wrote `len` bytes into the spare
+            // capacity advertised via the iovec, bounded by it, so
+            // `new_len <= capacity()`.
+            unsafe {
+                recv_buf.set_len(new_len);
+            }
+
+            // Parse the per-message control area for a UDP_GRO segment
+            // size. `msg_controllen` is what the kernel actually wrote.
+            let controllen = hdrs[i].msg_hdr.msg_controllen as usize;
+            gro_sizes[i] = if controllen == 0 {
+                None
+            } else {
+                cmsg::first_udp_gro_segment(&ctrls[i].0[..controllen])
+            };
+
+            if hdrs[i].msg_hdr.msg_flags & libc::MSG_TRUNC != 0 {
+                truncated += 1;
+            }
+        }
+        if truncated > 0 {
+            tracing::warn!(
+                "{truncated} datagram(s) truncated to receive buffer capacity; \
+                 the configured outside_mtu may be too small"
+            );
+        }
+
+        Ok(count)
+    }
 
     pub(crate) struct Recvmmsg;
 

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -685,6 +685,120 @@ pub async fn outside_io_task<ExtAppState: Send + Sync>(
     }
 }
 
+/// Split a GRO aggregate into per-datagram buffers on `gro_size`
+/// boundaries; the final segment may be shorter. The split-off views
+/// share the aggregate's backing slab — no copies.
+#[cfg(linux)]
+fn split_gro_segments(buf: &mut BytesMut, gro_size: usize, segments: &mut Vec<BytesMut>) {
+    debug_assert!(gro_size > 0);
+    while !buf.is_empty() {
+        let take = buf.len().min(gro_size);
+        segments.push(buf.split_to(take));
+    }
+}
+
+/// Outside traffic handler when TUN offload is enabled on a UDP
+/// connection. Two independent receive optimizations run here:
+///
+/// - **Socket read coalescing** (kernel `UDP_GRO`): the socket sets the
+///   `UDP_GRO` sockopt, so the kernel returns an equal-size datagram train
+///   as one buffer with the segment size in a control message; we split on
+///   it. The sockopt does the work — valid peer checksums are necessary but
+///   not sufficient. Without coalescing (old kernel, or zero-checksum peer)
+///   each slot just holds one datagram.
+///
+/// - **TUN write coalescing** (userspace `TcpGroTable`): in-order TCP
+///   segments are merged into TSO superpackets and written once. This needs
+///   only several same-flow segments in one window, not socket-level
+///   coalescing, so we hold the window open across a bounded drain of the
+///   ready datagrams and flush when the socket empties or the cap is hit.
+#[cfg(linux)]
+pub async fn outside_io_task_gro<ExtAppState: Send + Sync>(
+    conn: Arc<Mutex<Connection<ConnectionState<ExtAppState>>>>,
+    connection_type: ConnectionType,
+    outside_io: Arc<dyn io::outside::OutsideIORecvGro>,
+    inside_io: Arc<dyn io::inside::InsideIO<ExtAppState>>,
+    keepalive: Keepalive,
+    mut ready_signal: Option<oneshot::Sender<()>>,
+) -> Result<()> {
+    // A GRO aggregate can be up to the maximum IP datagram size.
+    const RECV_CAP: usize = lightway_core::gro::MAX_IPV4_PACKET_LEN;
+    const BATCH: usize = lightway_core::MAX_IO_BATCH_SIZE;
+
+    let mut bufs: [BytesMut; BATCH] = std::array::from_fn(|_| BytesMut::with_capacity(RECV_CAP));
+    let mut gro_sizes: [Option<u16>; BATCH] = [None; BATCH];
+    let mut segments: Vec<BytesMut> = Vec::new();
+    loop {
+        // Unrecoverable errors: https://github.com/tokio-rs/tokio/discussions/5552
+        outside_io.poll(tokio::io::Interest::READABLE).await?;
+
+        // Send ready signal after first successful poll
+        if let Some(tx) = ready_signal.take() {
+            let _ = tx.send(());
+        }
+
+        // One syscall pulls up to BATCH datagrams. Each may itself be a
+        // kernel-coalesced aggregate (gro_sizes[i] set) or a single
+        // datagram (None) — both feed the userspace TUN coalescer.
+        let count = match outside_io.recv_gro_batch(&mut bufs, &mut gro_sizes) {
+            IOCallbackResult::Ok(n) => n,
+            IOCallbackResult::WouldBlock => continue,
+            IOCallbackResult::Err(err) => return Err(err.into()),
+        };
+
+        // Open one TUN GRO window across the whole batch and flush it
+        // before releasing the conn lock. `gro_open` is idempotent; the
+        // flush must run even on error, so capture the result and propagate
+        // it after the lock is dropped.
+        inside_io.gro_open();
+        let result = {
+            let mut conn = conn.lock().unwrap();
+            let mut acc = Ok(());
+            for i in 0..count {
+                if bufs[i].is_empty() {
+                    continue;
+                }
+                // A datagram the kernel did not coalesce splits into
+                // exactly one segment (whole-buffer boundary).
+                let seg_size = match gro_sizes[i] {
+                    Some(gro_size) if gro_size > 0 => gro_size as usize,
+                    _ => bufs[i].len(),
+                };
+                segments.clear();
+                split_gro_segments(&mut bufs[i], seg_size, &mut segments);
+                let pkts = segments
+                    .iter_mut()
+                    .map(|b| OutsidePacket::Wire(b, connection_type));
+                let r =
+                    conn.multiple_outside_data_received(pkts, |err| err.is_fatal(connection_type));
+                if let Err(e) = r {
+                    acc = Err(e);
+                    break;
+                }
+            }
+            // Flush while the conn lock is still held. `send()` only runs
+            // under this mutex, so closing the window here leaves no gap for
+            // another task to coalesce past the drain and strand a packet
+            // until the next receive. `write_super` only does non-blocking
+            // `try_send`s, so holding the lock a moment longer costs
+            // nothing.
+            inside_io.gro_flush();
+            acc
+        };
+        result?;
+
+        // Reset the buffers consumed this round. Drop the split-off
+        // views first so the last buffer's slab can be reused.
+        segments.clear();
+        for b in &mut bufs[..count] {
+            b.clear();
+            b.reserve(RECV_CAP);
+        }
+
+        keepalive.outside_activity().await
+    }
+}
+
 const DEFAULT_TRACER_TRIGGER_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Tracks the tracer trigger for the inside IO loops: fires
@@ -1263,6 +1377,15 @@ pub async fn connect<
                     sock.enable_batch_receive();
                 }
 
+                // GRO delivery replaces per-packet receive entirely
+                // (a plain recv would merge separate datagrams), so
+                // only flip the sockopt when the GRO outside loop
+                // below will consume it.
+                #[cfg(linux)]
+                if config.enable_tun_offload {
+                    sock.enable_gro();
+                }
+
                 sock.set_send_buffer_size(config.sndbuf.as_u64().try_into()?)?;
                 sock.set_recv_buffer_size(config.rcvbuf.as_u64().try_into()?)?;
 
@@ -1414,6 +1537,29 @@ pub async fn connect<
     let mut ticker_task = ticker_task.spawn(Arc::downgrade(&conn));
     pmtud_timer_task.spawn(Arc::downgrade(&conn), &mut join_set);
 
+    // GRO capability is present only when `enable_tun_offload` flipped
+    // the sockopt on a UDP socket above; TCP mode and non-Linux targets
+    // fall back to the per-packet loop.
+    #[cfg(linux)]
+    let mut outside_io_loop: JoinHandle<anyhow::Result<()>> = match outside_io.clone().as_gro() {
+        Some(gro_io) => tokio::spawn(outside_io_task_gro(
+            conn.clone(),
+            connection_type,
+            gro_io,
+            inside_io.clone(),
+            keepalive.clone(),
+            None,
+        )),
+        None => tokio::spawn(outside_io_task(
+            conn.clone(),
+            config.outside_mtu,
+            connection_type,
+            outside_io.clone(),
+            keepalive.clone(),
+            None,
+        )),
+    };
+    #[cfg(not(linux))]
     let mut outside_io_loop: JoinHandle<anyhow::Result<()>> = tokio::spawn(outside_io_task(
         conn.clone(),
         config.outside_mtu,
@@ -2384,6 +2530,26 @@ mod tests {
             result.unwrap_err().to_string(),
             "All connections disconnected"
         );
+    }
+
+    /// GRO aggregates split on `gro_size` boundaries: full segments
+    /// plus a shorter trailing one; an exact multiple has no short
+    /// tail; content is preserved byte-for-byte across the views.
+    #[test_case(3300, 1350 => vec![1350, 1350, 600] ; "short trailing segment")]
+    #[test_case(2700, 1350 => vec![1350, 1350]      ; "exact multiple")]
+    #[test_case(600,  1350 => vec![600]             ; "single short packet")]
+    #[cfg(linux)]
+    fn gro_split_segment_sizes(total: usize, gro_size: usize) -> Vec<usize> {
+        let payload: Vec<u8> = (0..total).map(|i| (i % 251) as u8).collect();
+        let mut buf = BytesMut::from(&payload[..]);
+        let mut segments = Vec::new();
+
+        split_gro_segments(&mut buf, gro_size, &mut segments);
+
+        assert!(buf.is_empty());
+        let rejoined: Vec<u8> = segments.iter().flat_map(|s| s.iter().copied()).collect();
+        assert_eq!(rejoined, payload, "content preserved");
+        segments.iter().map(|s| s.len()).collect()
     }
 
     #[test_case(Some(true),  Some(true)  => None       ; "unchanged")]

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -18,6 +18,8 @@ use anyhow::{Context, Result, anyhow};
 use bytes::BytesMut;
 use bytesize::ByteSize;
 use futures::{FutureExt, stream::FuturesUnordered};
+#[cfg(linux)]
+pub use io::inside::InsideIORecvGso;
 pub use io::inside::{InsideIO, InsideIORecv};
 use io::outside::OutsideIO;
 use keepalive::Keepalive;
@@ -247,6 +249,11 @@ pub struct ClientConfig<ExtAppState: Send + Sync> {
     /// Base MTU for PMTU discovery
     pub pmtud_base_mtu: Option<u16>,
 
+    /// Enable offload for batch packet processing: GSO on the TUN
+    /// read + UDP send path, GRO on the UDP receive path.
+    /// Only effective on Linux; ignored elsewhere.
+    pub enable_tun_offload: bool,
+
     /// Enable IO-uring interface for Tunnel
     #[cfg(feature = "io-uring")]
     pub enable_tun_iouring: bool,
@@ -366,6 +373,7 @@ impl<ExtAppState: Send + Sync> ClientConfig<ExtAppState> {
             dns_config_mode: config.dns_config_mode,
             enable_pmtud: config.enable_pmtud,
             pmtud_base_mtu: config.pmtud_base_mtu,
+            enable_tun_offload: config.enable_tun_offload,
             #[cfg(feature = "io-uring")]
             enable_tun_iouring: config.enable_tun_iouring,
             #[cfg(feature = "io-uring")]
@@ -815,6 +823,69 @@ pub async fn inside_io_task<ExtAppState: Send + Sync>(
                     }
                 }
                 Ok(())
+            },
+        )?
+        else {
+            continue;
+        };
+
+        tracer.tick(&keepalive, last_outside_data_received).await;
+    }
+}
+
+/// Inside traffic handler when TUN offload (GSO) is enabled. Mirrors
+/// [`inside_io_task`], but reads GSO superpackets and forwards each via
+/// `Connection::inside_data_received_gso` (segment, encrypt per segment,
+/// ship as one `sendmsg(UDP_SEGMENT)`).
+#[cfg(linux)]
+pub async fn inside_io_task_gso<ExtAppState: Send + Sync>(
+    conn: Arc<Mutex<Connection<ConnectionState<ExtAppState>>>>,
+    inside_io: Arc<dyn io::inside::InsideIORecvGso<ExtAppState>>,
+    tun_dns_ip: Ipv4Addr,
+    keepalive: Keepalive,
+    keepalive_config: KeepaliveConfig,
+) -> Result<()> {
+    use lightway_core::gso::{VIRTIO_NET_HDR_F_NEEDS_CSUM, VIRTIO_NET_HDR_LEN, gso_none_checksum};
+
+    let mut tracer = TracerTrigger::new(&keepalive_config);
+
+    // Reused across iterations. `recv_gso` writes into the spare capacity
+    // (no zero-init) and returns `buf` holding the stripped IP superpacket;
+    // `clear()` + `reserve()` compacts the window to the slab start (len 0,
+    // no memcpy).
+    let initial_cap = VIRTIO_NET_HDR_LEN + lightway_core::gro::MAX_IPV4_PACKET_LEN;
+    let mut buf = BytesMut::with_capacity(initial_cap);
+    loop {
+        buf.clear();
+        buf.reserve(initial_cap);
+        let (_, hdr) = match inside_io.recv_gso(&mut buf).await {
+            IOCallbackResult::Ok(pair) => pair,
+            IOCallbackResult::WouldBlock => continue, // Spuriously failed to read, keep waiting
+            IOCallbackResult::Err(err) => {
+                // Fatal error
+                return Err(err.into());
+            }
+        };
+
+        // With checksum offload the kernel hands us the pseudo-header
+        // partial sum; finish it before the pipeline. Non-GSO only:
+        // build_segment recomputes each segment's checksum, so folding an
+        // aggregate here would be discarded work.
+        if hdr.is_gso_none() && hdr.flags & VIRTIO_NET_HDR_F_NEEDS_CSUM != 0 {
+            gso_none_checksum(buf.as_mut(), hdr.csum_start, hdr.csum_offset);
+        }
+
+        let Some(last_outside_data_received) = process_inside_packet(
+            &conn,
+            inside_io.as_ref(),
+            tun_dns_ip,
+            &mut buf,
+            |conn, buf| {
+                if hdr.is_gso_none() {
+                    conn.inside_data_received(buf)
+                } else {
+                    conn.inside_data_received_gso(buf, &hdr)
+                }
             },
         )?
         else {
@@ -1352,6 +1423,29 @@ pub async fn connect<
         None,
     ));
 
+    #[cfg(linux)]
+    let mut inside_io_loop: JoinHandle<anyhow::Result<()>> = if config.enable_tun_offload {
+        let gso_io = inside_io.clone().as_gso().context(
+            "enable_tun_offload is set but the inside IO backend does not support GSO offload",
+        )?;
+        tokio::spawn(inside_io_task_gso(
+            conn.clone(),
+            gso_io,
+            config.tun_dns_ip,
+            keepalive.clone(),
+            keepalive_config,
+        ))
+    } else {
+        tokio::spawn(inside_io_task(
+            conn.clone(),
+            inside_io.clone(),
+            config.tun_dns_ip,
+            keepalive.clone(),
+            keepalive_config,
+            config.inside_pkt_codec_stall_timeout,
+        ))
+    };
+    #[cfg(not(linux))]
     let mut inside_io_loop: JoinHandle<anyhow::Result<()>> = tokio::spawn(inside_io_task(
         conn.clone(),
         inside_io.clone(),
@@ -1600,10 +1694,36 @@ fn validate_client_config<
         return Err(anyhow!("At least one server should be specified"));
     }
 
+    // The io-uring inside backend cannot supply a GSO device
+    // (`supports_gso()` is always false), so `as_gso()` would return `None`
+    // and `connect()` would hard-fail. Reject the combination up front.
+    #[cfg(all(linux, feature = "io-uring"))]
+    if config.enable_tun_offload && config.enable_tun_iouring {
+        return Err(anyhow!(
+            "enable_tun_offload and enable_tun_iouring cannot be enabled together: \
+             the io-uring inside IO backend does not support GSO offload"
+        ));
+    }
+
     for server_config in servers {
         if server_config.inside_pkt_codec.is_some() && config.inside_pkt_codec_config.is_none() {
             return Err(anyhow!(
                 "Inside packet codec config has to be provided if inside packet codec is used (Server: {})",
+                server_config.server
+            ));
+        }
+
+        // Offload and the inside packet codec are mutually exclusive: the
+        // encoder takes the packet before segmentation
+        // (`CodecStatus::PacketAccepted` returns early, `build_segment`
+        // never runs), so the codec would ship a ~64KB superpacket whose IP
+        // `total_length` lies to the peer, and `ipv4_is_valid_packet` only
+        // checks the version nibble. Reject rather than corrupt traffic.
+        #[cfg(linux)]
+        if config.enable_tun_offload && server_config.inside_pkt_codec.is_some() {
+            return Err(anyhow!(
+                "enable_tun_offload and the inside packet codec cannot be enabled together: \
+                 the codec consumes the packet before GSO segmentation runs (Server: {})",
                 server_config.server
             ));
         }
@@ -1634,6 +1754,11 @@ pub async fn client<
     );
 
     validate_client_config(&config, &conn_confs)?;
+
+    #[cfg(linux)]
+    if config.enable_tun_offload {
+        config.tun_config.offload = true;
+    }
 
     let inside_io = match &config.inside_io {
         Some(io) => Arc::clone(io),
@@ -1851,6 +1976,94 @@ mod tests {
     use super::*;
 
     use test_case::test_case;
+
+    struct TestEventHandler;
+
+    impl EventCallback for TestEventHandler {
+        fn event(&mut self, _event: Event) {}
+    }
+
+    struct TestPacketCodecFactory;
+
+    impl lightway_app_utils::PacketCodecFactory for TestPacketCodecFactory {
+        fn build(&self) -> lightway_app_utils::PacketCodec {
+            unimplemented!("config validation never builds the codec")
+        }
+
+        fn get_codec_name(&self) -> String {
+            "test".to_string()
+        }
+    }
+
+    fn test_client_config() -> ClientConfig<()> {
+        ClientConfig::try_from_reload_sig_and_config(None, config::Config::default())
+            .expect("default config should be valid")
+    }
+
+    fn test_codec_config() -> ClientInsidePacketCodecConfig {
+        let (_tx, encoding_request_signal) = mpsc::channel(1);
+        ClientInsidePacketCodecConfig {
+            enable_inside_pkt_encoding: false,
+            encoding_request_signal,
+        }
+    }
+
+    fn test_conn_config(
+        inside_pkt_codec: Option<PacketCodecFactoryType>,
+    ) -> ClientConnectionConfig<TestEventHandler> {
+        ClientConnectionConfig {
+            mode: ClientConnectionMode::Datagram(None),
+            cipher: Cipher::Aes256,
+            server_dn: None,
+            server: "127.0.0.1:27690".parse().unwrap(),
+            auth: AuthMethod::UserPass {
+                user: "user".to_string(),
+                password: "password".to_string(),
+            },
+            cert_content: String::new(),
+            inside_plugins: Default::default(),
+            outside_plugins: Default::default(),
+            inside_pkt_codec,
+            event_handler: None,
+        }
+    }
+
+    #[test]
+    fn validate_default_client_config() {
+        let config = test_client_config();
+        assert!(validate_client_config(&config, &[test_conn_config(None)]).is_ok());
+    }
+
+    #[test]
+    fn validate_inside_pkt_codec_without_tun_offload() {
+        let mut config = test_client_config();
+        config.inside_pkt_codec_config = Some(test_codec_config());
+
+        let servers = [test_conn_config(Some(Box::new(TestPacketCodecFactory)))];
+        assert!(validate_client_config(&config, &servers).is_ok());
+    }
+
+    #[cfg(linux)]
+    #[test]
+    fn validate_tun_offload_with_inside_pkt_codec() {
+        let mut config = test_client_config();
+        config.enable_tun_offload = true;
+        config.inside_pkt_codec_config = Some(test_codec_config());
+
+        let servers = [test_conn_config(Some(Box::new(TestPacketCodecFactory)))];
+        let err = validate_client_config(&config, &servers)
+            .expect_err("offload + inside packet codec must be rejected");
+        assert!(err.to_string().contains("enable_tun_offload"), "{err}");
+    }
+
+    #[cfg(linux)]
+    #[test]
+    fn validate_tun_offload_without_inside_pkt_codec() {
+        let mut config = test_client_config();
+        config.enable_tun_offload = true;
+
+        assert!(validate_client_config(&config, &[test_conn_config(None)]).is_ok());
+    }
 
     #[test_case(1, vec![], false => None)]
     #[test_case(1, vec![0], true => Some(0))]

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -1319,16 +1319,23 @@ impl<AppState: Send> Connection<AppState> {
         // we only need capacity here — no zero-init.
         let mut segment = BytesMut::with_capacity(mtu);
 
-        // Can this aggregate travel as one `UDP_SEGMENT` batch? If not,
-        // fall back to one datagram per segment rather than dropping it.
-        let batched = gso_fits_one_batch(gso_segs);
+        // Can this aggregate travel as one `UDP_SEGMENT` batch? If not
+        // (too many segments, or the socket latched GSO off after the
+        // egress path rejected it), send one datagram per segment rather
+        // than dropping it.
+        let batched = gso_fits_one_batch(gso_segs) && self.session.io_cb().io.gso_enabled();
         if !batched {
             crate::metrics::gso_batch_skipped();
-            tracing::warn!(
-                gso_segs,
-                MAX_GSO_SEGS = gso::MAX_GSO_SEGS,
-                "GSO batching skipped, sending segments individually"
-            );
+            // Warn only for an oversized aggregate. The other reason — the
+            // socket latched GSO off — already warns once when it
+            // disengages, so don't repeat it here on every aggregate.
+            if !gso_fits_one_batch(gso_segs) {
+                tracing::warn!(
+                    gso_segs,
+                    MAX_GSO_SEGS = gso::MAX_GSO_SEGS,
+                    "GSO batching skipped, sending segments individually"
+                );
+            }
         }
 
         // Open the GSO coalescing buffer — IO callback will coalesce

--- a/lightway-core/src/connection/io_adapter.rs
+++ b/lightway-core/src/connection/io_adapter.rs
@@ -112,22 +112,21 @@ fn send_gso_chunked(
     iovs: &[std::io::IoSlice<'_>],
     entries_per_seg: usize,
     stride: u16,
-) -> IOCallbackResult<usize> {
+) -> IOCallbackResult<()> {
     let segs_per_send = (crate::gso::MAX_GSO_SEND_BYTES / stride.max(1) as usize)
         .clamp(1, crate::gso::MAX_GSO_SEGS);
     let entries_per_send = segs_per_send * entries_per_seg;
 
     // Note a failure at chunk index > 0 means the earlier chunks already
     // reached the wire and the remainder never will.
-    let mut sent = 0;
     for chunk in iovs.chunks(entries_per_send) {
         match io.send_gso(chunk, stride) {
-            IOCallbackResult::Ok(n) => sent += n,
+            IOCallbackResult::Ok(_) => continue,
             IOCallbackResult::WouldBlock => return IOCallbackResult::WouldBlock,
             IOCallbackResult::Err(e) => return IOCallbackResult::Err(e),
         }
     }
-    IOCallbackResult::Ok(sent)
+    IOCallbackResult::Ok(())
 }
 
 pub(crate) struct SendBuffer {
@@ -368,19 +367,19 @@ impl TlsIOAdapter {
         &mut self,
         gso_segs: usize,
         expresslane_data: bool,
-    ) -> IOCallbackResult<usize> {
+    ) -> IOCallbackResult<()> {
         use std::io::{Error, IoSlice};
 
         // No coalesced frame yet — caller's `gso.reset()` cleanup
         // path runs unconditionally, so this is also the safe exit
         // when nothing was buffered.
         let Some((tun_buf, tun_gso_size)) = self.gso_buf.frame() else {
-            return IOCallbackResult::Ok(0);
+            return IOCallbackResult::Ok(());
         };
         let tun_gso_size = tun_gso_size.get();
 
         if gso_segs == 0 {
-            return IOCallbackResult::Ok(0);
+            return IOCallbackResult::Ok(());
         }
 
         // Same Lightway header for every segment.
@@ -455,7 +454,7 @@ impl TlsIOAdapter {
         // All segments dropped by plugins — nothing to put on the wire,
         // but report success for the inside bytes the caller handed us.
         if segs.is_empty() {
-            return IOCallbackResult::Ok(tun_buf.len());
+            return IOCallbackResult::Ok(());
         }
 
         let stride = wire_gso_size.unwrap_or(0) as u16;
@@ -999,7 +998,7 @@ mod tests {
         let arg: OutsideIOSendCallbackArg = io.clone();
 
         let r = send_gso_chunked(&arg, &iovs, 1, 1350);
-        assert!(matches!(r, IOCallbackResult::Ok(_)));
+        assert!(matches!(r, IOCallbackResult::Ok(())));
         assert_eq!(io.calls(), vec![(10 * 1350, 1350)]);
     }
 
@@ -1019,7 +1018,7 @@ mod tests {
         let arg: OutsideIOSendCallbackArg = io.clone();
 
         let r = send_gso_chunked(&arg, &iovs, 1, STRIDE as u16);
-        assert!(matches!(r, IOCallbackResult::Ok(_)));
+        assert!(matches!(r, IOCallbackResult::Ok(())));
 
         let calls = io.calls();
         let segs_per_send = crate::gso::MAX_GSO_SEND_BYTES / STRIDE; // 48
@@ -1057,7 +1056,7 @@ mod tests {
         let arg: OutsideIOSendCallbackArg = io.clone();
 
         let r = send_gso_chunked(&arg, &iovs, 2, STRIDE as u16);
-        assert!(matches!(r, IOCallbackResult::Ok(_)));
+        assert!(matches!(r, IOCallbackResult::Ok(())));
 
         // Every chunk's byte count is a whole multiple of the stride
         // (all segments here are full-sized), within the send limit.
@@ -1111,7 +1110,7 @@ mod tests {
         let arg: OutsideIOSendCallbackArg = io.clone();
 
         let r = send_gso_chunked(&arg, &iovs, 1, stride as u16);
-        assert!(matches!(r, IOCallbackResult::Ok(_)));
+        assert!(matches!(r, IOCallbackResult::Ok(())));
 
         let calls = io.calls();
         let mut total = 0usize;
@@ -1141,7 +1140,7 @@ mod tests {
         let arg: OutsideIOSendCallbackArg = io.clone();
 
         let r = send_gso_chunked(&arg, &iovs, 1, u16::MAX);
-        assert!(matches!(r, IOCallbackResult::Ok(_)));
+        assert!(matches!(r, IOCallbackResult::Ok(())));
         assert_eq!(io.calls().len(), 3, "one segment per call");
     }
 

--- a/lightway-core/src/connection/io_adapter.rs
+++ b/lightway-core/src/connection/io_adapter.rs
@@ -98,6 +98,38 @@ impl GsoBuffer {
     }
 }
 
+/// Flush GSO wire segments, splitting into multiple `sendmsg(UDP_SEGMENT)`
+/// calls when the batch exceeds either kernel per-send limit: payload bytes
+/// ([`crate::gso::MAX_GSO_SEND_BYTES`], else `EMSGSIZE`) or segment count
+/// ([`crate::gso::MAX_GSO_SEGS`], else `EINVAL` from `udp_send_skb()`). The
+/// byte budget alone does not bound segments — stride 256 packs 255. Chunks
+/// split on segment boundaries so `UDP_SEGMENT`'s uniform stride holds per
+/// call. A mid-batch failure is surfaced for the caller's log and the
+/// remainder dropped; the peer's transport recovers the loss.
+#[cfg(target_os = "linux")]
+fn send_gso_chunked(
+    io: &OutsideIOSendCallbackArg,
+    iovs: &[std::io::IoSlice<'_>],
+    entries_per_seg: usize,
+    stride: u16,
+) -> IOCallbackResult<usize> {
+    let segs_per_send = (crate::gso::MAX_GSO_SEND_BYTES / stride.max(1) as usize)
+        .clamp(1, crate::gso::MAX_GSO_SEGS);
+    let entries_per_send = segs_per_send * entries_per_seg;
+
+    // Note a failure at chunk index > 0 means the earlier chunks already
+    // reached the wire and the remainder never will.
+    let mut sent = 0;
+    for chunk in iovs.chunks(entries_per_send) {
+        match io.send_gso(chunk, stride) {
+            IOCallbackResult::Ok(n) => sent += n,
+            IOCallbackResult::WouldBlock => return IOCallbackResult::WouldBlock,
+            IOCallbackResult::Err(e) => return IOCallbackResult::Err(e),
+        }
+    }
+    IOCallbackResult::Ok(sent)
+}
+
 pub(crate) struct SendBuffer {
     data: BytesMut,
     total_capacity: usize,
@@ -373,7 +405,7 @@ impl TlsIOAdapter {
                 iovs.push(IoSlice::new(&hdr_buf[..]));
                 iovs.push(IoSlice::new(&tun_buf[start..end]));
             }
-            return self.io.send_gso(&iovs, stride);
+            return send_gso_chunked(&self.io, &iovs, 2, stride);
         }
 
         // Plugin path: each segment is built into its own BytesMut so
@@ -428,7 +460,7 @@ impl TlsIOAdapter {
 
         let stride = wire_gso_size.unwrap_or(0) as u16;
         let iovs: Vec<IoSlice<'_>> = segs.iter().map(|s| IoSlice::new(&s[..])).collect();
-        self.io.send_gso(&iovs, stride)
+        send_gso_chunked(&self.io, &iovs, 1, stride)
     }
 
     // In general, TCP send can succeed even for partial data and the caller
@@ -587,6 +619,54 @@ mod tests {
             _gso_size: u16,
         ) -> IOCallbackResult<usize> {
             IOCallbackResult::Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+        }
+
+        fn peer_addr(&self) -> std::net::SocketAddr {
+            std::unreachable!("Should not be testing peer_addr");
+        }
+    }
+
+    /// Scripted results and the recorded `(total_bytes, gso_size)` of
+    /// every `send_gso` call.
+    #[cfg(target_os = "linux")]
+    type FakeGsoState = (VecDeque<IOCallbackResult<usize>>, Vec<(usize, u16)>);
+
+    /// Records every `send_gso` call as `(total_bytes, gso_size)`,
+    /// optionally failing calls from a scripted queue first.
+    #[cfg(target_os = "linux")]
+    struct FakeGsoIOSend(Mutex<FakeGsoState>);
+
+    #[cfg(target_os = "linux")]
+    impl FakeGsoIOSend {
+        fn new() -> Arc<Self> {
+            Arc::new(Self(Mutex::new((VecDeque::new(), Vec::new()))))
+        }
+        fn with_fakes(fakes: VecDeque<IOCallbackResult<usize>>) -> Arc<Self> {
+            Arc::new(Self(Mutex::new((fakes, Vec::new()))))
+        }
+        fn calls(&self) -> Vec<(usize, u16)> {
+            self.0.lock().unwrap().1.clone()
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    impl OutsideIOSendCallback for FakeGsoIOSend {
+        fn send(&self, _buf: &[u8]) -> IOCallbackResult<usize> {
+            std::unreachable!("Should not be testing send");
+        }
+
+        fn send_gso(
+            &self,
+            bufs: &[std::io::IoSlice<'_>],
+            gso_size: u16,
+        ) -> IOCallbackResult<usize> {
+            let total: usize = bufs.iter().map(|b| b.len()).sum();
+            let (fakes, calls) = &mut *self.0.lock().unwrap();
+            calls.push((total, gso_size));
+            match fakes.pop_front() {
+                Some(r) => r,
+                None => IOCallbackResult::Ok(total),
+            }
         }
 
         fn peer_addr(&self) -> std::net::SocketAddr {
@@ -905,5 +985,188 @@ mod tests {
         g.open();
         g.put(&[0xAA; 1280]);
         g.put(&[0xBB; 1281]);
+    }
+
+    /// A batch that fits within the kernel's single-send limit goes
+    /// out as exactly one `send_gso` call.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn gso_flush_under_limit_single_send() {
+        let io = FakeGsoIOSend::new();
+        let seg = vec![0xAA; 1350];
+        let iovs: Vec<std::io::IoSlice<'_>> =
+            (0..10).map(|_| std::io::IoSlice::new(&seg)).collect();
+        let arg: OutsideIOSendCallbackArg = io.clone();
+
+        let r = send_gso_chunked(&arg, &iovs, 1, 1350);
+        assert!(matches!(r, IOCallbackResult::Ok(_)));
+        assert_eq!(io.calls(), vec![(10 * 1350, 1350)]);
+    }
+
+    /// Field failure: a 65535-byte TSO aggregate at MTU 1350 is 50 wire
+    /// segments (67500 bytes), over the skb limit, so the flush must split
+    /// to keep every payload within `MAX_GSO_SEND_BYTES`.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn gso_flush_over_limit_splits_on_segment_boundary() {
+        const STRIDE: usize = 1350;
+        const SEGS: usize = 50;
+
+        let io = FakeGsoIOSend::new();
+        let seg = vec![0xAA; STRIDE];
+        let iovs: Vec<std::io::IoSlice<'_>> =
+            (0..SEGS).map(|_| std::io::IoSlice::new(&seg)).collect();
+        let arg: OutsideIOSendCallbackArg = io.clone();
+
+        let r = send_gso_chunked(&arg, &iovs, 1, STRIDE as u16);
+        assert!(matches!(r, IOCallbackResult::Ok(_)));
+
+        let calls = io.calls();
+        let segs_per_send = crate::gso::MAX_GSO_SEND_BYTES / STRIDE; // 48
+        assert_eq!(
+            calls,
+            vec![
+                (segs_per_send * STRIDE, STRIDE as u16),
+                ((SEGS - segs_per_send) * STRIDE, STRIDE as u16)
+            ]
+        );
+        for (total, _) in calls {
+            assert_le!(total, crate::gso::MAX_GSO_SEND_BYTES);
+        }
+    }
+
+    /// Chunk boundaries must fall on whole segments even when each
+    /// segment is scattered over multiple iovec entries (the
+    /// zero-copy path uses 2 per segment: shared header + payload).
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn gso_flush_split_respects_entries_per_seg() {
+        const HDR: usize = 16;
+        const PAYLOAD: usize = 1334;
+        const STRIDE: usize = HDR + PAYLOAD; // 1350
+        const SEGS: usize = 50;
+
+        let io = FakeGsoIOSend::new();
+        let hdr = vec![0xBB; HDR];
+        let payload = vec![0xAA; PAYLOAD];
+        let mut iovs: Vec<std::io::IoSlice<'_>> = Vec::with_capacity(SEGS * 2);
+        for _ in 0..SEGS {
+            iovs.push(std::io::IoSlice::new(&hdr));
+            iovs.push(std::io::IoSlice::new(&payload));
+        }
+        let arg: OutsideIOSendCallbackArg = io.clone();
+
+        let r = send_gso_chunked(&arg, &iovs, 2, STRIDE as u16);
+        assert!(matches!(r, IOCallbackResult::Ok(_)));
+
+        // Every chunk's byte count is a whole multiple of the stride
+        // (all segments here are full-sized), within the send limit.
+        let calls = io.calls();
+        assert_eq!(calls.len(), 2);
+        for (total, _) in calls {
+            assert_eq!(total % STRIDE, 0, "chunk split mid-segment");
+            assert_le!(total, crate::gso::MAX_GSO_SEND_BYTES);
+        }
+    }
+
+    /// `WouldBlock` from the socket must reach the caller rather than
+    /// folding into a successful return.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn gso_flush_would_block_is_surfaced() {
+        const STRIDE: usize = 1350;
+
+        let io = FakeGsoIOSend::with_fakes(vec![IOCallbackResult::WouldBlock].into());
+        let seg = vec![0xAA; STRIDE];
+        let iovs: Vec<std::io::IoSlice<'_>> =
+            (0..10).map(|_| std::io::IoSlice::new(&seg)).collect();
+        let arg: OutsideIOSendCallbackArg = io.clone();
+
+        let r = send_gso_chunked(&arg, &iovs, 1, STRIDE as u16);
+        assert!(matches!(r, IOCallbackResult::WouldBlock));
+        assert_eq!(io.calls().len(), 1);
+    }
+
+    /// The byte budget alone over-packs at small strides: the kernel also
+    /// caps segments per send at `UDP_MAX_SEGMENTS`, so `segs_per_send`
+    /// must be clamped to `MAX_GSO_SEGS` as well. At stride 256 the byte
+    /// budget yields 255 segments (65487/256), over `UDP_MAX_SEGMENTS`.
+    #[test_case(256 ; "stride 256")]
+    #[test_case(100 ; "stride 100")]
+    #[test_case(64  ; "stride 64")]
+    #[cfg(target_os = "linux")]
+    fn gso_flush_clamps_segments_per_send(stride: usize) {
+        const SEGS: usize = 200;
+
+        // Precondition: the byte budget alone would exceed the segment cap.
+        assert!(
+            crate::gso::MAX_GSO_SEND_BYTES / stride > crate::gso::MAX_GSO_SEGS,
+            "stride {stride} does not exercise the clamp"
+        );
+
+        let io = FakeGsoIOSend::new();
+        let seg = vec![0xAA; stride];
+        let iovs: Vec<std::io::IoSlice<'_>> =
+            (0..SEGS).map(|_| std::io::IoSlice::new(&seg)).collect();
+        let arg: OutsideIOSendCallbackArg = io.clone();
+
+        let r = send_gso_chunked(&arg, &iovs, 1, stride as u16);
+        assert!(matches!(r, IOCallbackResult::Ok(_)));
+
+        let calls = io.calls();
+        let mut total = 0usize;
+        for (bytes, _) in &calls {
+            assert_eq!(bytes % stride, 0, "chunk split mid-segment");
+            assert!(
+                bytes / stride <= crate::gso::MAX_GSO_SEGS,
+                "chunk of {} segments exceeds the kernel cap",
+                bytes / stride
+            );
+            assert!(*bytes <= crate::gso::MAX_GSO_SEND_BYTES);
+            total += bytes;
+        }
+        assert_eq!(total, SEGS * stride, "no bytes lost");
+        assert_eq!(calls.len(), SEGS.div_ceil(crate::gso::MAX_GSO_SEGS));
+    }
+
+    /// A stride larger than the whole byte budget still yields one segment
+    /// per call rather than zero.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn gso_flush_clamps_lower_bound() {
+        let io = FakeGsoIOSend::new();
+        let stride = crate::gso::MAX_GSO_SEND_BYTES + 100;
+        let seg = vec![0xAA; stride];
+        let iovs: Vec<std::io::IoSlice<'_>> = (0..3).map(|_| std::io::IoSlice::new(&seg)).collect();
+        let arg: OutsideIOSendCallbackArg = io.clone();
+
+        let r = send_gso_chunked(&arg, &iovs, 1, u16::MAX);
+        assert!(matches!(r, IOCallbackResult::Ok(_)));
+        assert_eq!(io.calls().len(), 3, "one segment per call");
+    }
+
+    /// A failure after the first chunk is surfaced to the caller —
+    /// the already-sent chunks cannot be retried, the rest is dropped.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn gso_flush_mid_batch_error_is_surfaced() {
+        const STRIDE: usize = 1350;
+        const SEGS: usize = 50;
+
+        let io = FakeGsoIOSend::with_fakes(
+            vec![
+                IOCallbackResult::Ok(48 * STRIDE),
+                IOCallbackResult::Err(Error::other("EMSGSIZE")),
+            ]
+            .into(),
+        );
+        let seg = vec![0xAA; STRIDE];
+        let iovs: Vec<std::io::IoSlice<'_>> =
+            (0..SEGS).map(|_| std::io::IoSlice::new(&seg)).collect();
+        let arg: OutsideIOSendCallbackArg = io.clone();
+
+        let r = send_gso_chunked(&arg, &iovs, 1, STRIDE as u16);
+        assert!(matches!(r, IOCallbackResult::Err(e) if e.to_string() == "EMSGSIZE"));
+        assert_eq!(io.calls().len(), 2);
     }
 }

--- a/lightway-core/src/gro.rs
+++ b/lightway-core/src/gro.rs
@@ -1,0 +1,1223 @@
+//! GRO (Generic Receive Offload) TCP coalescing.
+//!
+//! Receive-side mirror of [`crate::gso`]: merges decrypted, in-order,
+//! same-flow IPv4 TCP segments into one TSO superpacket written to a Linux
+//! TUN behind a `virtio_net_hdr`, so the kernel traverses its receive path
+//! once per batch. Rules mirror the kernel's `tcp_gro_receive`: same flow,
+//! strictly in sequence, headers byte-identical apart from the per-segment
+//! fields (IP length/id/checksum, TCP seq/checksum, PSH/FIN). Anything else
+//! ends the batch, where the kernel flushes.
+
+use bytes::BytesMut;
+use pnet_packet::tcp::TcpFlags;
+
+use crate::gso::{
+    MAX_GSO_SEGS, VIRTIO_NET_HDR_F_NEEDS_CSUM, VIRTIO_NET_HDR_GSO_TCPV4, VirtioNetHdr,
+};
+
+/// IPv4 header length when IHL == 5 — the only shape we coalesce
+/// (packets with IP options are rejected), so every header offset
+/// below is fixed.
+const IPV4_HDR_LEN: usize = 20;
+/// Minimum TCP header length (Data Offset == 5).
+const TCP_MIN_HDR_LEN: usize = 20;
+/// Largest IPv4 packet: `total_length` is a u16.
+pub const MAX_IPV4_PACKET_LEN: usize = u16::MAX as usize;
+/// IPv4 protocol number for TCP.
+const IPPROTO_TCP: u8 = 6;
+/// The TCP flag bits a segment may set without breaking the batch;
+/// they end the batch and are OR'd onto the superpacket flags.
+const TCP_PSH_FIN: u8 = TcpFlags::PSH | TcpFlags::FIN;
+/// TCP flags that make a segment non-coalescable outright.
+const TCP_NO_COALESCE_FLAGS: u8 = TcpFlags::SYN | TcpFlags::RST | TcpFlags::URG | TcpFlags::CWR;
+
+/// Outcome of offering a packet to [`TcpGroBatch::append`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GroAppend {
+    /// Packet absorbed into the batch.
+    Coalesced,
+    /// Packet absorbed, but the batch must be flushed now.
+    CoalescedFlush,
+    /// Packet cannot join the batch (or is not coalescable at all).
+    /// Caller must take()+write the batch, then re-offer or write the
+    /// packet directly.
+    Incompatible,
+}
+
+/// Fields extracted from a packet that passed the coalescability
+/// checks in [`parse_coalescable`].
+struct SegInfo {
+    /// TCP header length in bytes (Data Offset × 4).
+    tcp_hdr_len: usize,
+    /// TCP payload length in bytes (>= 1).
+    payload_len: usize,
+    /// TCP sequence number.
+    seq: u32,
+    /// The segment's PSH/FIN bits (other flush-worthy flags never
+    /// reach here — they fail the coalescability check).
+    psh_fin: u8,
+}
+
+/// Validate that `pkt` is a coalescable IPv4 TCP segment and extract
+/// the fields the batch logic needs. Returns `None` for anything we
+/// must not coalesce: non-IPv4, IP options, length mismatch,
+/// fragments, non-TCP, truncated/short TCP header, empty payload
+/// (pure ACKs), or SYN/RST/URG/CWR flags.
+fn parse_coalescable(pkt: &[u8]) -> Option<SegInfo> {
+    use pnet_packet::ip::IpNextHeaderProtocols;
+    use pnet_packet::ipv4::{Ipv4Flags, Ipv4Packet};
+    use pnet_packet::tcp::TcpPacket;
+
+    if pkt.len() < IPV4_HDR_LEN + TCP_MIN_HDR_LEN {
+        return None;
+    }
+    // Version 4 with IHL == 5 in a single byte; IHL > 5 (IP options)
+    // is rejected to keep all header offsets fixed. Raw bytes here
+    // (as in `gso::calc_hdr_len`): the version has to be known before
+    // an `Ipv4Packet` may be constructed.
+    if pkt[0] != 0x45 {
+        return None;
+    }
+    // The length check above guarantees both views can be built.
+    let ip = Ipv4Packet::new(pkt)?;
+    if ip.get_total_length() as usize != pkt.len() {
+        return None;
+    }
+    // Fragmented: MF set or non-zero fragment offset (DF is fine).
+    if ip.get_flags() & Ipv4Flags::MoreFragments != 0 || ip.get_fragment_offset() != 0 {
+        return None;
+    }
+    if ip.get_next_level_protocol() != IpNextHeaderProtocols::Tcp {
+        return None;
+    }
+    let tcp_bytes = &pkt[IPV4_HDR_LEN..];
+    let tcp = TcpPacket::new(tcp_bytes)?;
+    let tcp_hdr_len = tcp.get_data_offset() as usize * 4;
+    if tcp_hdr_len < TCP_MIN_HDR_LEN || tcp_hdr_len > tcp_bytes.len() {
+        return None;
+    }
+    let payload_len = tcp_bytes.len() - tcp_hdr_len;
+    if payload_len == 0 {
+        // Pure ACKs are not coalescable.
+        return None;
+    }
+    let flags = tcp.get_flags();
+    if flags & TCP_NO_COALESCE_FLAGS != 0 {
+        return None;
+    }
+    let seq = tcp.get_sequence();
+    Some(SegInfo {
+        tcp_hdr_len,
+        payload_len,
+        seq,
+        psh_fin: flags & TCP_PSH_FIN,
+    })
+}
+
+/// Folded one's-complement sum of the TCP pseudo header, *not*
+/// complemented. This is what `VIRTIO_NET_HDR_F_NEEDS_CSUM` expects: the
+/// receiver completes it by summing from `csum_start` and complementing —
+/// the inverse of [`crate::gso::gso_none_checksum`].
+fn pseudo_header_partial(pkt: &[u8]) -> u16 {
+    let tcp_len = (pkt.len() - IPV4_HDR_LEN) as u16;
+    let mut c = internet_checksum::Checksum::new();
+    c.add_bytes(&pkt[12..20]);
+    // [zero, proto, len_hi, len_lo] — the big-endian pseudo-header trailer.
+    c.add_bytes(&[0, IPPROTO_TCP, (tcp_len >> 8) as u8, tcp_len as u8]);
+    // `checksum()` returns the complemented sum; undo the complement to
+    // get the partial the receiver will continue summing from.
+    !u16::from_be_bytes(c.checksum())
+}
+
+/// Accumulates in-order, same-flow IPv4 TCP segments into one TSO
+/// superpacket. The first segment is stored whole and fixes the flow
+/// identity and `gso_size`; later segments contribute payload only.
+/// [`Self::take`] returns the buffer with the `virtio_net_hdr` to prepend.
+pub struct TcpGroBatch {
+    /// First segment's full bytes followed by later segments' payloads.
+    buf: BytesMut,
+    /// Number of segments absorbed so far.
+    segs: usize,
+    /// First segment's payload length; fixes the batch MSS.
+    gso_size: usize,
+    /// First segment's TCP header length (Data Offset × 4).
+    tcp_hdr_len: usize,
+    /// Sequence number the next in-order segment must carry.
+    next_seq: u32,
+    /// PSH/FIN bits accumulated from absorbed segments, OR'd into the
+    /// superpacket's flags by [`Self::take`].
+    psh_fin: u8,
+}
+
+impl TcpGroBatch {
+    /// Create an empty batch.
+    pub fn new() -> Self {
+        Self {
+            buf: BytesMut::new(),
+            segs: 0,
+            gso_size: 0,
+            tcp_hdr_len: 0,
+            next_seq: 0,
+            psh_fin: 0,
+        }
+    }
+
+    /// True if no segment has been absorbed since the last
+    /// [`Self::take`].
+    pub fn is_empty(&self) -> bool {
+        self.segs == 0
+    }
+
+    /// Offer a packet (a full IPv4 frame, no virtio header). If the
+    /// batch is empty, a coalescable packet starts it — except a
+    /// PSH/FIN-marked one, which could never grow beyond a single
+    /// segment and is rejected so the caller writes it directly.
+    ///
+    /// On [`GroAppend::Incompatible`] nothing was absorbed and the
+    /// batch is unchanged; the caller must [`Self::take`]+write the
+    /// batch, then re-offer or write the packet directly.
+    pub fn append(&mut self, pkt: &[u8]) -> GroAppend {
+        let Some(info) = parse_coalescable(pkt) else {
+            return GroAppend::Incompatible;
+        };
+
+        if self.segs == 0 {
+            // Kernel GRO flushes on PSH: a starting PSH/FIN segment
+            // would only ever form a single-segment batch flushed
+            // immediately with its bytes untouched, so absorbing it
+            // would copy the packet just to hand it straight back.
+            // Reject it and let the caller write it directly.
+            if info.psh_fin != 0 {
+                return GroAppend::Incompatible;
+            }
+            debug_assert!(self.buf.is_empty());
+            // Reserve the full superpacket size up front so absorbing
+            // segments never grows the buffer by doubling.
+            self.buf.reserve(MAX_IPV4_PACKET_LEN);
+            self.buf.extend_from_slice(pkt);
+            self.segs = 1;
+            self.gso_size = info.payload_len;
+            self.tcp_hdr_len = info.tcp_hdr_len;
+            self.next_seq = info.seq.wrapping_add(info.payload_len as u32);
+            self.psh_fin = 0;
+            return GroAppend::Coalesced;
+        }
+
+        // ---- flow/header identity checks against the first segment ----
+
+        if info.tcp_hdr_len != self.tcp_hdr_len {
+            return GroAppend::Incompatible;
+        }
+        let hdr_len = IPV4_HDR_LEN + self.tcp_hdr_len;
+        // The two comparisons below are deliberately raw byte ranges — a
+        // whitelist of *exclusions*, not field accessors — and must stay
+        // that way: they are exhaustive by construction (every byte except
+        // the few excluded is compared, so any unanticipated field forces a
+        // safe flush; a blacklist of accessors would splice two TCP states
+        // on a forgotten field), and they cover the variable-length TCP
+        // options region, which the kernel also compares byte-wise.
+        //
+        // IPv4 bytes must match except total_length (2..4), id (4..6) and
+        // checksum (10..12): same addresses, TOS, TTL, DF and flow.
+        let b = &self.buf;
+        if pkt[0..2] != b[0..2] || pkt[6..10] != b[6..10] || pkt[12..20] != b[12..20] {
+            return GroAppend::Incompatible;
+        }
+        // TCP header bytes must match except seq (4..8), checksum
+        // (16..18) and the PSH/FIN bits of the flags byte — same
+        // ports, ack, window, urgent pointer and options, or the
+        // kernel would have flushed.
+        let (p, q) = (&pkt[IPV4_HDR_LEN..hdr_len], &b[IPV4_HDR_LEN..hdr_len]);
+        if p[0..4] != q[0..4]
+            || p[8..13] != q[8..13]
+            || (p[13] & !TCP_PSH_FIN) != (q[13] & !TCP_PSH_FIN)
+            || p[14..16] != q[14..16]
+            || p[18..] != q[18..]
+        {
+            return GroAppend::Incompatible;
+        }
+
+        // ---- ordering and size checks ----
+
+        // Strictly in-order: no overlap, no gap.
+        if info.seq != self.next_seq {
+            return GroAppend::Incompatible;
+        }
+        // A segment larger than the batch MSS cannot be part of the
+        // same TSO train.
+        if info.payload_len > self.gso_size {
+            return GroAppend::Incompatible;
+        }
+        // The superpacket's IP total_length is a u16.
+        if self.buf.len() + info.payload_len > MAX_IPV4_PACKET_LEN {
+            return GroAppend::Incompatible;
+        }
+
+        // ---- absorb payload ----
+
+        self.buf.extend_from_slice(&pkt[hdr_len..]);
+        self.segs += 1;
+        self.next_seq = self.next_seq.wrapping_add(info.payload_len as u32);
+        self.psh_fin |= info.psh_fin;
+
+        // Flush on a short segment (it ends the train, like the
+        // kernel), on PSH/FIN, or at the segment cap.
+        if info.payload_len < self.gso_size || info.psh_fin != 0 || self.segs >= MAX_GSO_SEGS {
+            GroAppend::CoalescedFlush
+        } else {
+            GroAppend::Coalesced
+        }
+    }
+
+    /// True iff the batch holds segments and `pkt` belongs to the same
+    /// flow as its first segment: IPv4 with IHL 5, protocol TCP, long
+    /// enough to carry the ports, and src/dst addresses (bytes 12..20)
+    /// plus TCP ports (bytes 20..24) byte-equal to the batch's.
+    ///
+    /// A cheap identity test only — [`Self::append`] still performs
+    /// the full coalescability checks.
+    fn matches_flow(&self, pkt: &[u8]) -> bool {
+        self.segs != 0
+            && pkt.len() >= IPV4_HDR_LEN + 4
+            && pkt[0] == 0x45
+            && pkt[9] == IPPROTO_TCP
+            && pkt[12..IPV4_HDR_LEN + 4] == self.buf[12..IPV4_HDR_LEN + 4]
+    }
+
+    /// Take the assembled superpacket and its virtio header, resetting
+    /// the batch. None if empty.
+    ///
+    /// A single-segment batch is returned untouched with a default
+    /// (`GSO_NONE`, no flags) header — its checksums are already
+    /// valid, the caller writes it as a plain packet. A multi-segment
+    /// batch gets its IP header fixed up (total length, recomputed
+    /// header checksum), accumulated PSH/FIN bits OR'd into the TCP
+    /// flags, and the TCP checksum field seeded with the pseudo-header
+    /// partial sum as `VIRTIO_NET_HDR_F_NEEDS_CSUM` requires.
+    pub fn take(&mut self) -> Option<(BytesMut, VirtioNetHdr)> {
+        if self.segs == 0 {
+            return None;
+        }
+        let segs = self.segs;
+        let gso_size = self.gso_size;
+        let tcp_hdr_len = self.tcp_hdr_len;
+        let psh_fin = self.psh_fin;
+        let mut buf = self.buf.split();
+        self.segs = 0;
+        self.gso_size = 0;
+        self.tcp_hdr_len = 0;
+        self.next_seq = 0;
+        self.psh_fin = 0;
+
+        if segs == 1 {
+            return Some((buf, VirtioNetHdr::default()));
+        }
+
+        // IP-layer fixups: total length over the whole aggregate,
+        // first segment's id kept, header checksum recomputed.
+        {
+            use pnet_packet::ipv4::MutableIpv4Packet;
+            let total_len = buf.len() as u16;
+            let mut ip = MutableIpv4Packet::new(&mut buf[..IPV4_HDR_LEN])
+                .expect("batch buffer always holds a full IPv4 header");
+            ip.set_total_length(total_len);
+            ip.set_checksum(0);
+            let csum = pnet_packet::ipv4::checksum(&ip.to_immutable());
+            ip.set_checksum(csum);
+        }
+
+        // TCP fixups: propagate PSH/FIN collected from absorbed
+        // segments, seed the checksum field with the pseudo-header
+        // partial (big-endian, not complemented — `set_checksum`
+        // writes a host `u16` big-endian).
+        //
+        // The partial is computed before the mutable TCP view is taken;
+        // it reads only the IP addresses and the total length, none of
+        // which the fixups below touch.
+        let partial = pseudo_header_partial(&buf);
+        {
+            use pnet_packet::tcp::MutableTcpPacket;
+            let mut tcp = MutableTcpPacket::new(&mut buf[IPV4_HDR_LEN..])
+                .expect("batch buffer always holds a full TCP header");
+            tcp.set_flags(tcp.get_flags() | psh_fin);
+            tcp.set_checksum(partial);
+        }
+
+        let vhdr = VirtioNetHdr {
+            flags: VIRTIO_NET_HDR_F_NEEDS_CSUM,
+            gso_type: VIRTIO_NET_HDR_GSO_TCPV4,
+            hdr_len: (IPV4_HDR_LEN + tcp_hdr_len) as u16,
+            gso_size: gso_size as u16,
+            csum_start: IPV4_HDR_LEN as u16,
+            csum_offset: 16,
+        };
+        Some((buf, vhdr))
+    }
+}
+
+impl Default for TcpGroBatch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Maximum concurrently-open flows in a [`TcpGroTable`] window.
+const MAX_GRO_FLOWS: usize = 8;
+
+/// Result of offering a packet to a [`TcpGroTable`].
+pub struct GroTableAppend {
+    /// Superpackets that must be written to the TUN now, in order.
+    /// Usually empty (no allocation): flushes only happen on PSH/FIN,
+    /// caps, or same-flow incompatibility.
+    pub flushes: Vec<(BytesMut, VirtioNetHdr)>,
+    /// False: the packet was not absorbed — the caller must write it
+    /// directly AFTER writing `flushes` (same-flow ordering).
+    pub consumed: bool,
+}
+
+/// A bounded pool of [`TcpGroBatch`]es keyed by flow, so several concurrent
+/// TCP flows coalesce within one GRO window without flushing each other.
+/// Within-flow write order is preserved (a flow's pending superpacket is
+/// flushed before any packet of that flow is handed back for a direct
+/// write); cross-flow order is arbitrary.
+pub struct TcpGroTable {
+    /// Fixed pool of batches; a slot is free when its batch is empty.
+    slots: [TcpGroBatch; MAX_GRO_FLOWS],
+}
+
+impl TcpGroTable {
+    /// Create a table with all slots empty.
+    pub fn new() -> Self {
+        Self {
+            slots: std::array::from_fn(|_| TcpGroBatch::new()),
+        }
+    }
+
+    /// True if no batch holds segments.
+    pub fn is_empty(&self) -> bool {
+        self.slots.iter().all(TcpGroBatch::is_empty)
+    }
+
+    /// Offer a packet (a full IPv4 frame, no virtio header) to the
+    /// table. The caller must write every entry of
+    /// [`GroTableAppend::flushes`] to the TUN in order, then — iff
+    /// `consumed` is false — write the packet itself directly.
+    ///
+    /// A packet matching a held flow goes to that flow's batch; if the
+    /// batch rejects it (seq gap, ack change, pure ACK, PSH/FIN-first…)
+    /// the batch is flushed first so its segments reach the TUN before
+    /// the packet, and the packet re-offered as a fresh seed. With no
+    /// matching flow and no free slot the packet is simply not
+    /// consumed — nothing held belongs to its flow, so a direct write
+    /// cannot reorder within a flow.
+    pub fn append(&mut self, pkt: &[u8]) -> GroTableAppend {
+        if let Some(batch) = self.slots.iter_mut().find(|b| b.matches_flow(pkt)) {
+            return match batch.append(pkt) {
+                GroAppend::Coalesced => GroTableAppend {
+                    flushes: Vec::new(),
+                    consumed: true,
+                },
+                GroAppend::CoalescedFlush => {
+                    let out = batch.take().expect("batch just absorbed a segment");
+                    GroTableAppend {
+                        flushes: vec![out],
+                        consumed: true,
+                    }
+                }
+                GroAppend::Incompatible => {
+                    // Same flow but unmergeable: the held segments
+                    // must hit the TUN before this packet. The packet
+                    // then re-seeds the freed slot when it can.
+                    let old = batch.take().expect("matches_flow implies non-empty");
+                    let mut flushes = vec![old];
+                    let consumed = Self::seed(batch, pkt, &mut flushes);
+                    GroTableAppend { flushes, consumed }
+                }
+            };
+        }
+
+        // New flow: seed a free slot if the table has room.
+        let Some(slot) = self.slots.iter_mut().find(|b| b.is_empty()) else {
+            return GroTableAppend {
+                flushes: Vec::new(),
+                consumed: false,
+            };
+        };
+        let mut flushes = Vec::new();
+        let consumed = Self::seed(slot, pkt, &mut flushes);
+        GroTableAppend { flushes, consumed }
+    }
+
+    /// Offer `pkt` to an empty `batch`. Returns whether it was
+    /// consumed; a segment that flushes immediately is pushed onto
+    /// `flushes`. Not consumed when the packet is not coalescable at
+    /// all (non-IPv4, non-TCP, pure ACK, PSH/FIN-first…).
+    fn seed(
+        batch: &mut TcpGroBatch,
+        pkt: &[u8],
+        flushes: &mut Vec<(BytesMut, VirtioNetHdr)>,
+    ) -> bool {
+        match batch.append(pkt) {
+            GroAppend::Coalesced => true,
+            GroAppend::CoalescedFlush => {
+                flushes.push(batch.take().expect("batch just absorbed a segment"));
+                true
+            }
+            GroAppend::Incompatible => false,
+        }
+    }
+
+    /// Take every pending superpacket (window close). Cross-flow order
+    /// is arbitrary. Slots retain no data and are reused afterwards.
+    pub fn drain(&mut self) -> Vec<(BytesMut, VirtioNetHdr)> {
+        self.slots
+            .iter_mut()
+            .filter_map(TcpGroBatch::take)
+            .collect()
+    }
+}
+
+impl Default for TcpGroTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::BytesMut;
+    use pnet_packet::ipv4::{Ipv4Packet, MutableIpv4Packet};
+    use pnet_packet::tcp::MutableTcpPacket;
+    use std::net::Ipv4Addr;
+
+    const TCP_FLAG_ACK: u8 = TcpFlags::ACK;
+    const TCP_FLAG_FIN: u8 = TcpFlags::FIN;
+    const TCP_FLAG_PSH: u8 = TcpFlags::PSH;
+    const SRC: [u8; 4] = [10, 0, 0, 1];
+    const DST: [u8; 4] = [10, 0, 0, 2];
+
+    fn src() -> Ipv4Addr {
+        SRC.into()
+    }
+
+    fn dst() -> Ipv4Addr {
+        DST.into()
+    }
+
+    fn payload(len: usize) -> Vec<u8> {
+        (0..len).map(|i| (i % 251) as u8).collect()
+    }
+
+    // ---- builders ----
+
+    /// One IPv4 TCP segment with real, valid IP and TCP checksums
+    /// (computed via pnet, the same way gso.rs recomputes them) so
+    /// coalesce-then-resplit round trips are byte-exact.
+    struct Seg {
+        seq: u32,
+        id: u16,
+        flags: u8,
+        ack: u32,
+        window: u16,
+        ttl: u8,
+        src_port: u16,
+        tcp_opts: Vec<u8>,
+        payload: Vec<u8>,
+    }
+
+    impl Seg {
+        fn new(seq: u32, id: u16, payload_len: usize) -> Self {
+            Self {
+                seq,
+                id,
+                flags: TCP_FLAG_ACK,
+                ack: 0x2222_0000,
+                window: 0xFFFF,
+                ttl: 64,
+                src_port: 1234,
+                tcp_opts: Vec::new(),
+                payload: payload(payload_len),
+            }
+        }
+
+        fn flags(mut self, flags: u8) -> Self {
+            self.flags = flags;
+            self
+        }
+
+        fn ack(mut self, ack: u32) -> Self {
+            self.ack = ack;
+            self
+        }
+
+        fn window(mut self, window: u16) -> Self {
+            self.window = window;
+            self
+        }
+
+        fn ttl(mut self, ttl: u8) -> Self {
+            self.ttl = ttl;
+            self
+        }
+
+        fn src_port(mut self, port: u16) -> Self {
+            self.src_port = port;
+            self
+        }
+
+        fn tcp_opts(mut self, opts: &[u8]) -> Self {
+            assert_eq!(opts.len() % 4, 0, "TCP options must pad to 32-bit words");
+            self.tcp_opts = opts.to_vec();
+            self
+        }
+
+        fn build(&self) -> Vec<u8> {
+            let tcp_hdr_len = TCP_MIN_HDR_LEN + self.tcp_opts.len();
+            let total = IPV4_HDR_LEN + tcp_hdr_len + self.payload.len();
+            let mut pkt = Vec::with_capacity(total);
+
+            let mut ip = [0u8; IPV4_HDR_LEN];
+            ip[0] = 0x45; // version=4, IHL=5
+            ip[2..4].copy_from_slice(&(total as u16).to_be_bytes());
+            ip[4..6].copy_from_slice(&self.id.to_be_bytes());
+            ip[6] = 0x40; // DF
+            ip[8] = self.ttl;
+            ip[9] = IPPROTO_TCP;
+            ip[12..16].copy_from_slice(&SRC);
+            ip[16..20].copy_from_slice(&DST);
+            pkt.extend_from_slice(&ip);
+
+            let mut tcp = vec![0u8; tcp_hdr_len];
+            tcp[0..2].copy_from_slice(&self.src_port.to_be_bytes());
+            tcp[2..4].copy_from_slice(&5678u16.to_be_bytes());
+            tcp[4..8].copy_from_slice(&self.seq.to_be_bytes());
+            tcp[8..12].copy_from_slice(&self.ack.to_be_bytes());
+            tcp[12] = ((tcp_hdr_len / 4) as u8) << 4;
+            tcp[13] = self.flags;
+            tcp[14..16].copy_from_slice(&self.window.to_be_bytes());
+            tcp[TCP_MIN_HDR_LEN..].copy_from_slice(&self.tcp_opts);
+            pkt.extend_from_slice(&tcp);
+
+            pkt.extend_from_slice(&self.payload);
+
+            let mut ip = MutableIpv4Packet::new(&mut pkt[..IPV4_HDR_LEN]).unwrap();
+            let csum = pnet_packet::ipv4::checksum(&ip.to_immutable());
+            ip.set_checksum(csum);
+            let mut tcp = MutableTcpPacket::new(&mut pkt[IPV4_HDR_LEN..]).unwrap();
+            let csum = pnet_packet::tcp::ipv4_checksum(&tcp.to_immutable(), &src(), &dst());
+            tcp.set_checksum(csum);
+            pkt
+        }
+    }
+
+    // ---- verifiers ----
+
+    /// Hand-folded pseudo-header partial sum, independent of the
+    /// implementation's helper.
+    fn expected_partial(tcp_len: usize) -> u16 {
+        let mut acc: u32 = 0;
+        for addr in [SRC, DST] {
+            acc += u16::from_be_bytes([addr[0], addr[1]]) as u32;
+            acc += u16::from_be_bytes([addr[2], addr[3]]) as u32;
+        }
+        acc += IPPROTO_TCP as u32;
+        acc += tcp_len as u32;
+        while acc > 0xFFFF {
+            acc = (acc >> 16) + (acc & 0xFFFF);
+        }
+        acc as u16
+    }
+
+    /// Verify the superpacket's stored IPv4 header checksum against a
+    /// recomputed one over the header with the field zeroed.
+    fn check_ip_csum(sp: &[u8]) {
+        let mut copy = sp[..IPV4_HDR_LEN].to_vec();
+        let mut ip = MutableIpv4Packet::new(&mut copy).unwrap();
+        let stored = ip.get_checksum();
+        ip.set_checksum(0);
+        assert_eq!(
+            stored,
+            pnet_packet::ipv4::checksum(&ip.to_immutable()),
+            "IPv4 header csum"
+        );
+    }
+
+    // ---- tests ----
+
+    /// Three equal-size segments coalesce into one superpacket with
+    /// fixed-up IP header, first seq preserved, the pseudo-header
+    /// partial in the TCP checksum field and a fully-populated
+    /// VirtioNetHdr.
+    #[test]
+    fn three_full_segments_coalesce() {
+        let p = 500usize;
+        let seq0 = 0xAABB_0000u32;
+        let id0 = 0x0042u16;
+        let mut batch = TcpGroBatch::new();
+        assert!(batch.is_empty());
+        for i in 0..3u32 {
+            let pkt = Seg::new(seq0 + i * p as u32, id0 + i as u16, p).build();
+            assert_eq!(batch.append(&pkt), GroAppend::Coalesced, "seg {i}");
+        }
+        assert!(!batch.is_empty());
+
+        let (sp, vhdr) = batch.take().unwrap();
+        assert!(batch.is_empty());
+        let total = IPV4_HDR_LEN + TCP_MIN_HDR_LEN + 3 * p;
+        assert_eq!(sp.len(), total);
+
+        let ip = Ipv4Packet::new(&sp[..IPV4_HDR_LEN]).unwrap();
+        assert_eq!(ip.get_total_length() as usize, total, "IP total_len");
+        assert_eq!(ip.get_identification(), id0, "first segment's IP id");
+        check_ip_csum(&sp);
+
+        // TCP: first seq preserved, checksum field holds the
+        // pseudo-header partial (not complemented).
+        assert_eq!(u32::from_be_bytes(sp[24..28].try_into().unwrap()), seq0);
+        let tcp_len = total - IPV4_HDR_LEN;
+        assert_eq!(
+            u16::from_be_bytes(sp[36..38].try_into().unwrap()),
+            expected_partial(tcp_len),
+            "pseudo-header partial"
+        );
+
+        // Completing the partial the way the kernel would on transmit
+        // (gso_none_checksum is the exact inverse contract) must yield
+        // a valid TCP checksum over the whole aggregate.
+        let mut full = sp.to_vec();
+        crate::gso::gso_none_checksum(&mut full, 20, 16);
+        let mut l4 = full[IPV4_HDR_LEN..].to_vec();
+        let mut tcp = MutableTcpPacket::new(&mut l4).unwrap();
+        let stored = tcp.get_checksum();
+        tcp.set_checksum(0);
+        assert_eq!(
+            stored,
+            pnet_packet::tcp::ipv4_checksum(&tcp.to_immutable(), &src(), &dst()),
+            "completed TCP csum"
+        );
+
+        assert_eq!(vhdr.flags, VIRTIO_NET_HDR_F_NEEDS_CSUM);
+        assert_eq!(vhdr.gso_type, VIRTIO_NET_HDR_GSO_TCPV4);
+        assert_eq!(vhdr.hdr_len, (IPV4_HDR_LEN + TCP_MIN_HDR_LEN) as u16);
+        assert_eq!(vhdr.gso_size, p as u16);
+        assert_eq!(vhdr.csum_start, IPV4_HDR_LEN as u16);
+        assert_eq!(vhdr.csum_offset, 16);
+    }
+
+    /// Coalesce N in-order segments (sequential IP ids, valid
+    /// checksums), then re-split with gso.rs. Every rebuilt segment
+    /// must be byte-identical to its original.
+    #[test]
+    fn round_trip_with_gso_split() {
+        let p = 1000usize;
+        let n = 4usize;
+        let seq0 = 0x1000_0000u32;
+        let id0 = 0x0100u16;
+        let originals: Vec<Vec<u8>> = (0..n)
+            .map(|i| Seg::new(seq0 + (i * p) as u32, id0 + i as u16, p).build())
+            .collect();
+
+        let mut batch = TcpGroBatch::new();
+        for (i, pkt) in originals.iter().enumerate() {
+            assert_eq!(batch.append(pkt), GroAppend::Coalesced, "seg {i}");
+        }
+        let (sp, vhdr) = batch.take().unwrap();
+
+        let hdr_len = crate::gso::calc_hdr_len(&sp).unwrap();
+        assert_eq!(hdr_len, IPV4_HDR_LEN + TCP_MIN_HDR_LEN);
+        assert_eq!(
+            crate::gso::calc_gso_segs(sp.len(), hdr_len, vhdr.gso_size as usize),
+            n
+        );
+        let mut out = BytesMut::with_capacity(4096);
+        for (i, orig) in originals.iter().enumerate() {
+            crate::gso::build_segment(&vhdr, hdr_len, &sp, i, &mut out).unwrap();
+            assert_eq!(&out[..], &orig[..], "rebuilt segment {i} differs");
+        }
+    }
+
+    /// A short trailing segment is absorbed and flushes the batch; the
+    /// superpacket length reflects it and re-splitting yields the
+    /// short final segment byte-for-byte.
+    #[test]
+    fn short_trailing_segment_flushes() {
+        let p = 300usize;
+        let s = 120usize;
+        let seq0 = 0x0500_0000u32;
+        let id0 = 0x0777u16;
+        let seg0 = Seg::new(seq0, id0, p).build();
+        let seg1 = Seg::new(seq0 + p as u32, id0 + 1, p).build();
+        let seg2 = Seg::new(seq0 + 2 * p as u32, id0 + 2, s).build();
+
+        let mut batch = TcpGroBatch::new();
+        assert_eq!(batch.append(&seg0), GroAppend::Coalesced);
+        assert_eq!(batch.append(&seg1), GroAppend::Coalesced);
+        assert_eq!(batch.append(&seg2), GroAppend::CoalescedFlush);
+
+        let (sp, vhdr) = batch.take().unwrap();
+        assert_eq!(sp.len(), IPV4_HDR_LEN + TCP_MIN_HDR_LEN + 2 * p + s);
+        let hdr_len = crate::gso::calc_hdr_len(&sp).unwrap();
+        assert_eq!(
+            crate::gso::calc_gso_segs(sp.len(), hdr_len, vhdr.gso_size as usize),
+            3
+        );
+        let mut out = BytesMut::with_capacity(2048);
+        crate::gso::build_segment(&vhdr, hdr_len, &sp, 2, &mut out).unwrap();
+        assert_eq!(&out[..], &seg2[..], "short final segment");
+    }
+
+    /// PSH on a follower segment is absorbed, flushes the batch and is
+    /// propagated into the superpacket's TCP flags.
+    #[test]
+    fn psh_mid_train_flushes_and_propagates() {
+        let p = 200usize;
+        let seq0 = 0x0100_0000u32;
+        let seg0 = Seg::new(seq0, 1, p).build();
+        let seg1 = Seg::new(seq0 + p as u32, 2, p)
+            .flags(TCP_FLAG_ACK | TCP_FLAG_PSH)
+            .build();
+
+        let mut batch = TcpGroBatch::new();
+        assert_eq!(batch.append(&seg0), GroAppend::Coalesced);
+        assert_eq!(batch.append(&seg1), GroAppend::CoalescedFlush);
+
+        let (sp, _vhdr) = batch.take().unwrap();
+        assert_eq!(sp.len(), IPV4_HDR_LEN + TCP_MIN_HDR_LEN + 2 * p);
+        assert_eq!(sp[33], TCP_FLAG_ACK | TCP_FLAG_PSH, "PSH propagated");
+    }
+
+    /// FIN behaves like PSH: absorbed, flushes, propagated.
+    #[test]
+    fn fin_mid_train_flushes_and_propagates() {
+        let p = 200usize;
+        let seq0 = 0x0200_0000u32;
+        let seg0 = Seg::new(seq0, 1, p).build();
+        let seg1 = Seg::new(seq0 + p as u32, 2, p)
+            .flags(TCP_FLAG_ACK | TCP_FLAG_FIN)
+            .build();
+
+        let mut batch = TcpGroBatch::new();
+        assert_eq!(batch.append(&seg0), GroAppend::Coalesced);
+        assert_eq!(batch.append(&seg1), GroAppend::CoalescedFlush);
+
+        let (sp, _vhdr) = batch.take().unwrap();
+        assert_eq!(sp.len(), IPV4_HDR_LEN + TCP_MIN_HDR_LEN + 2 * p);
+        assert_eq!(sp[33], TCP_FLAG_ACK | TCP_FLAG_FIN, "FIN propagated");
+    }
+
+    /// A sequence gap is Incompatible and leaves the batch unchanged —
+    /// take() still yields the earlier segments, and the rejected
+    /// packet can start a fresh batch afterwards.
+    #[test]
+    fn sequence_gap_incompatible_batch_unchanged() {
+        let p = 100usize;
+        let seq0 = 0x0300_0000u32;
+        let seg0 = Seg::new(seq0, 1, p).build();
+        let seg1 = Seg::new(seq0 + p as u32, 2, p).build();
+        // Gap: skips one segment's worth of payload.
+        let gap = Seg::new(seq0 + 3 * p as u32, 3, p).build();
+
+        let mut batch = TcpGroBatch::new();
+        assert_eq!(batch.append(&seg0), GroAppend::Coalesced);
+        assert_eq!(batch.append(&seg1), GroAppend::Coalesced);
+        assert_eq!(batch.append(&gap), GroAppend::Incompatible);
+
+        let (sp, vhdr) = batch.take().unwrap();
+        assert_eq!(sp.len(), IPV4_HDR_LEN + TCP_MIN_HDR_LEN + 2 * p);
+        assert_eq!(vhdr.gso_size as usize, p);
+
+        // Batch is reusable: the rejected packet starts a new one.
+        assert_eq!(batch.append(&gap), GroAppend::Coalesced);
+        let (sp, vhdr) = batch.take().unwrap();
+        assert_eq!(&sp[..], &gap[..]);
+        assert_eq!(vhdr.to_bytes(), VirtioNetHdr::default().to_bytes());
+    }
+
+    /// Any flow/header difference beyond the per-segment mutable
+    /// fields is Incompatible: ack_seq, source port, TTL, window, and
+    /// TCP options (both different length and same-length different
+    /// bytes).
+    #[test]
+    fn flow_and_header_mismatches_incompatible() {
+        let p = 100usize;
+        let seq0 = 0x0400_0000u32;
+        let mut batch = TcpGroBatch::new();
+        assert_eq!(
+            batch.append(&Seg::new(seq0, 1, p).build()),
+            GroAppend::Coalesced
+        );
+
+        let follower = || Seg::new(seq0 + p as u32, 2, p);
+        let cases: Vec<(&str, Vec<u8>)> = vec![
+            ("ack", follower().ack(0x2222_0001).build()),
+            ("src port", follower().src_port(4321).build()),
+            ("ttl", follower().ttl(63).build()),
+            ("window", follower().window(0x1234).build()),
+            ("options length", follower().tcp_opts(&[1, 1, 1, 0]).build()),
+        ];
+        for (what, pkt) in cases {
+            assert_eq!(
+                batch.append(&pkt),
+                GroAppend::Incompatible,
+                "differing {what}"
+            );
+        }
+        // Sanity: an identical-flow follower still coalesces.
+        assert_eq!(batch.append(&follower().build()), GroAppend::Coalesced);
+
+        // Same-length but different option bytes also mismatch.
+        let mut batch = TcpGroBatch::new();
+        let first = Seg::new(seq0, 1, p).tcp_opts(&[1, 1, 1, 1]).build();
+        assert_eq!(batch.append(&first), GroAppend::Coalesced);
+        let diff_opts = follower().tcp_opts(&[1, 1, 1, 0]).build();
+        assert_eq!(batch.append(&diff_opts), GroAppend::Incompatible);
+        let same_opts = follower().tcp_opts(&[1, 1, 1, 1]).build();
+        assert_eq!(batch.append(&same_opts), GroAppend::Coalesced);
+    }
+
+    /// A pure ACK (no payload) is never coalescable, even into an
+    /// empty batch.
+    #[test]
+    fn pure_ack_incompatible() {
+        let ack = Seg::new(0x0600_0000, 1, 0).build();
+        let mut batch = TcpGroBatch::new();
+        assert_eq!(batch.append(&ack), GroAppend::Incompatible);
+        assert!(batch.is_empty());
+        assert!(batch.take().is_none());
+    }
+
+    /// Non-TCP (UDP) and non-IPv4 (v6 version nibble) packets are
+    /// Incompatible.
+    #[test]
+    fn non_tcp_and_ipv6_incompatible() {
+        let mut batch = TcpGroBatch::new();
+
+        let mut udp = Seg::new(0x0700_0000, 1, 100).build();
+        udp[9] = 17; // IPPROTO_UDP
+        assert_eq!(batch.append(&udp), GroAppend::Incompatible);
+
+        let mut v6 = Seg::new(0x0700_0000, 1, 100).build();
+        v6[0] = 0x60;
+        assert_eq!(batch.append(&v6), GroAppend::Incompatible);
+
+        assert!(batch.is_empty());
+    }
+
+    /// An append that would push the superpacket past 65535 bytes
+    /// (IPv4 total_length is a u16) is Incompatible and absorbs
+    /// nothing.
+    #[test]
+    fn byte_cap_incompatible_nothing_appended() {
+        let p = 30000usize;
+        let seq0 = 0x0800_0000u32;
+        let mut batch = TcpGroBatch::new();
+        for i in 0..2u32 {
+            let pkt = Seg::new(seq0 + i * p as u32, 1 + i as u16, p).build();
+            assert_eq!(batch.append(&pkt), GroAppend::Coalesced, "seg {i}");
+        }
+        let len_before = batch.buf.len();
+        assert_eq!(len_before, IPV4_HDR_LEN + TCP_MIN_HDR_LEN + 2 * p);
+
+        // 60040 + 30000 > 65535 — must be rejected without absorbing.
+        let third = Seg::new(seq0 + 2 * p as u32, 3, p).build();
+        assert_eq!(batch.append(&third), GroAppend::Incompatible);
+        assert_eq!(batch.buf.len(), len_before, "nothing appended");
+
+        let (sp, vhdr) = batch.take().unwrap();
+        assert_eq!(sp.len(), len_before);
+        assert_eq!(vhdr.gso_size as usize, p);
+    }
+
+    /// A single-segment take() returns the packet bytes untouched with
+    /// a default (GSO_NONE, no flags) header.
+    #[test]
+    fn single_segment_take_untouched() {
+        let pkt = Seg::new(0x0900_0000, 0x0055, 333).build();
+        let mut batch = TcpGroBatch::new();
+        assert_eq!(batch.append(&pkt), GroAppend::Coalesced);
+        let (sp, vhdr) = batch.take().unwrap();
+        assert_eq!(&sp[..], &pkt[..], "bytes untouched");
+        assert_eq!(vhdr.to_bytes(), VirtioNetHdr::default().to_bytes());
+        assert!(batch.is_empty());
+    }
+
+    /// A follower whose payload exceeds the batch's gso_size cannot be
+    /// part of the same TSO train.
+    #[test]
+    fn oversized_follower_incompatible() {
+        let p = 100usize;
+        let seq0 = 0x0A00_0000u32;
+        let mut batch = TcpGroBatch::new();
+        assert_eq!(
+            batch.append(&Seg::new(seq0, 1, p).build()),
+            GroAppend::Coalesced
+        );
+        let big = Seg::new(seq0 + p as u32, 2, 150).build();
+        assert_eq!(batch.append(&big), GroAppend::Incompatible);
+        // Batch still holds only the first segment.
+        let (sp, vhdr) = batch.take().unwrap();
+        assert_eq!(sp.len(), IPV4_HDR_LEN + TCP_MIN_HDR_LEN + p);
+        assert_eq!(vhdr.to_bytes(), VirtioNetHdr::default().to_bytes());
+    }
+
+    /// A starting packet with PSH is rejected without being absorbed —
+    /// it could only ever flush immediately as a single-segment batch,
+    /// so the caller writes it directly instead of copying it through
+    /// the batch.
+    #[test]
+    fn starting_psh_incompatible() {
+        let pkt = Seg::new(0x0B00_0000, 1, 100)
+            .flags(TCP_FLAG_ACK | TCP_FLAG_PSH)
+            .build();
+        let mut batch = TcpGroBatch::new();
+        assert_eq!(batch.append(&pkt), GroAppend::Incompatible);
+        assert!(batch.is_empty());
+        assert!(batch.take().is_none());
+    }
+
+    /// The 64th segment (MAX_GSO_SEGS) is absorbed and flushes the
+    /// batch.
+    #[test]
+    fn segment_cap_flushes_at_max_gso_segs() {
+        let p = 8usize;
+        let seq0 = 0x0C00_0000u32;
+        let mut batch = TcpGroBatch::new();
+        for i in 0..MAX_GSO_SEGS {
+            let pkt = Seg::new(seq0 + (i * p) as u32, i as u16, p).build();
+            let want = if i == MAX_GSO_SEGS - 1 {
+                GroAppend::CoalescedFlush
+            } else {
+                GroAppend::Coalesced
+            };
+            assert_eq!(batch.append(&pkt), want, "seg {i}");
+        }
+        let (sp, vhdr) = batch.take().unwrap();
+        assert_eq!(sp.len(), IPV4_HDR_LEN + TCP_MIN_HDR_LEN + MAX_GSO_SEGS * p);
+        assert_eq!(vhdr.gso_size as usize, p);
+    }
+
+    // ---- TcpGroTable tests ----
+
+    /// Two flows interleaved segment-by-segment coalesce independently
+    /// with zero intermediate flushes; drain() yields one superpacket
+    /// per flow, byte-identical to coalescing that flow alone.
+    #[test]
+    fn table_interleaved_flows_coalesce_independently() {
+        let p = 400usize;
+        let seg_a = |i: u32| Seg::new(0x1000_0000 + i * p as u32, i as u16, p).src_port(1111);
+        let seg_b = |i: u32| Seg::new(0x2000_0000 + i * p as u32, 100 + i as u16, p).src_port(2222);
+
+        let mut table = TcpGroTable::new();
+        assert!(table.is_empty());
+        for i in 0..3u32 {
+            for pkt in [seg_a(i).build(), seg_b(i).build()] {
+                let r = table.append(&pkt);
+                assert!(r.consumed, "seg {i} consumed");
+                assert!(r.flushes.is_empty(), "seg {i} no intermediate flush");
+            }
+        }
+        assert!(!table.is_empty());
+
+        // Reference: each flow coalesced alone in a plain batch.
+        let alone = |mk: &dyn Fn(u32) -> Seg| {
+            let mut batch = TcpGroBatch::new();
+            for i in 0..3u32 {
+                assert_eq!(batch.append(&mk(i).build()), GroAppend::Coalesced);
+            }
+            batch.take().unwrap()
+        };
+        let (sp_a, vh_a) = alone(&seg_a);
+        let (sp_b, vh_b) = alone(&seg_b);
+
+        let mut out = table.drain();
+        assert!(table.is_empty());
+        assert_eq!(out.len(), 2);
+        // Cross-flow order is arbitrary: identify flows by src port.
+        out.sort_by_key(|(sp, _)| u16::from_be_bytes([sp[20], sp[21]]));
+        assert_eq!(&out[0].0[..], &sp_a[..], "flow A superpacket");
+        assert_eq!(out[0].1.to_bytes(), vh_a.to_bytes());
+        assert_eq!(&out[1].0[..], &sp_b[..], "flow B superpacket");
+        assert_eq!(out[1].1.to_bytes(), vh_b.to_bytes());
+    }
+
+    /// A same-flow sequence gap flushes the held superpacket, and the
+    /// gap packet seeds a fresh batch that drains with its own seq.
+    #[test]
+    fn table_same_flow_seq_gap_flushes_and_reseeds() {
+        let p = 100usize;
+        let seq0 = 0x0300_0000u32;
+        let mut table = TcpGroTable::new();
+        for i in 0..2u32 {
+            let r = table.append(&Seg::new(seq0 + i * p as u32, 1 + i as u16, p).build());
+            assert!(r.consumed && r.flushes.is_empty(), "seg {i}");
+        }
+        // Gap: skips one segment's worth of payload.
+        let gap = Seg::new(seq0 + 3 * p as u32, 3, p).build();
+        let r = table.append(&gap);
+        assert!(r.consumed, "gap packet seeds a fresh batch");
+        assert_eq!(r.flushes.len(), 1);
+        assert_eq!(
+            r.flushes[0].0.len(),
+            IPV4_HDR_LEN + TCP_MIN_HDR_LEN + 2 * p,
+            "held 2-segment superpacket flushed"
+        );
+
+        let out = table.drain();
+        assert_eq!(out.len(), 1);
+        assert_eq!(&out[0].0[..], &gap[..], "fresh batch holds the gap packet");
+    }
+
+    /// A same-flow pure ACK flushes the held superpacket but is not
+    /// consumed — the caller writes it directly after the flush.
+    #[test]
+    fn table_same_flow_pure_ack_flushes_not_consumed() {
+        let p = 100usize;
+        let seq0 = 0x0400_0000u32;
+        let held = Seg::new(seq0, 1, p).build();
+        let mut table = TcpGroTable::new();
+        assert!(table.append(&held).consumed);
+
+        let ack = Seg::new(seq0 + p as u32, 2, 0).build();
+        let r = table.append(&ack);
+        assert!(!r.consumed, "pure ACK never coalesces");
+        assert_eq!(r.flushes.len(), 1);
+        assert_eq!(
+            &r.flushes[0].0[..],
+            &held[..],
+            "held segments flushed first"
+        );
+        assert!(table.is_empty());
+    }
+
+    /// A packet of a different flow lands in its own slot without
+    /// flushing the flow already held.
+    #[test]
+    fn table_different_flow_no_cross_flush() {
+        let p = 100usize;
+        let mut table = TcpGroTable::new();
+        assert!(table.append(&Seg::new(0x0500_0000, 1, p).build()).consumed);
+
+        let other = Seg::new(0x0600_0000, 2, p).src_port(4321).build();
+        let r = table.append(&other);
+        assert!(r.consumed, "new flow takes its own slot");
+        assert!(r.flushes.is_empty(), "no cross-flow flush");
+        assert_eq!(table.drain().len(), 2);
+    }
+
+    /// With MAX_GRO_FLOWS flows held, a packet of yet another flow is
+    /// not consumed and flushes nothing; the held flows drain intact.
+    #[test]
+    fn table_overflow_rejects_extra_flow() {
+        let p = 100usize;
+        let mut table = TcpGroTable::new();
+        for i in 0..MAX_GRO_FLOWS {
+            let pkt = Seg::new(0x0700_0000, i as u16, p)
+                .src_port(1000 + i as u16)
+                .build();
+            let r = table.append(&pkt);
+            assert!(r.consumed && r.flushes.is_empty(), "flow {i}");
+        }
+
+        let extra = Seg::new(0x0700_0000, 99, p)
+            .src_port(1000 + MAX_GRO_FLOWS as u16)
+            .build();
+        let r = table.append(&extra);
+        assert!(!r.consumed, "table full: not absorbed");
+        assert!(r.flushes.is_empty(), "table full: nothing flushed");
+
+        let out = table.drain();
+        assert_eq!(out.len(), MAX_GRO_FLOWS);
+        let mut ports: Vec<u16> = out
+            .iter()
+            .map(|(sp, _)| u16::from_be_bytes([sp[20], sp[21]]))
+            .collect();
+        ports.sort_unstable();
+        let want: Vec<u16> = (0..MAX_GRO_FLOWS).map(|i| 1000 + i as u16).collect();
+        assert_eq!(ports, want, "all held flows drain intact");
+    }
+
+    /// A PSH-marked first segment of a fresh flow is not consumed and
+    /// occupies no slot — the caller writes the original bytes
+    /// directly, with no copy through the table.
+    #[test]
+    fn table_psh_start_fresh_flow_not_consumed() {
+        let pkt = Seg::new(0x0800_0000, 1, 100)
+            .flags(TCP_FLAG_ACK | TCP_FLAG_PSH)
+            .build();
+        let mut table = TcpGroTable::new();
+        let r = table.append(&pkt);
+        assert!(!r.consumed, "caller writes the packet directly");
+        assert!(r.flushes.is_empty());
+        assert!(table.is_empty(), "no slot occupied");
+        assert!(table.drain().is_empty());
+    }
+
+    /// A PSH-marked same-flow segment that cannot join the held train
+    /// (seq gap) flushes the train and — being PSH-first for the
+    /// freed slot — is itself not consumed: it reaches the TUN as a
+    /// direct write after the flush, preserving in-flow order.
+    #[test]
+    fn table_psh_after_seq_gap_flushes_then_direct() {
+        let p = 100usize;
+        let seq0 = 0x0810_0000u32;
+        let held = Seg::new(seq0, 1, p).build();
+        let mut table = TcpGroTable::new();
+        assert!(table.append(&held).consumed);
+
+        // Gap: skips one segment's worth of payload.
+        let psh = Seg::new(seq0 + 2 * p as u32, 2, p)
+            .flags(TCP_FLAG_ACK | TCP_FLAG_PSH)
+            .build();
+        let r = table.append(&psh);
+        assert!(!r.consumed);
+        assert_eq!(r.flushes.len(), 1);
+        assert_eq!(&r.flushes[0].0[..], &held[..], "held segment flushed first");
+        assert!(table.is_empty());
+    }
+
+    /// Non-coalescable packets (UDP, IPv6) are not consumed and do not
+    /// disturb a held flow.
+    #[test]
+    fn table_non_tcp_and_ipv6_not_consumed() {
+        let p = 100usize;
+        let held = Seg::new(0x0900_0000, 1, p).build();
+        let mut table = TcpGroTable::new();
+        assert!(table.append(&held).consumed);
+
+        let mut udp = Seg::new(0x0A00_0000, 2, p).build();
+        udp[9] = 17; // IPPROTO_UDP
+        let mut v6 = Seg::new(0x0A00_0000, 3, p).build();
+        v6[0] = 0x60;
+        for pkt in [udp, v6] {
+            let r = table.append(&pkt);
+            assert!(!r.consumed);
+            assert!(r.flushes.is_empty());
+        }
+
+        let out = table.drain();
+        assert_eq!(out.len(), 1);
+        assert_eq!(&out[0].0[..], &held[..]);
+    }
+
+    /// After a drain the slots are reusable: the table coalesces a new
+    /// train exactly as a fresh one would.
+    #[test]
+    fn table_reusable_after_drain() {
+        let p = 200usize;
+        let mut table = TcpGroTable::new();
+        assert!(table.append(&Seg::new(0x0B00_0000, 1, p).build()).consumed);
+        assert_eq!(table.drain().len(), 1);
+        assert!(table.is_empty());
+
+        let seq0 = 0x0C00_0000u32;
+        for i in 0..2u32 {
+            let r = table.append(&Seg::new(seq0 + i * p as u32, 1 + i as u16, p).build());
+            assert!(r.consumed && r.flushes.is_empty(), "seg {i}");
+        }
+        let out = table.drain();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].0.len(), IPV4_HDR_LEN + TCP_MIN_HDR_LEN + 2 * p);
+        assert_eq!(out[0].1.gso_size as usize, p);
+    }
+}

--- a/lightway-core/src/gro.rs
+++ b/lightway-core/src/gro.rs
@@ -105,6 +105,12 @@ fn parse_coalescable(pkt: &[u8]) -> Option<SegInfo> {
     if flags & TCP_NO_COALESCE_FLAGS != 0 {
         return None;
     }
+    // Most expensive check last: a segment with a bad TCP checksum must not
+    // coalesce, or `take` would reseed a valid checksum over corrupt bytes.
+    // See [`tcp_checksum_valid`].
+    if !tcp_checksum_valid(pkt) {
+        return None;
+    }
     let seq = tcp.get_sequence();
     Some(SegInfo {
         tcp_hdr_len,
@@ -112,6 +118,26 @@ fn parse_coalescable(pkt: &[u8]) -> Option<SegInfo> {
         seq,
         psh_fin: flags & TCP_PSH_FIN,
     })
+}
+
+/// Verify a segment's TCP checksum (pseudo-header + TCP header + payload).
+/// Kernel GRO validates before coalescing so a corrupt segment cannot be
+/// laundered: [`TcpGroBatch::take`] reseeds `NEEDS_CSUM`, which makes the
+/// kernel *complete* the checksum rather than check it, so a bad segment
+/// merged here would reach the app with a freshly-valid checksum over
+/// corrupt bytes. A segment that fails is left for the caller to write
+/// directly, where a plain (non-`NEEDS_CSUM`) write lets the kernel
+/// validate and drop it and TCP retransmits. `pkt` is a full IHL==5 IPv4
+/// TCP frame.
+fn tcp_checksum_valid(pkt: &[u8]) -> bool {
+    let tcp_len = (pkt.len() - IPV4_HDR_LEN) as u16;
+    let mut c = internet_checksum::Checksum::new();
+    c.add_bytes(&pkt[12..20]); // src + dst addresses
+    c.add_bytes(&[0, IPPROTO_TCP, (tcp_len >> 8) as u8, tcp_len as u8]);
+    c.add_bytes(&pkt[IPV4_HDR_LEN..]); // TCP header + payload, checksum field included
+    // A valid segment folds to 0xFFFF, whose complement (what `checksum`
+    // returns) is zero.
+    c.checksum() == [0, 0]
 }
 
 /// Folded one's-complement sum of the TCP pseudo header, *not*
@@ -703,6 +729,36 @@ mod tests {
         assert_eq!(vhdr.gso_size, p as u16);
         assert_eq!(vhdr.csum_start, IPV4_HDR_LEN as u16);
         assert_eq!(vhdr.csum_offset, 16);
+    }
+
+    /// A segment whose TCP checksum is wrong (a flipped payload byte)
+    /// must not coalesce: `take` would otherwise reseed a valid checksum
+    /// over corrupt bytes, laundering a packet the kernel would have
+    /// dropped on the non-offload path. As the first segment it fails to
+    /// start a batch; mid-train it flushes the good prefix and is left for
+    /// a direct write.
+    #[test]
+    fn bad_tcp_checksum_not_coalesced() {
+        let p = 400usize;
+        let seq0 = 0x9000_0000u32;
+
+        // As the opening segment: rejected, batch stays empty.
+        let mut corrupt = Seg::new(seq0, 1, p).build();
+        *corrupt.last_mut().unwrap() ^= 0xFF; // flip a payload byte -> bad TCP csum
+        let mut batch = TcpGroBatch::new();
+        assert_eq!(batch.append(&corrupt), GroAppend::Incompatible);
+        assert!(batch.is_empty(), "corrupt opener must not start a batch");
+
+        // Mid-train: a good segment starts the batch, the corrupt follower
+        // flushes it and is not absorbed.
+        let good = Seg::new(seq0, 1, p).build();
+        assert_eq!(batch.append(&good), GroAppend::Coalesced);
+        let mut corrupt2 = Seg::new(seq0 + p as u32, 2, p).build();
+        *corrupt2.last_mut().unwrap() ^= 0xFF;
+        assert_eq!(batch.append(&corrupt2), GroAppend::Incompatible);
+        // Only the one good segment is in the batch.
+        let (sp, _) = batch.take().unwrap();
+        assert_eq!(sp.len(), IPV4_HDR_LEN + TCP_MIN_HDR_LEN + p);
     }
 
     /// Coalesce N in-order segments (sequential IP ids, valid

--- a/lightway-core/src/gso.rs
+++ b/lightway-core/src/gso.rs
@@ -93,6 +93,21 @@ impl VirtioNetHdr {
         unsafe { Ok(&*(ptr as *const VirtioNetHdr)) }
     }
 
+    /// Serialize to the on-wire layout used by the TUN vnet header.
+    ///
+    /// virtio-net fields are guest-endian, which is native endian for
+    /// every target we build for.
+    pub fn to_bytes(&self) -> [u8; VIRTIO_NET_HDR_LEN] {
+        let mut b = [0u8; VIRTIO_NET_HDR_LEN];
+        b[0] = self.flags;
+        b[1] = self.gso_type;
+        b[2..4].copy_from_slice(&self.hdr_len.to_ne_bytes());
+        b[4..6].copy_from_slice(&self.gso_size.to_ne_bytes());
+        b[6..8].copy_from_slice(&self.csum_start.to_ne_bytes());
+        b[8..10].copy_from_slice(&self.csum_offset.to_ne_bytes());
+        b
+    }
+
     /// True if `gso_type` indicates a TCP segmentation aggregate (v4 or v6).
     ///
     /// Linux ORs `VIRTIO_NET_HDR_GSO_ECN` (0x80) into `gso_type` for
@@ -234,7 +249,7 @@ fn transport_checksum(src: &[u8], dst: &[u8], proto: u8, transport: &[u8]) -> u1
 }
 
 /// GSO type: TCP segmentation aggregate over IPv4.
-const VIRTIO_NET_HDR_GSO_TCPV4: u8 = 1;
+pub(crate) const VIRTIO_NET_HDR_GSO_TCPV4: u8 = 1;
 /// GSO type: TCP segmentation aggregate over IPv6.
 const VIRTIO_NET_HDR_GSO_TCPV6: u8 = 4;
 /// ECN flag OR'd into `gso_type` for ECN-marked aggregates.

--- a/lightway-core/src/gso.rs
+++ b/lightway-core/src/gso.rs
@@ -50,6 +50,23 @@ pub(crate) const MAX_GSO_SEGS: usize = 64;
 /// `MAX_GSO_SEGS` segments, each at most `MAX_OUTSIDE_MTU`.
 pub(crate) const MAX_GSO_FRAME_BYTES: usize = MAX_GSO_SEGS * crate::MAX_OUTSIDE_MTU;
 
+/// Maximum size of an IP datagram: the IP length field is 16 bits.
+#[cfg(target_os = "linux")]
+const IP_MAX_DATAGRAM_SIZE: usize = u16::MAX as usize;
+/// Fixed IPv6 header size (RFC 8200 §3). Larger than the IPv4 header, so
+/// used as the worst case when bounding a segment's overhead.
+#[cfg(target_os = "linux")]
+const IPV6_HEADER_SIZE: usize = 40;
+
+/// Max UDP payload bytes one `sendmsg(UDP_SEGMENT)` may carry: the kernel
+/// builds the whole batch into one skb, bounded by the max IP datagram size
+/// less the UDP and (worst-case) IPv6 headers; beyond it fails `EMSGSIZE`. A
+/// TUN TSO aggregate can exceed this before the wire::Header, so flushes are
+/// chunked to it. Linux-only consumer; gated to avoid a dead_code warning.
+#[cfg(target_os = "linux")]
+pub(crate) const MAX_GSO_SEND_BYTES: usize =
+    IP_MAX_DATAGRAM_SIZE - crate::UDP_HEADER_SIZE - IPV6_HEADER_SIZE;
+
 impl VirtioNetHdr {
     /// Interpret the first [`VIRTIO_NET_HDR_LEN`] bytes of `buf` as a
     /// `&VirtioNetHdr` without copying.

--- a/lightway-core/src/io.rs
+++ b/lightway-core/src/io.rs
@@ -66,6 +66,16 @@ pub trait OutsideIOSendCallback {
     /// `sendmsg`, which the kernel splits into `gso_size`-byte
     /// segments. The trailing segment may be shorter than `gso_size`.
     fn send_gso(&self, bufs: &[IoSlice<'_>], gso_size: u16) -> IOCallbackResult<usize>;
+
+    /// Whether kernel UDP GSO (`UDP_SEGMENT`) is usable on this socket.
+    /// Starts `true`; an implementation may latch it `false` once a send
+    /// is rejected with a capability error (typically `EIO` on an egress
+    /// device without TX checksum offload, which UDP GSO requires). When
+    /// `false` the connection sends one datagram per segment instead of
+    /// coalescing. Transports that never call `send_gso` keep the default.
+    fn gso_enabled(&self) -> bool {
+        true
+    }
 }
 
 /// Convenience type to use as function arguments

--- a/lightway-core/src/lib.rs
+++ b/lightway-core/src/lib.rs
@@ -10,6 +10,8 @@ mod context;
 mod encoding_request_states;
 mod features;
 #[cfg(any(target_os = "linux", test))]
+pub mod gro;
+#[cfg(any(target_os = "linux", test))]
 pub mod gso;
 mod io;
 mod keyshare;

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -499,7 +499,11 @@ async fn inside_io_loop_gso(
             }
         };
 
-        if hdr.flags & VIRTIO_NET_HDR_F_NEEDS_CSUM != 0 {
+        // Only for non-GSO packets: the kernel sets NEEDS_CSUM on TSO
+        // aggregates too, but `gso::build_segment` recomputes each
+        // segment's checksum from scratch, so folding the (up to
+        // ~64KB) superpacket here would be immediately discarded work.
+        if hdr.is_gso_none() && hdr.flags & VIRTIO_NET_HDR_F_NEEDS_CSUM != 0 {
             gso_none_checksum(pkt.as_mut(), hdr.csum_start, hdr.csum_offset);
         }
 

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -96,6 +96,18 @@ run-udp-iouring-test:
 run-udp-tun-offload-test:
     DO +TEST --MODE=udp --SERVER_PORT=27690 --SERVER_EXTRA_ARGS="--enable-tun-offload"
 
+# run-udp-client-tun-offload-test runs e2e test using UDP with client TUN offload (GSO) enabled
+run-udp-client-tun-offload-test:
+    DO +TEST --MODE=udp --SERVER_PORT=27690 --CLIENT_EXTRA_ARGS="--enable-tun-offload"
+
+# run-udp-both-tun-offload-test runs e2e test using UDP with TUN offload enabled on both peers
+run-udp-both-tun-offload-test:
+    DO +TEST --MODE=udp --SERVER_PORT=27690 --SERVER_EXTRA_ARGS="--enable-tun-offload" --CLIENT_EXTRA_ARGS="--enable-tun-offload"
+
+# run-tcp-client-tun-offload-test runs e2e test using TCP with client TUN offload (GSO) enabled
+run-tcp-client-tun-offload-test:
+    DO +TEST --MODE=tcp --SERVER_PORT=443 --CLIENT_EXTRA_ARGS="--enable-tun-offload"
+
 # run-udp-client-batch-receive-test runs e2e test using UDP with batch receive enabled
 run-udp-client-batch-receive-test:
     DO +TEST --MODE=udp --SERVER_PORT=27690 --CLIENT_EXTRA_ARGS="--enable-batch-receive"
@@ -267,6 +279,9 @@ run-all-tests-wolfssl:
     BUILD +run-udp-pmtud-test
     BUILD +run-udp-iouring-test
     BUILD +run-udp-tun-offload-test
+    BUILD +run-udp-client-tun-offload-test
+    BUILD +run-udp-both-tun-offload-test
+    BUILD +run-tcp-client-tun-offload-test
     BUILD +run-udp-client-batch-receive-test
     BUILD +run-udp-server-batch-receive-test
     BUILD +run-udp-both-batch-receive-test


### PR DESCRIPTION
## Part 3 of 3 — client GSO/GRO offload implementation

Final part of a three-PR stack that adds client-side TUN GSO/GRO offload.
**Base this on part 2 (refactorings).** This part adds the actual feature,
one logical change per commit: deriving the vnet header from the
negotiated `IFF_VNET_HDR`, chunking GSO flushes to the kernel's per-send
limits, TCP GRO coalescing, the client GSO send path, `UDP_GRO` receive,
TSO superpacket coalescing on download, and batched `recvmmsg` GRO
receive.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CI and Manually tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`