### PR TITLE
client: log route error with route info

### DIFF
--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -72,8 +72,8 @@ pub enum RouteMode {
 pub enum RoutingTableError {
     #[error("AsyncRoutingManager error {0}")]
     AsyncRoutingManagerError(std::io::Error),
-    #[error("Failed to Add Route {0}")]
-    AddRouteError(std::io::Error),
+    #[error("Failed to Add {0}: {1}")]
+    AddRouteError(Route, std::io::Error),
     #[error("Default interface not found: {0}")]
     DefaultInterfaceNotFound(std::io::Error),
     #[error("Default route not found")]
@@ -362,7 +362,7 @@ impl RouteManagerInner {
                 } else if e.kind() == std::io::ErrorKind::PermissionDenied {
                     Err(RoutingTableError::InsufficientPermissions)
                 } else {
-                    Err(RoutingTableError::AddRouteError(e))
+                    Err(RoutingTableError::AddRouteError(route.clone(), e))
                 }
             }
         }


### PR DESCRIPTION
## Description

Include the failing route in `AddRouteError` so that the error message emitted on a failed route addition names the specific route that could not be installed.

### Change details

- **`route_manager.rs`**: extends the `AddRouteError` variant from `AddRouteError(std::io::Error)` to `AddRouteError(Route, std::io::Error)`, and updates its `#[error(...)]` format string from `"Failed to Add Route {0}"` to `"Failed to Add {0}: {1}"`. The single call-site that constructs the variant now passes `route.clone()` alongside the underlying `io::Error`.
- The error message after changes
```log
2026-08-19T02:50:08.330253Z  INFO lightway_client::route_manager: Added Route { destination: 1.1.1.1/32, gateway: 10.4.20.1, if_index: 14, if_name: None }
2026-08-19T02:50:08.332138Z  INFO lightway_client::route_manager: Added Route { destination: 0.0.0.0/1, gateway: 10.125.0.1, if_index: 22, if_name: None }
2026-08-19T02:50:08.334094Z  INFO lightway_client::route_manager: Added Route { destination: 128.0.0.0/1, gateway: 10.125.0.1, if_index: 22, if_name: None }
Error: Failed to Add Route { destination: 10.125.0.1/32, gateway: 10.125.0.1, if_index: 22, if_name: None }: Can't assign requested address (os error 49)
```

## Motivation and Context

Previously a failed route addition produced an error such as `"Failed to Add Route: permission denied"` with no indication of *which* route was being added. Including the route in the error variant surfaces it in logs and error chains, making it much easier to diagnose routing failures — particularly when multiple routes are added concurrently or when the failing route is not otherwise obvious from context.
- The error message before changes
```log
2026-08-19T02:53:39.325653Z  INFO lightway_client::route_manager: Added Route { destination: 1.1.1.1/32, gateway: 10.4.20.1, if_index: 14, if_name: None }
2026-08-19T02:53:39.327627Z  INFO lightway_client::route_manager: Added Route { destination: 0.0.0.0/1, gateway: 10.125.0.1, if_index: 22, if_name: None }
2026-08-19T02:53:39.329482Z  INFO lightway_client::route_manager: Added Route { destination: 128.0.0.0/1, gateway: 10.125.0.1, if_index: 22, if_name: None }
Error: Failed to Add Route Can't assign requested address (os error 49)
```

## How Has This Been Tested?

- [x] follow current testcases

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (internal restructuring, no behaviour change for end users)
- [ ] CI / infrastructure change (no production code affected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
- [ ] Any update to `xenon/libxenon-src` is accompanied by a reference to the specific commit in the git changelog
