### PR TITLE
lightway-client: windows: modify wait timeout to 5 sec

### DIFF
--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -282,11 +282,17 @@ fn spawn_reload_event_handler(
     cli_patch: ConfigPatch,
 ) -> Option<mpsc::Receiver<ReloadableClientConfig>> {
     use windows_sys::Win32::{
-        Foundation::{CloseHandle, WAIT_OBJECT_0},
-        System::Threading::{CreateEventW, INFINITE, WaitForSingleObject},
+        Foundation::{CloseHandle, WAIT_OBJECT_0, WAIT_TIMEOUT},
+        System::Threading::{CreateEventW, WaitForSingleObject},
     };
 
     const EVENT_NAME: &str = "Global\\LightwayConfigReload";
+
+    // Bound the wait so a shutting-down runtime isn't stuck joining this blocking
+    // thread forever: dropping the Tokio runtime waits for any in-flight
+    // `spawn_blocking` call to return, and `WaitForSingleObject(..., INFINITE)`
+    // never would on its own.
+    const WAIT_TIMEOUT_MS: u32 = 5_000;
 
     let wide_name: Vec<u16> = EVENT_NAME
         .encode_utf16()
@@ -325,12 +331,13 @@ fn spawn_reload_event_handler(
             let h = send_handle;
             let wait_result = tokio::task::spawn_blocking(move || {
                 // SAFETY: handle was created above, is valid
-                unsafe { WaitForSingleObject(h.raw(), INFINITE) }
+                unsafe { WaitForSingleObject(h.raw(), WAIT_TIMEOUT_MS) }
             })
             .await;
 
             match wait_result {
                 Ok(WAIT_OBJECT_0) => {}
+                Ok(WAIT_TIMEOUT) => continue,
                 Ok(code) => {
                     tracing::error!("WaitForSingleObject returned unexpected code: {code}");
                     break;


### PR DESCRIPTION
## Description
Currently windows client wait indefinitely blocking for all process to terminate. However for some reason when the thread terminates, the waiting thread doesn't get the status update and the client hangs indefinitely.

We have modified this behaviour and we wait for 5 seconds and loop again. So if all threads are terminated by this time, we do not wait indefinitely


## How Has This Been Tested?
Tested locally on the windows vm

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
