### PR TITLE
docs: highlight BoringSSL (D)TLS 1.3 cipher restriction limitation

### DIFF
--- a/docs/tls_backends.md
+++ b/docs/tls_backends.md
@@ -8,6 +8,10 @@ compile time. Two backends are supported:
   [`boring`](https://github.com/cloudflare/boring) bindings, designed as a
   drop-in replacement for the `wolfssl` crate's API).
 
+> [!CAUTION]
+> The backends are not fully equivalent: switching backend changes some
+> runtime behavior, such as which TLS 1.3 cipher suites a server accepts.
+
 ## Selecting a backend
 The backend is chosen with the mutually exclusive `wolfssl` and `boringssl`
 cargo features. Exactly one must be enabled; `lightway-core` fails the build
@@ -32,3 +36,22 @@ The actual switch lives in `lightway-core/src/tls/mod.rs`. This module:
 * enforces the mutual exclusivity with `compile_error!` - the build fails
   unless exactly one of the `wolfssl` / `boringssl` features is enabled;
 * reports which backend is in use at runtime via `get_version_string()`.
+
+## Behavioral differences
+### (D)TLS 1.3 cipher suite restriction
+**BoringSSL** cannot restrict or reorder TLS 1.3 cipher suites at all.
+This is an upstream design decision: BoringSSL's TLS 1.3 suites (and preferences) are fixed and do not participate in the `SSL_CTX_set_cipher_list` mechanism.
+A warning about this will be emitted in the console.
+
+In practice, a BoringSSL-backed server always accepts all three TLS 1.3
+suites - `TLS_AES_128_GCM_SHA256`, `TLS_AES_256_GCM_SHA384` and
+`TLS_CHACHA20_POLY1305_SHA256` - and selects among them using BoringSSL's
+built-in preference (typically AES-128-GCM on machines with AES hardware).
+Therefore,
+
+* **AES-128-GCM may be negotiated** even though the configured cipher list
+  requests AES-256/ChaCha20 only, including with clients that would be
+  rejected by a wolfSSL-backed server.
+ 
+* **The DTLS ChaCha20-first preference is not honored**; the negotiated
+  suite for Lightway/UDP follows BoringSSL's built-in ordering instead.

--- a/lightway-boring/src/context.rs
+++ b/lightway-boring/src/context.rs
@@ -188,7 +188,7 @@ impl ContextBuilder {
     pub fn with_cipher_list(mut self, cipher_list: &str) -> Result<Self> {
         if self.method.is_v1_3() {
             tracing::warn!(
-                "BoringSSL does not support cipher list restriction for (D)TLS 1.3, ignoring \"with_cipher_list\"."
+                "BoringSSL does not support cipher list restriction for (D)TLS 1.3, ignoring \"with_cipher_list\". The default cipher list and behavior in BoringSSL will be used."
             );
             return Ok(self);
         }

--- a/lightway-core/src/cipher.rs
+++ b/lightway-core/src/cipher.rs
@@ -139,6 +139,7 @@ mod tests {
             ]
         );
 
+        // Note: BoringSSL backend expose no APIs for restricting cipher list in TLS1.3.
         #[cfg(boringssl)]
         assert_eq!(
             suites,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a "Behavioral differences" section to `docs/tls_backends.md` with a caution callout in the intro, expand the runtime warning emitted, and note the limitation in the cipher suite test.

## Motivation and Context
BoringSSL's TLS 1.3 cipher suites are fixed upstream and do not participate in the SSL_CTX_set_cipher_list mechanism, so the server's configured cipher list ("TLS13-*" entries) is not enforced on the boringssl backend. A BoringSSL-backed server accepts all three TLS 1.3 suites and picks via BoringSSL's built-in preference.

The current `tls_backends.md` does not mention such differences.

## How Has This Been Tested?
CI passes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
