### PR TITLE
boring: Expose per-session SslVerifyMode settings

### DIFF
--- a/lightway-boring/src/config.rs
+++ b/lightway-boring/src/config.rs
@@ -4,7 +4,7 @@
 //! DTLS MTU, domain name verification, SNI, and post-quantum key share group
 //! preferences.
 
-use super::CurveGroup;
+use super::{CurveGroup, SslVerifyMode};
 
 /// Configuration for creating a session
 pub struct SessionConfig<IOCB> {
@@ -23,6 +23,9 @@ pub struct SessionConfig<IOCB> {
     /// or classical groups, which negotiate normally through the
     /// supported_groups extension.
     pub keyshare_group: Option<CurveGroup>,
+    /// Per-session certificate verification mode. When set, overrides the
+    /// context-level mode for this session via `SSL_set_verify`.
+    pub ssl_verify_mode: Option<SslVerifyMode>,
 }
 
 impl<IOCB> SessionConfig<IOCB> {
@@ -34,6 +37,7 @@ impl<IOCB> SessionConfig<IOCB> {
             checked_domain_name: None,
             server_name_indication: None,
             keyshare_group: None,
+            ssl_verify_mode: None,
         }
     }
 
@@ -82,6 +86,12 @@ impl<IOCB> SessionConfig<IOCB> {
     /// classical groups are a no-op here; they negotiate via `supported_groups`.
     pub fn with_keyshare_group(mut self, group: CurveGroup) -> Self {
         self.keyshare_group = Some(group);
+        self
+    }
+
+    /// Set the certificate verification mode for this session.
+    pub fn with_ssl_verify_mode(mut self, mode: SslVerifyMode) -> Self {
+        self.ssl_verify_mode = Some(mode);
         self
     }
 
@@ -135,6 +145,20 @@ mod tests {
         let config = SessionConfig::new(mock_io).with_keyshare_group(CurveGroup::X25519MLKEM768);
 
         assert_eq!(config.keyshare_group, Some(CurveGroup::X25519MLKEM768));
+    }
+
+    #[test]
+    fn test_session_config_ssl_verify_mode() {
+        let mock_io = MockIOAdapter::new();
+
+        let config = SessionConfig::new(mock_io);
+        assert!(config.ssl_verify_mode.is_none());
+
+        let config = config.with_ssl_verify_mode(SslVerifyMode::SslVerifyNone);
+        assert!(matches!(
+            config.ssl_verify_mode,
+            Some(SslVerifyMode::SslVerifyNone)
+        ));
     }
 
     #[test]

--- a/lightway-boring/src/context.rs
+++ b/lightway-boring/src/context.rs
@@ -14,10 +14,10 @@ use crate::error::Result;
 #[cfg(feature = "debug")]
 use crate::debug::Tls13SecretCallbacksArg;
 
-use super::{CurveGroup, IOCallbacks, Method, RootCertificate, Secret, TlsError};
+use super::{CurveGroup, IOCallbacks, Method, RootCertificate, Secret, SslVerifyMode, TlsError};
 use boring::error::ErrorStack;
 use boring::pkey::PKey;
-use boring::ssl::{SslContext, SslContextBuilder, SslMethod, SslVerifyMode, SslVersion};
+use boring::ssl::{SslContext, SslContextBuilder, SslMethod, SslVersion};
 use boring::x509::X509;
 use boring::x509::store::X509StoreBuilder;
 use zeroize::Zeroizing;
@@ -47,8 +47,11 @@ impl ContextBuilder {
         }
         .map_err(|e| NewContextBuilderError(e.to_string()))?;
 
+        // BoringSSL defaults to SSL_VERIFY_NONE everywhere; wolfSSL clients
+        // verify the server certificate by default. Match wolfSSL here.
+        // Currently this could be overridden by per-session config.
         if method.is_client() {
-            builder.set_verify(SslVerifyMode::PEER);
+            builder.set_verify(SslVerifyMode::SslVerifyPeer.into());
         }
 
         // Pin the context to the requested protocol version

--- a/lightway-boring/src/lib.rs
+++ b/lightway-boring/src/lib.rs
@@ -38,6 +38,7 @@ pub use error::{Error, ErrorKind, NewContextBuilderError, NewSessionError, TlsEr
 pub use session::Session;
 pub use types::{
     CurveGroup, IOCallbackResult, IOCallbacks, Method, Poll, PollResult, ProtocolVersion,
+    SslVerifyMode,
 };
 
 #[cfg(feature = "debug")]

--- a/lightway-boring/src/session.rs
+++ b/lightway-boring/src/session.rs
@@ -132,6 +132,12 @@ where
             ssl.set_hostname(sni)?;
         }
 
+        // Per-session verify mode overrides the context-level SSL_CTX_set_verify,
+        // matching wolfssl's wolfSSL_set_verify behavior. No verify callback.
+        if let Some(mode) = config.ssl_verify_mode {
+            ssl.set_verify(mode.into());
+        }
+
         // Configure key share group if specified
         if let Some(group) = config.keyshare_group {
             let group_id = group.to_ssl_group()?;
@@ -291,6 +297,11 @@ where
     /// Get mutable reference to the I/O adapter
     pub fn io_cb_mut(&mut self) -> &mut IOCB {
         &mut self.ssl_stream.get_mut().io
+    }
+
+    /// Sets verification method for remote peers via `SSL_set_verify`.
+    pub fn set_verify(&mut self, mode: super::SslVerifyMode) {
+        self.ssl_stream.ssl_mut().set_verify(mode.into());
     }
 
     /// Get current cipher name

--- a/lightway-boring/src/types.rs
+++ b/lightway-boring/src/types.rs
@@ -91,6 +91,26 @@ impl CurveGroup {
     }
 }
 
+/// SSL verification mode.
+#[derive(Debug, Default, Copy, Clone)]
+pub enum SslVerifyMode {
+    /// No verification done
+    /// Note: Unlike WolfSSL, BoringSSL still verifies the cert under this mode, it just doesn't abort the connection. `verify_result()` still stores the verification result.
+    SslVerifyNone,
+    /// Verify peers certificate
+    #[default]
+    SslVerifyPeer,
+}
+
+impl From<SslVerifyMode> for boring::ssl::SslVerifyMode {
+    fn from(value: SslVerifyMode) -> Self {
+        match value {
+            SslVerifyMode::SslVerifyNone => boring::ssl::SslVerifyMode::NONE,
+            SslVerifyMode::SslVerifyPeer => boring::ssl::SslVerifyMode::PEER,
+        }
+    }
+}
+
 /// Protocol version
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProtocolVersion {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Expose the `with_ssl_verify_mode` settings in `SessionConfig<IOCB>` on BoringSSL backend. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Provide more settings per-session in downstream users.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
CI passing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] The correct base branch is being used, if not `main`
