### PR TITLE
CVPN-2704: Gate client keepalive liveness on decrypt progres

### DIFF
--- a/lightway-client/src/keepalive.rs
+++ b/lightway-client/src/keepalive.rs
@@ -536,6 +536,33 @@ mod tests {
     #[test_case(true; "continuous")]
     #[test_case(false; "non-continuous")]
     #[tokio::test]
+    async fn outside_activity_cancels_pending_timeout(continuous: bool) {
+        let (sleep_manager, connection) =
+            KeepaliveTestBuilder::new().continuous(continuous).build();
+
+        let (keepalive, task) = Keepalive::new(sleep_manager.clone(), connection.clone());
+        start_keepalives(&keepalive, &sleep_manager, continuous).await;
+
+        // A keepalive is pending, so the dead-man timeout is armed.
+        assert_eq!(connection.keepalive_count(), 1);
+
+        keepalive.outside_activity().await;
+        sleep(Duration::from_millis(10)).await;
+
+        // The timeout was disarmed, so firing it is a no-op rather than a termination. Contrast
+        // timeout_causes_task_termination, where the same trigger without intervening activity
+        // yields KeepaliveResult::Timedout.
+        sleep_manager.trigger_timeout();
+        sleep(Duration::from_millis(10)).await;
+
+        drop(keepalive);
+        let result = task.await.unwrap().unwrap();
+        assert!(matches!(result, KeepaliveResult::Cancelled));
+    }
+
+    #[test_case(true; "continuous")]
+    #[test_case(false; "non-continuous")]
+    #[tokio::test]
     async fn suspend_stops_keepalives(continuous: bool) {
         let (sleep_manager, connection) =
             KeepaliveTestBuilder::new().continuous(continuous).build();

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -632,7 +632,8 @@ pub async fn outside_io_task<ExtAppState: Send + Sync>(
             .iter_mut()
             .take(count)
             .map(|b| OutsidePacket::Wire(b, connection_type));
-        conn.lock()
+        let frames_decoded = conn
+            .lock()
             .unwrap()
             .multiple_outside_data_received(pkts, |err| err.is_fatal(connection_type))?;
 
@@ -641,7 +642,9 @@ pub async fn outside_io_task<ExtAppState: Send + Sync>(
             b.reserve(mtu);
         }
 
-        keepalive.outside_activity().await
+        if frames_decoded > 0 {
+            keepalive.outside_activity().await
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Reset the keepalive dead-man timer only on **authenticated decrypt progress**. `outside_io_task` previously called `keepalive.outside_activity()` after every receive batch, regardless of whether any bytes actually decoded. It now calls it only when the batch produced at least one decoded lightway frame (`frames_decoded > 0`).

`Event::KeepaliveReply` (a decoded pong) already refreshes liveness on its own path, so an idle-but-healthy tunnel is unaffected. The change is carrier-agnostic and covers the TCP path as well as UDP.

- `lightway-client/src/lib.rs` — gate the `outside_activity()` call on decode progress.
- `lightway-client/src/keepalive.rs` — supporting change and coverage.

## Motivation and Context

Previously, a UDP/DTLS client can think it is connected when the server is dead with no timeout, reconnect, or disconnect ever surfaced to the app. This can be triggered by:
1. The server terminating ungracefully or the goodbye packet being dropped
2. The server restarting before the keepalive triggers. 
3. The client will try to send a keepalive to the new server
4. The server sends a rejection with wrong session-id
5. The client will see packets coming in and assume the server is still alive.
6. After keepalive timeout, client retries keepalive and repeats this cycle.

## How Has This Been Tested?

Reproduced and verified end to end with the real `lightway-server` and `lightway-client` binaries as separate processes over UDP (Linux x86_64, network namespaces), with a real crash-style server restart (kill + relaunch → empty session table → plaintext reject stream):

The affected path is shared cross-platform client code (no OS-specific gating); it reproduces on Linux.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
