### PR TITLE
client: Re-pin server route on every network change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ repository = "https://github.com/expressvpn/lightway"
 edition = "2024"
 authors = ["lightway-developers@expressvpn.com"]
 license = "AGPL-3.0-only"
-rust-version = "1.91.0"
+rust-version = "1.95.0"
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -856,7 +856,8 @@ async fn handle_network_change<ExtAppState: Send + Sync>(
 /// nudge the connection-level network-change handler. On Apple platforms the
 /// nudge also fires when the server route was actually replaced (Datagram
 /// wiring only). Failed route refreshes retry from inside the select! loop so
-/// fresh wake-ups are never blocked; a fresh event restarts the retry budget.
+/// fresh wake-ups are never blocked, and a fresh event inherits the retry it
+/// supersedes, so consecutive failures keep backing off rather than resetting.
 /// Owns the [`RouteUpdater`], so aborting the task removes the installed routes.
 #[cfg(desktop)]
 async fn network_event_coordinator(
@@ -914,12 +915,11 @@ async fn network_event_coordinator(
                 if route_repin_state.is_some() => None,
         };
 
-        // A fresh event restarts the retry clock but keeps any nudge owed
-        // from the interrupted retry.
+        // A fresh event serves immediately but inherits the superseded retry's
+        // owed nudge, failure clock and back-off position, so a re-pin that
+        // keeps failing keeps escalating across events.
         let mut state = match event {
-            Some(nudge) => {
-                RepinState::new(nudge || route_repin_state.take().is_some_and(|p| p.nudge))
-            }
+            Some(nudge) => RepinState::for_event(nudge, route_repin_state.take()),
             None => route_repin_state.take().expect("branch guarded on is_some"),
         };
 

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -925,10 +925,20 @@ async fn network_event_coordinator(
 
         match route_updater.check_and_update_server_route().await {
             Err(e) => {
-                route_updater.on_repin_failure(&mut state, &e);
-                // Reconnect and nudge wait for the terminal outcome.
-                route_repin_state = Some(state);
-                continue;
+                match &e {
+                    route_manager::RoutingTableError::ServerRouteAddFailed(_) => {
+                        tracing::error!(
+                            "Fatal error updating server route: {e}. Shutting down VPN."
+                        );
+                        break;
+                    }
+                    _ => {
+                        route_updater.on_repin_failure(&mut state, &e);
+                        // Reconnect and nudge wait for the terminal outcome.
+                        route_repin_state = Some(state);
+                        continue;
+                    }
+                }
             }
             // A replaced server route is ground truth that the path to the
             // server moved; probe it so the session floats promptly.

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -42,7 +42,7 @@ use crate::debug::WiresharkKeyLogger;
 use crate::dns_manager::{DnsConfigMode, DnsManager, DnsManagerError, DnsSetup};
 use crate::keepalive::Config as KeepaliveConfig;
 #[cfg(desktop)]
-use crate::route_manager::{RouteManager, RouteMode, RouteUpdater};
+use crate::route_manager::{RepinState, RouteManager, RouteMode, RouteUpdater};
 #[cfg(batch_receive)]
 use lightway_core::MAX_IO_BATCH_SIZE;
 pub use lightway_core::{
@@ -855,8 +855,9 @@ async fn handle_network_change<ExtAppState: Send + Sync>(
 /// socket (Apple platforms) and, when the wake-up represents a network transition,
 /// nudge the connection-level network-change handler. On Apple platforms the
 /// nudge also fires when the server route was actually replaced (Datagram
-/// wiring only). Owns the [`RouteUpdater`], so aborting the task removes the
-/// installed routes.
+/// wiring only). Failed route refreshes retry from inside the select! loop so
+/// fresh wake-ups are never blocked; a fresh event restarts the retry budget.
+/// Owns the [`RouteUpdater`], so aborting the task removes the installed routes.
 #[cfg(desktop)]
 async fn network_event_coordinator(
     mut route_updater: RouteUpdater,
@@ -868,15 +869,17 @@ async fn network_event_coordinator(
     network_change_signal: mpsc::Sender<()>,
 ) {
     tracing::info!("Reacting to network change events...");
-    loop {
-        let mut nudge = nudge_on_route_event;
+    let mut route_repin_state: Option<RepinState> = None;
 
-        tokio::select! {
+    loop {
+        // `Some(nudge)` is a fresh network event; `None` is a retry tick.
+        let event = tokio::select! {
             changed = route_rx.changed() => {
                 if changed.is_err() {
                     // Wake source gone; dropping the updater clears routes.
                     break;
                 }
+                let mut nudge = nudge_on_route_event;
                 // Fold a transition that fired alongside the route event into
                 // this iteration instead of waking a second time.
                 if let Some(rx) = transition_rx.as_mut()
@@ -885,6 +888,7 @@ async fn network_event_coordinator(
                     rx.mark_unchanged();
                     nudge = true;
                 }
+                Some(nudge)
             }
             changed = async {
                 match transition_rx.as_mut() {
@@ -897,22 +901,40 @@ async fn network_event_coordinator(
                     transition_rx = None;
                     continue;
                 }
-                nudge = true;
                 // A transition can complete on the address leg alone; consume
                 // any simultaneous route event so the pair is one iteration.
                 if route_rx.has_changed().unwrap_or(false) {
                     route_rx.mark_unchanged();
                 }
+                Some(true)
             }
-        }
+            // The deadline is absolute, so recreating the sleep future each
+            // iteration is fine.
+            _ = async { tokio::time::sleep_until(route_repin_state.as_ref().unwrap().next_at).await },
+                if route_repin_state.is_some() => None,
+        };
+
+        // A fresh event restarts the retry clock but keeps any nudge owed
+        // from the interrupted retry.
+        let mut state = match event {
+            Some(nudge) => {
+                RepinState::new(nudge || route_repin_state.take().is_some_and(|p| p.nudge))
+            }
+            None => route_repin_state.take().expect("branch guarded on is_some"),
+        };
 
         match route_updater.check_and_update_server_route().await {
+            Err(e) => {
+                route_updater.on_repin_failure(&mut state, &e);
+                // Reconnect and nudge wait for the terminal outcome.
+                route_repin_state = Some(state);
+                continue;
+            }
             // A replaced server route is ground truth that the path to the
             // server moved; probe it so the session floats promptly.
             #[cfg(apple)]
-            Ok(true) if nudge_on_route_update => nudge = true,
+            Ok(true) if nudge_on_route_update => state.nudge = true,
             Ok(_) => {}
-            Err(e) => tracing::warn!("Updating server route failed: {:?}", e),
         }
 
         // The connected outside socket pins the route resolved at connect()
@@ -922,7 +944,9 @@ async fn network_event_coordinator(
             io.reconnect();
         }
 
-        if nudge && let Err(e) = network_change_signal.send(()).await {
+        if state.nudge
+            && let Err(e) = network_change_signal.send(()).await
+        {
             tracing::error!("Failed to send network_change_signal: {e}");
         }
     }

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -200,7 +200,7 @@ impl RouteUpdater {
     /// Delegate a failed re-pin to the mode handler, which updates the retry
     /// deadline on `state` and logs at the appropriate level.
     pub fn on_repin_failure(&self, state: &mut RepinState, error: &RoutingTableError) {
-        self.inner.repin_mode.on_failure(state, error);
+        RepinMode::on_failure(state, error);
     }
 }
 

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -577,6 +577,10 @@ impl RouteManagerInner {
                 tracing::info!("Updated server route for network change");
                 return Ok(true);
             }
+        } else {
+            warn!("Server route missing - reinstalling with {current_route:}");
+            self.add_route_server(current_route).await?;
+            return Ok(true);
         }
 
         Ok(false)

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -543,47 +543,46 @@ impl RouteManagerInner {
             let route_changed =
                 server_gateway != current_gateway || server_if_index != current_if_index;
 
-            if self.repin_mode.needs_repin(route_changed) {
-                if route_changed {
-                    tracing::debug!(
-                        "Default route changed - old (interface, gateway): ({:?}, {:?}), new (interface, gateway): ({:?}, {:?})",
-                        server_gateway,
-                        server_if_index,
-                        current_gateway,
-                        current_if_index
-                    );
-                } else {
-                    tracing::debug!(
-                        "Re-pinning server route with unchanged (interface, gateway): ({:?}, {:?})",
-                        current_if_index,
-                        current_gateway
-                    );
-                }
-
-                // Create new route with current gateway and interface
-                let prefix = host_prefix_len(&self.server_ip);
-                let mut new_server_route = Route::new(self.server_ip, prefix);
-                if let Some(if_index) = current_if_index {
-                    new_server_route = new_server_route.with_if_index(if_index);
-                }
-                if let Some(gateway) = current_gateway {
-                    new_server_route = new_server_route.with_gateway(gateway);
-                }
-                #[cfg(windows)]
-                let new_server_route = new_server_route.with_metric(0);
-
-                self.update_server_route(new_server_route).await?;
-
-                tracing::info!("Updated server route for network change");
-                return Ok(true);
+            if !self.repin_mode.needs_repin(route_changed) {
+                return Ok(false);
             }
+
+            if route_changed {
+                tracing::debug!(
+                    "Default route changed - old (interface, gateway): ({:?}, {:?}), new (interface, gateway): ({:?}, {:?})",
+                    server_gateway,
+                    server_if_index,
+                    current_gateway,
+                    current_if_index
+                );
+            } else {
+                tracing::debug!(
+                    "Re-pinning server route with unchanged (interface, gateway): ({:?}, {:?})",
+                    current_if_index,
+                    current_gateway
+                );
+            }
+
+            // Create new route with current gateway and interface
+            let prefix = host_prefix_len(&self.server_ip);
+            let mut new_server_route = Route::new(self.server_ip, prefix);
+            if let Some(if_index) = current_if_index {
+                new_server_route = new_server_route.with_if_index(if_index);
+            }
+            if let Some(gateway) = current_gateway {
+                new_server_route = new_server_route.with_gateway(gateway);
+            }
+            #[cfg(windows)]
+            let new_server_route = new_server_route.with_metric(0);
+
+            self.update_server_route(new_server_route).await?;
+
+            tracing::info!("Updated server route for network change");
         } else {
             warn!("Server route missing - reinstalling with {current_route:}");
             self.add_route_server(current_route).await?;
-            return Ok(true);
         }
-
-        Ok(false)
+        Ok(true)
     }
 }
 

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -77,6 +77,8 @@ pub enum RoutingTableError {
     AsyncRoutingManagerError(std::io::Error),
     #[error("Failed to Add {0}: {1}")]
     AddRouteError(Route, std::io::Error),
+    #[error("Failed to add server route (fatal): {0}")]
+    ServerRouteAddFailed(std::io::Error),
     #[error("Default interface not found: {0}")]
     DefaultInterfaceNotFound(std::io::Error),
     #[error("Default route not found")]
@@ -409,17 +411,20 @@ impl RouteManagerInner {
         Ok(())
     }
 
-    /// Updates the server route by adding the new one first, then deleting the old
-    /// This ensures we never leave the server route missing if the operation is interrupted
+    /// Updates the server route by deleting the old route first, then adding the new one.
+    /// Returns ServerRouteAddFailed if adding the new route fails (fatal error that stops the VPN).
+    /// This ensures we never leave the server route in an inconsistent state.
     async fn update_server_route(&mut self, new_route: Route) -> Result<(), RoutingTableError> {
-        self.add_route(&new_route).await?;
-
-        if let Some(old_route) = self.server_route.clone() {
-            if old_route != new_route {
-                let _ = self.route_manager_async.delete(&old_route).await;
-            }
+        if let Some(old_route) = self.server_route.clone()
+            && self.route_manager_async.delete(&old_route).await.is_ok()
+        {
+            self.server_route = None;
         }
-
+        self.add_route(&new_route).await.map_err(|e| {
+            RoutingTableError::ServerRouteAddFailed(std::io::Error::other(format!(
+                "Server route add failed: {e:?}"
+            )))
+        })?;
         self.server_route = Some(new_route);
         Ok(())
     }

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -409,6 +409,21 @@ impl RouteManagerInner {
         Ok(())
     }
 
+    /// Updates the server route by adding the new one first, then deleting the old
+    /// This ensures we never leave the server route missing if the operation is interrupted
+    async fn update_server_route(&mut self, new_route: Route) -> Result<(), RoutingTableError> {
+        self.add_route(&new_route).await?;
+
+        if let Some(old_route) = self.server_route.clone() {
+            if old_route != new_route {
+                let _ = self.route_manager_async.delete(&old_route).await;
+            }
+        }
+
+        self.server_route = Some(new_route);
+        Ok(())
+    }
+
     /// Adds LAN Route and stores it
     async fn add_route_lan(&mut self, route: Route) -> Result<(), RoutingTableError> {
         self.add_route(&route).await?;
@@ -545,13 +560,7 @@ impl RouteManagerInner {
                     );
                 }
 
-                // Update server route with new gateway/interface
-                if let Some(old_route) = self.server_route.take() {
-                    // Remove old route
-                    let _ = self.route_manager_async.delete(&old_route).await;
-                }
-
-                // Add new route with current gateway and interface
+                // Create new route with current gateway and interface
                 let prefix = host_prefix_len(&self.server_ip);
                 let mut new_server_route = Route::new(self.server_ip, prefix);
                 if let Some(if_index) = current_if_index {
@@ -563,7 +572,7 @@ impl RouteManagerInner {
                 #[cfg(windows)]
                 let new_server_route = new_server_route.with_metric(0);
 
-                self.add_route_server(new_server_route).await?;
+                self.update_server_route(new_server_route).await?;
 
                 tracing::info!("Updated server route for network change");
                 return Ok(true);

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -13,6 +13,9 @@ use windows_sys::Win32::Foundation::ERROR_OBJECT_ALREADY_EXISTS;
 #[cfg(windows)]
 use crate::platform::windows::utils;
 
+pub mod repin;
+pub use repin::{RepinMode, RepinState};
+
 // LAN networks for RouteMode::Lan
 const LAN_NETWORKS: [(IpAddr, u8); 5] = [
     (
@@ -126,6 +129,7 @@ struct RouteManagerInner {
     vpn_routes: Vec<Route>,
     lan_routes: Vec<Route>,
     server_route: Option<Route>,
+    repin_mode: RepinMode,
 }
 
 impl RouteManager {
@@ -192,6 +196,12 @@ impl RouteUpdater {
         }
         self.inner.check_and_update_server_route().await
     }
+
+    /// Delegate a failed re-pin to the mode handler, which updates the retry
+    /// deadline on `state` and logs at the appropriate level.
+    pub fn on_repin_failure(&self, state: &mut RepinState, error: &RoutingTableError) {
+        self.inner.repin_mode.on_failure(state, error);
+    }
 }
 
 impl RouteManagerInner {
@@ -217,6 +227,10 @@ impl RouteManagerInner {
             vpn_routes: Vec::with_capacity(TUNNEL_ROUTES.len() + 1),
             lan_routes: Vec::with_capacity(LAN_NETWORKS.len()),
             server_route: None,
+            repin_mode: cfg_select! {
+                apple => { RepinMode::Always }
+                _ =>     { RepinMode::OnRouteChange }
+            },
         })
     }
 
@@ -511,14 +525,25 @@ impl RouteManagerInner {
             let server_if_index = server_route.if_index();
 
             // Check if the route to the server has changed
-            if server_gateway != current_gateway || server_if_index != current_if_index {
-                tracing::debug!(
-                    "Default route changed - old (interface, gateway): ({:?}, {:?}), new (interface, gateway): ({:?}, {:?})",
-                    server_gateway,
-                    server_if_index,
-                    current_gateway,
-                    current_if_index
-                );
+            let route_changed =
+                server_gateway != current_gateway || server_if_index != current_if_index;
+
+            if self.repin_mode.needs_repin(route_changed) {
+                if route_changed {
+                    tracing::debug!(
+                        "Default route changed - old (interface, gateway): ({:?}, {:?}), new (interface, gateway): ({:?}, {:?})",
+                        server_gateway,
+                        server_if_index,
+                        current_gateway,
+                        current_if_index
+                    );
+                } else {
+                    tracing::debug!(
+                        "Re-pinning server route with unchanged (interface, gateway): ({:?}, {:?})",
+                        current_if_index,
+                        current_gateway
+                    );
+                }
 
                 // Update server route with new gateway/interface
                 if let Some(old_route) = self.server_route.take() {
@@ -1079,9 +1104,12 @@ mod tests {
         assert!(inner.server_route.is_some());
         let initial_server_route = inner.server_route.as_ref().unwrap().clone();
 
-        // Test check_and_update_server_route when no change is needed
+        // Test check_and_update_server_route when no change is needed but repin in MacOS
         let result = inner.check_and_update_server_route().await;
-        assert!(matches!(result, Ok(false)));
+        cfg_select! {
+            macos => { assert!(matches!(result, Ok(true))); }
+            _ =>     { assert!(matches!(result, Ok(false))); }
+        }
 
         // Server route should remain unchanged
         assert!(inner.server_route.is_some());
@@ -1202,9 +1230,12 @@ mod tests {
         assert_eq!(initial_server_route.destination(), EXTERNAL_IP_V6);
         assert_eq!(initial_server_route.prefix(), Ipv6Addr::BITS as u8);
 
-        // Test check_and_update_server_route when no change is needed
+        // Test check_and_update_server_route when no change is needed but repin in MacOS
         let result = inner.check_and_update_server_route().await;
-        assert!(matches!(result, Ok(false)));
+        cfg_select! {
+            macos => { assert!(matches!(result, Ok(true))); }
+            _ =>     { assert!(matches!(result, Ok(false))); }
+        }
 
         // Server route should remain unchanged
         assert!(inner.server_route.is_some());

--- a/lightway-client/src/route_manager/repin.rs
+++ b/lightway-client/src/route_manager/repin.rs
@@ -41,36 +41,28 @@ impl RepinMode {
         }
     }
 
-    pub fn on_failure(&self, state: &mut RepinState, error: &RoutingTableError) {
-        match self {
-            RepinMode::OnRouteChange => {
-                tracing::warn!("Server route update failed: {error:?}");
-                state.next_at = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
-            }
-            RepinMode::Always => {
-                const MIN_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
-                const LONG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+    pub fn on_failure(state: &mut RepinState, error: &RoutingTableError) {
+        const MIN_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+        const LONG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
 
-                let next_interval = if state.retry_count > 4 {
-                    // more than 15.5s
-                    tracing::error!(
-                        "Server route update failed ({error:?}) in {:}, retrying",
-                        state.elapsed_since_start().as_secs()
-                    );
-                    LONG_INTERVAL
-                } else {
-                    let exponential =
-                        MIN_INTERVAL.as_millis() as u64 * 2_u64.saturating_pow(state.retry_count);
-                    tracing::debug!(
-                        "Server route update failed ({error:?}) in {:}, retrying",
-                        state.elapsed_since_start().as_secs()
-                    );
-                    std::time::Duration::from_millis(exponential)
-                };
+        let next_interval = if state.retry_count > 4 {
+            // more than 15.5s
+            tracing::error!(
+                "Server route update failed ({error:?}) in {:}, retrying",
+                state.elapsed_since_start().as_secs()
+            );
+            LONG_INTERVAL
+        } else {
+            let exponential =
+                MIN_INTERVAL.as_millis() as u64 * 2_u64.saturating_pow(state.retry_count);
+            tracing::debug!(
+                "Server route update failed ({error:?}) in {:}, retrying",
+                state.elapsed_since_start().as_secs()
+            );
+            std::time::Duration::from_millis(exponential)
+        };
 
-                state.retry_count = state.retry_count.saturating_add(1);
-                state.next_at = tokio::time::Instant::now() + next_interval;
-            }
-        }
+        state.retry_count = state.retry_count.saturating_add(1);
+        state.next_at = tokio::time::Instant::now() + next_interval;
     }
 }

--- a/lightway-client/src/route_manager/repin.rs
+++ b/lightway-client/src/route_manager/repin.rs
@@ -1,0 +1,76 @@
+use super::RoutingTableError;
+
+/// Retry state carried across select! iterations while a re-pin is pending.
+pub struct RepinState {
+    started_at: tokio::time::Instant,
+    pub next_at: tokio::time::Instant,
+    pub nudge: bool,
+    retry_count: u32,
+}
+
+impl RepinState {
+    pub fn new(nudge: bool) -> Self {
+        let now = tokio::time::Instant::now();
+        Self {
+            started_at: now,
+            next_at: now,
+            nudge,
+            retry_count: 0,
+        }
+    }
+
+    pub fn elapsed_since_start(&self) -> std::time::Duration {
+        self.started_at.elapsed()
+    }
+}
+
+pub enum RepinMode {
+    /// Only re-pin when the gateway or interface index actually changed.
+    OnRouteChange,
+    /// Always re-pin on every network event — handles within-subnet roaming on
+    /// Apple platforms where routing identifiers are identical but the physical
+    /// path has changed and the outside socket needs rebinding.
+    Always,
+}
+
+impl RepinMode {
+    pub fn needs_repin(&self, route_changed: bool) -> bool {
+        match self {
+            RepinMode::OnRouteChange => route_changed,
+            RepinMode::Always => true,
+        }
+    }
+
+    pub fn on_failure(&self, state: &mut RepinState, error: &RoutingTableError) {
+        match self {
+            RepinMode::OnRouteChange => {
+                tracing::warn!("Server route update failed: {error:?}");
+                state.next_at = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
+            }
+            RepinMode::Always => {
+                const MIN_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+                const LONG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+
+                let next_interval = if state.retry_count > 4 {
+                    // more than 15.5s
+                    tracing::error!(
+                        "Server route update failed ({error:?}) in {:}, retrying",
+                        state.elapsed_since_start().as_secs()
+                    );
+                    LONG_INTERVAL
+                } else {
+                    let exponential =
+                        MIN_INTERVAL.as_millis() as u64 * 2_u64.saturating_pow(state.retry_count);
+                    tracing::debug!(
+                        "Server route update failed ({error:?}) in {:}, retrying",
+                        state.elapsed_since_start().as_secs()
+                    );
+                    std::time::Duration::from_millis(exponential)
+                };
+
+                state.retry_count = state.retry_count.saturating_add(1);
+                state.next_at = tokio::time::Instant::now() + next_interval;
+            }
+        }
+    }
+}

--- a/lightway-client/src/route_manager/repin.rs
+++ b/lightway-client/src/route_manager/repin.rs
@@ -9,13 +9,23 @@ pub struct RepinState {
 }
 
 impl RepinState {
-    pub fn new(nudge: bool) -> Self {
-        let now = tokio::time::Instant::now();
-        Self {
-            started_at: now,
-            next_at: now,
-            nudge,
-            retry_count: 0,
+    /// State for a fresh network event, or superseding `pending`, if any.
+    pub fn for_event(nudge: bool, pending: Option<RepinState>) -> Self {
+        if let Some(pending) = pending {
+            Self {
+                started_at: pending.started_at,
+                nudge: nudge || pending.nudge,
+                next_at: pending.next_at,
+                retry_count: pending.retry_count,
+            }
+        } else {
+            let now = tokio::time::Instant::now();
+            Self {
+                started_at: now,
+                nudge,
+                next_at: now,
+                retry_count: 0,
+            }
         }
     }
 


### PR DESCRIPTION
## Description

This PR improves the server route management and re-pinning logic in the lightway client. The changes refactor the route update process, consolidate duplicate retry logic, and implement more robust re-pinning behavior on network changes.
Ticket: CVPN-2731

### Key Changes:

1. **Route Update Consolidation**: Extract duplicate route deletion and addition logic into a `update_server_route()` helper method to reduce code duplication and prevent potential inconsistency bugs.

2. **Unified Retry Logic**: Previously, exponential back-off retry logic was only applied under `RepinMode::Always` on Apple targets, while `RepinMode::OnRouteChange` used simpler 1s fixed retry with warning-level logs. Both modes now share consistent retry behavior with log-level escalation.

3. **In-Loop Retry for Re-pins**: On Apple platforms, re-pin the server route unconditionally on every network event. Failed re-pins are retried from inside the `network_event_coordinator` select! loop with exponential back-off (500ms → 1s → 2s → 4s → 8s → 10s), allowing the loop to continue servicing other events while retry deadlines are pending.

4. **RepinMode Abstraction**: Introduce `RepinMode` and `RepinState` to `route_manager/repin.rs` with a single variant (`OnRouteChange`) that re-pins only when gateway or interface index actually changed. Wire `repin_mode` into `RouteManagerInner` and delegate the update decision to `repin_mode.needs_repin()`.

5. **MSRV Bump**: Bump Minimum Supported Rust Version to 1.95.0 for `cfg_select!` support.

## Motivation and Context

These changes improve resilience to within-subnet roaming scenarios on macOS where routing identifiers are identical but the physical network path has changed. By reliably re-pinning the outside socket on every network transition and properly retrying failed attempts, the client can handle seamless roaming without connection drops.

## How Has This Been Tested?
- Follow current testcase

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
