### PR TITLE
[CVPN-2667] add option to set TUN interface txqueuelen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ tokio-stream = "0.1.14"
 tokio-util = "0.7.10"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
-tun-rs = { version = "2.8.5", features = ["async"] }
+tun-rs = { version = "2.8.8", features = ["async"] }
 windows-sys = "0.61.0"
 wolfssl = "7.4.0"
 uniffi = "0.26.1"

--- a/lightway-app-utils/src/tun.rs
+++ b/lightway-app-utils/src/tun.rs
@@ -54,6 +54,9 @@ pub struct TunConfig {
     /// device. Required for the GSO inside-IO path.
     #[cfg(target_os = "linux")]
     pub offload: bool,
+    /// Transmit queue length (txqueuelen) for the TUN interface.
+    #[cfg(target_os = "linux")]
+    pub tx_queue_len: Option<u32>,
     #[cfg(windows)]
     /// Optional wintun file path for Windows TUN interfaces
     pub wintun_file: Option<String>,
@@ -94,6 +97,11 @@ impl Debug for TunConfig {
         }
         #[cfg(unix)]
         s.field("close_fd_on_drop", &self.close_fd_on_drop);
+        #[cfg(linux)]
+        if let Some(txqueuelen) = self.tx_queue_len.as_ref() {
+            s.field("txqueuelen", txqueuelen);
+        }
+
         s.finish()
     }
 }
@@ -131,6 +139,13 @@ impl TunConfig {
     /// Set the MTU.
     pub fn mtu(&mut self, value: u16) -> &mut Self {
         self.mtu = Some(value);
+        self
+    }
+
+    /// Set the transmit queue length (txqueuelen) of the interface (Linux only).
+    #[cfg(target_os = "linux")]
+    pub fn tx_queue_len(&mut self, value: u32) -> &mut Self {
+        self.tx_queue_len = Some(value);
         self
     }
 
@@ -232,6 +247,10 @@ impl TunConfig {
             #[cfg(target_os = "linux")]
             if self.offload {
                 builder = builder.offload(true);
+            }
+            #[cfg(target_os = "linux")]
+            if let Some(tx_queue_len) = self.tx_queue_len {
+                builder = builder.tx_queue_len(tx_queue_len);
             }
             let device = builder.build_async()?;
 

--- a/lightway-client/src/config.rs
+++ b/lightway-client/src/config.rs
@@ -104,6 +104,13 @@ pub struct Config {
     #[patch(attribute(doc = "Tun device name to use"))]
     pub tun_name: Option<String>,
 
+    #[cfg(linux)]
+    #[patch(attribute(serde(default)))]
+    #[patch(attribute(clap(long)))]
+    #[patch(attribute(doc = "Transmit queue length (txqueuelen) of the Tun device"))]
+    #[schemars(extend("x-cfg" = "linux"))]
+    pub tun_txqueuelen: u32,
+
     #[cfg(windows)]
     #[patch(attribute(clap(long)))]
     #[patch(attribute(doc = "Path to wintun.dll file (Windows only)"))]
@@ -493,6 +500,16 @@ impl Config {
                 && self.wintun_ring_capacity <= ByteSize::mib(64),
             "wintun_ring_capacity must be a power of two between 128KiB and 64MiB"
         );
+        #[cfg(linux)]
+        {
+            anyhow::ensure!(self.tun_txqueuelen != 0, "tun_txqueuelen must not be 0");
+            if self.tun_txqueuelen < 1000 {
+                tracing::warn!(
+                    txqueuelen = self.tun_txqueuelen,
+                    "tun_txqueuelen is below the recommended minimum of 1000"
+                );
+            }
+        }
         Ok(())
     }
 }
@@ -516,6 +533,8 @@ impl Default for Config {
             tun_name: None,
             #[cfg(not(macos))]
             tun_name: Some("lightway".to_string()),
+            #[cfg(linux)]
+            tun_txqueuelen: 1000,
             #[cfg(windows)]
             wintun_file: None,
             #[cfg(windows)]
@@ -867,6 +886,26 @@ mod tests {
             "sndbuf is set but cannot be applied to this TCP connections"
         ));
         assert!(logs_contain("127.0.0.1:27690"));
+    }
+
+    #[cfg(linux)]
+    #[tracing_test::traced_test]
+    #[test]
+    fn validate_warns_on_low_tun_txqueuelen() {
+        let mut config = Config::default();
+        config.tun_txqueuelen = 500;
+        assert!(config.validate().is_ok());
+        assert!(logs_contain(
+            "tun_txqueuelen is below the recommended minimum of 1000"
+        ));
+    }
+
+    #[cfg(linux)]
+    #[test]
+    fn validate_rejects_zero_tun_txqueuelen() {
+        let mut config = Config::default();
+        config.tun_txqueuelen = 0;
+        assert!(config.validate().is_err());
     }
 
     #[cfg(not(macos))]

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -301,6 +301,9 @@ impl<ExtAppState: Send + Sync> ClientConfig<ExtAppState> {
             tun_config.tun_name(tun_name.clone());
         }
 
+        #[cfg(linux)]
+        tun_config.tx_queue_len(config.tun_txqueuelen);
+
         #[cfg(windows)]
         {
             if let Some(ref wintun_file) = config.wintun_file {

--- a/lightway-server/src/config.rs
+++ b/lightway-server/src/config.rs
@@ -51,6 +51,12 @@ pub struct Config {
     #[patch(attribute(doc = "Tun device name to use"))]
     pub tun_name: Option<String>,
 
+    #[cfg(linux)]
+    #[patch(attribute(serde(default)))]
+    #[patch(attribute(clap(long)))]
+    #[patch(attribute(doc = "Transmit queue length (txqueuelen) of the Tun device"))]
+    pub tun_txqueuelen: u32,
+
     #[patch(attribute(clap(long)))]
     #[patch(attribute(doc = "IP pool to assign clients"))]
     pub ip_pool: Ipv4Net,
@@ -208,6 +214,8 @@ impl Default for Config {
             server_cert: PathBuf::from("./server.crt"),
             server_key: PathBuf::from("./server.key"),
             tun_name: None,
+            #[cfg(linux)]
+            tun_txqueuelen: 1000,
             ip_pool: IP_POOL,
             ip_map: None,
             tun_ip: None,
@@ -280,6 +288,17 @@ impl Config {
             )
         }
 
+        #[cfg(linux)]
+        {
+            anyhow::ensure!(self.tun_txqueuelen != 0, "tun_txqueuelen must not be 0");
+            if self.tun_txqueuelen < 1000 {
+                tracing::warn!(
+                    txqueuelen = self.tun_txqueuelen,
+                    "tun_txqueuelen is below the recommended minimum of 1000"
+                );
+            }
+        }
+
         Ok(())
     }
 }
@@ -309,6 +328,26 @@ mod tests {
         let mut config = Config::default();
         config.mode = ConnectionType::Udp;
         config.proxy_protocol = true;
+        assert!(config.validate().is_err());
+    }
+
+    #[cfg(linux)]
+    #[tracing_test::traced_test]
+    #[test]
+    fn validate_warns_on_low_tun_txqueuelen() {
+        let mut config = Config::default();
+        config.tun_txqueuelen = 500;
+        assert!(config.validate().is_ok());
+        assert!(logs_contain(
+            "tun_txqueuelen is below the recommended minimum of 1000"
+        ));
+    }
+
+    #[cfg(linux)]
+    #[test]
+    fn validate_rejects_zero_tun_txqueuelen() {
+        let mut config = Config::default();
+        config.tun_txqueuelen = 0;
         assert!(config.validate().is_err());
     }
 

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -280,6 +280,8 @@ impl<SA: for<'a> ServerAuth<AuthState<'a>>> ServerConfig<SA> {
         if let Some(tun_name) = config.tun_name {
             tun_config.tun_name(tun_name);
         }
+        #[cfg(linux)]
+        tun_config.tx_queue_len(config.tun_txqueuelen);
         tun_config.up();
 
         Ok(crate::ServerConfig {


### PR DESCRIPTION
## Description
Set default txqueuelen to 1000.
Bump tun-rs version.

## Motivation and Context
We want to set default txqueuelen on linux tun interface to 1000 to prevent packet drops on high-throughput tunnels.

## How Has This Been Tested?
Checked that txqueuelen is set accordingly when specified and defaults to 1000 when not.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
