### PR TITLE
ci: fix path for client+server in one nix build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -312,7 +312,7 @@ jobs:
         uses: actions/upload-artifact@v4.6.2
         with:
           name: lightway-server-${{ matrix.target }}
-          path: result/bin/lightway-server
+          path: result-1/bin/lightway-server
 
   nix-tests:
     name: Nix tests (${{ matrix.os }})


### PR DESCRIPTION
## Description

Fix the artifact upload path for `lightway-server` in the combined client+server `nix build` CI step.

When `nix build` is given multiple installables (e.g. `.#lightway-client-<target> .#lightway-server-<target>`), Nix creates `result` for the first output and `result-1`, `result-2`, … for subsequent ones. The upload step for `lightway-server` was still pointing at `result/bin/lightway-server`, which resolves to the client binary. The path is corrected to `result-1/bin/lightway-server`.

## Motivation and Context

The previous PR (#499) collapsed client and server builds into a single `nix build` invocation to halve CI wall-clock time, but left the server artifact upload path unchanged. As a result the `lightway-server-<target>` artifact contained the client binary. This one-line fix makes the upload path match Nix's actual output symlink layout.

## How Has This Been Tested?

- [X] `result-1/bin/lightway-server` symlink confirmed to point to the server binary in the Nix build output

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] CI / infrastructure change (no production code affected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
- [ ] Any update to `xenon/libxenon-src` is accompanied by a reference to the specific commit in the git changelog
