### PR TITLE
server: client: config: handle unknown fields from config file for client and server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
+ "tracing-test",
 ]
 
 [[package]]
@@ -3251,18 +3252,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "struct-patch"
-version = "0.12.7"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33b1be720fec2481ed6f1d2b95fefa464500cc55ce0ba5938aba77718da5f2"
+checksum = "c3a820f68a123e0ddbcd5215c95bd7d865482d3ad7a9ae463bf2adaf541746ec"
 dependencies = [
  "struct-patch-derive",
 ]
 
 [[package]]
 name = "struct-patch-derive"
-version = "0.12.7"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4bfb88f9c30c62693f33814de38c84fd833c7a5b92238655d158deb3ac62d9f"
+checksum = "d01189c2d9e14bea08d9dcac1e4e347e91f027d68617096d83a19017e2a7b070"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ serde-env = "0.3"
 serde-saphyr = "0.0.22"
 serial_test = "3.4.0"
 socket2 = "0.6.0"
-struct-patch = { version =  "0.12.5", features= ["catalyst"] }
+struct-patch = { version =  "0.13.2", features= ["catalyst"] }
 test-case = "3.1.0"
 thiserror = "2.0.3"
 tokio = { version = "1.33.0", features = ["rt-multi-thread", "macros", "net", "time", "sync", "io-util", "fs", "signal"] }

--- a/lightway-client/src/config.rs
+++ b/lightway-client/src/config.rs
@@ -12,6 +12,7 @@ use lightway_app_utils::args::{
 use lightway_core::{AuthMethod, MAX_OUTSIDE_MTU, Version};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::time::Duration as StdDuration;
 use std::{net::Ipv4Addr, path::PathBuf};
 use struct_patch::{Patch, Substrate};
@@ -345,6 +346,18 @@ pub struct Config {
     #[patch(attribute(clap(skip)))]
     #[schemars(extend("x-cfg" = "mobile"))]
     pub sni_header: String,
+
+    #[patch(attribute(clap(short, long)))]
+    #[patch(empty_value = false)]
+    #[patch(attribute(serde(default)))]
+    #[patch(attribute(doc = r#"Accept unknown inputs with error message without quiting"#))]
+    pub accept_unknowns: bool,
+
+    /// The unknown options from config file
+    #[patch(attribute(clap(skip)))]
+    #[patch(attribute(serde(flatten)))]
+    #[patch(skip_wrap, apply_by(std::collections::HashMap::extend))]
+    pub unknowns: HashMap<String, serde_json::Value>,
 }
 
 impl Config {
@@ -416,6 +429,15 @@ impl Config {
 
     /// Ensure the config is validated, and alerted when there's a conflict in the settings.
     pub fn validate(&self) -> anyhow::Result<()> {
+        if !self.unknowns.is_empty() {
+            let fields: Vec<&str> = self.unknowns.keys().map(String::as_str).collect();
+            if self.accept_unknowns {
+                tracing::warn!(fields = ?fields, "unknown config fields will be ignored");
+            } else {
+                anyhow::bail!("unknown config fields: {:?}", fields);
+            }
+        }
+
         let mut all_servers: Vec<(&str, ConnectionType)> = self
             .servers
             .iter()
@@ -543,6 +565,8 @@ impl Default for Config {
             enable_dpapi: false,
             #[cfg(feature = "mobile")]
             sni_header: String::new(),
+            accept_unknowns: false,
+            unknowns: HashMap::new(),
         }
     }
 }
@@ -807,6 +831,27 @@ mod tests {
     fn validate_default_config() {
         let config = Config::default();
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn config_unknown_fields_cause_error() {
+        let yaml = "unknown_field: true\n";
+        let patch = serde_saphyr::from_str::<ConfigPatch>(yaml).expect("should parse");
+        let mut config = Config::default();
+        config.apply(patch);
+        assert!(config.validate().is_err());
+    }
+
+    #[tracing_test::traced_test]
+    #[test]
+    fn config_unknown_fields_with_accept_flag_only_warns() {
+        let yaml = "unknown_field: true\n";
+        let patch = serde_saphyr::from_str::<ConfigPatch>(yaml).expect("should parse");
+        let mut config = Config::default();
+        config.accept_unknowns = true;
+        config.apply(patch);
+        assert!(config.validate().is_ok());
+        assert!(logs_contain("unknown config fields will be ignored"));
     }
 
     #[cfg(not(macos))]

--- a/lightway-server/Cargo.toml
+++ b/lightway-server/Cargo.toml
@@ -63,3 +63,4 @@ cfg_aliases.workspace = true
 more-asserts.workspace = true
 test-case.workspace = true
 serial_test.workspace = true
+tracing-test = "0.2.6"

--- a/lightway-server/src/config.rs
+++ b/lightway-server/src/config.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,
 };
@@ -178,6 +179,18 @@ pub struct Config {
     #[patch(attribute(doc = r#"Disable IP pool randomization
     Should be used for debugging only"#))]
     pub randomize_ippool: bool,
+
+    #[patch(attribute(clap(short, long)))]
+    #[patch(empty_value = false)]
+    #[patch(attribute(serde(default)))]
+    #[patch(attribute(doc = r#"Accept unknown inputs with error message without quiting"#))]
+    pub accept_unknowns: bool,
+
+    /// The unknown options from config file
+    #[patch(attribute(clap(skip)))]
+    #[patch(attribute(serde(flatten)))]
+    #[patch(skip_wrap, apply_by(std::collections::HashMap::extend))]
+    pub unknowns: HashMap<String, serde_json::Value>,
 }
 
 impl Default for Config {
@@ -231,6 +244,8 @@ impl Default for Config {
             tls_debug: false,
             #[cfg(feature = "debug")]
             randomize_ippool: true,
+            accept_unknowns: false,
+            unknowns: HashMap::new(),
         }
     }
 }
@@ -238,6 +253,15 @@ impl Default for Config {
 impl Config {
     /// Ensure the config is validated, and alerted when there's a conflict in the settings.
     pub fn validate(&self) -> anyhow::Result<()> {
+        if !self.unknowns.is_empty() {
+            let fields: Vec<&str> = self.unknowns.keys().map(String::as_str).collect();
+            if self.accept_unknowns {
+                tracing::warn!(fields = ?fields, "unknown config fields will be ignored");
+            } else {
+                anyhow::bail!("unknown config fields: {:?}", fields);
+            }
+        }
+
         if self.enable_expresslane {
             anyhow::ensure!(self.mode.is_udp(), "Expresslane only work in udp mode")
         }
@@ -301,5 +325,26 @@ mod tests {
         let mut config = Config::default();
         config.enable_batch_send = true;
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn config_unknown_fields_cause_error() {
+        let yaml = "unknown_field: true\n";
+        let patch = serde_saphyr::from_str::<ConfigPatch>(yaml).expect("should parse");
+        let mut config = Config::default();
+        config.apply(patch);
+        assert!(config.validate().is_err());
+    }
+
+    #[tracing_test::traced_test]
+    #[test]
+    fn config_unknown_fields_with_accept_flag_only_warns() {
+        let yaml = "unknown_field: true\n";
+        let patch = serde_saphyr::from_str::<ConfigPatch>(yaml).expect("should parse");
+        let mut config = Config::default();
+        config.accept_unknowns = true;
+        config.apply(patch);
+        assert!(config.validate().is_ok());
+        assert!(logs_contain("unknown config fields will be ignored"));
     }
 }

--- a/tests/server/server_config.yaml
+++ b/tests/server/server_config.yaml
@@ -1,6 +1,5 @@
 ---
 bind_address: 0.0.0.0:27690
-bind_attempts: 3
 mode: tcp
 server_cert: "tests/certs/server.crt"
 server_key: "tests/certs/server.key"


### PR DESCRIPTION
## Description

Detect unknown fields in config files for both `lightway-client` and `lightway-server`, and fail at validation time with a clear error message. An `--accept-unknowns` flag is added to both binaries to downgrade the error to a logged warning, allowing the process to continue.

### Change details

Previously, deserialising a config file with a typo or a removed field would succeed silently, making it easy to unknowingly run with an ineffective setting. This PR surfaces those mistakes at startup.

Key mechanical changes:

- **Unknown-field collection**: `#[patch(attribute(serde(deny_unknown_fields)))]` is replaced with a `#[patch(attribute(serde(flatten)))]` `HashMap<String, serde_json::Value>` field (`unknowns`) that absorbs any key not matched by a known field. This shifts detection from parse time to validation time, which is needed because `struct-patch`'s `deny_unknown_fields` and `flatten` cannot coexist.
- **`Config::validate()`** (client and server): if `unknowns` is non-empty, either bail with an error listing the unknown keys (default) or emit a `tracing::error!` / `tracing::warn!` and continue when `--accept-unknowns` is set.
- **`--accept-unknowns` / `-a` flag**: added to both `ConfigPatch` structs via `#[patch(attribute(clap(short, long)))]`. Lets operators migrate config files incrementally without blocking startup.
- **`struct-patch` bump 0.12.5 → 0.13.2**: required for `skip_wrap` + `apply_by` support used by the `unknowns` field merge strategy.
- **Test fixture**: removes the stale `bind_attempts` field from `tests/server/server_config.yaml`, which would now trigger the new error.
- **Unit tests** (client and server):
  - `config_unknown_fields_cause_error` – parses a YAML with an unknown key, applies the patch, and asserts `validate()` returns an error.
  - `config_unknown_fields_with_accept_flag_only_warns` – same setup but with `accept_unknowns = true`; asserts `validate()` succeeds and the expected log message is emitted (via `tracing-test`).

## Motivation and Context

Config files with typos or stale keys (e.g. from a field that was renamed or removed) were silently accepted, giving users no feedback that their setting was being ignored. Rejecting unknown fields at validation time surfaces these mistakes immediately at startup, while the `--accept-unknowns` escape hatch avoids hard-blocking operators who need time to clean up their config files.

## How Has This Been Tested?
- [x] add new testcase with unknow fields

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (internal restructuring, no behaviour change for end users)
- [ ] CI / infrastructure change (no production code affected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
- [ ] Any update to `xenon/libxenon-src` is accompanied by a reference to the specific commit in the git changelog
