### PR TITLE
Fix test-cross-riscv64-wolfssl Flaky Tests

### DIFF
--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -770,9 +770,12 @@ async fn expresslane_health_probe(
         (el_state, degraded_at, reflected)
     };
 
-    let (_, result) = tokio::time::timeout(std::time::Duration::from_secs(15), async move {
-        tokio::join!(server_task, client_task)
-    })
+    // Emulated targets requires much more time to run this,
+    // sometimes >15s. So we use the platform-aware base timeout, scaled up.
+    let (_, result) = tokio::time::timeout(
+        std::time::Duration::from_millis(get_test_timeout() * 8),
+        async move { tokio::join!(server_task, client_task) },
+    )
     .await
     .expect("expresslane health probe timed out");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Increased the timeout in `async fn expresslane_health_probe` beyond the original 15s, to the global platform-aware test timeout scaled up.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Measured the actual test run usage, sometimes the tests took >16 seconds to finish, causing flaky tests. 15 seconds is too little on Emulated targets like ARM or RISC-V. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
CI passing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] The correct base branch is being used, if not `main`
