### PR TITLE
CVPN-2732 Charge tokio coop budget for manual-readiness UDP receives

### DIFF
--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -637,6 +637,22 @@ pub async fn outside_io_task<ExtAppState: Send + Sync>(
             .unwrap()
             .multiple_outside_data_received(pkts, |err| err.is_fatal(connection_type))?;
 
+        // The receives above go through tokio's manual readiness API
+        // (`ready()` + `try_io`-style receives), which charges no
+        // cooperative budget, so without this the loop's only yield is
+        // an empty socket: under sustained load it never parks and
+        // starves sibling tasks (notably the TUN reader) for the length
+        // of the backlog. Charge one unit per datagram received, as
+        // tokio's own charged IO paths would — the semantics proposed
+        // in <https://github.com/tokio-rs/tokio/issues/6237> —
+        // `consume_budget` yields only when the task's ~128-unit budget
+        // is exhausted, bounding a turn at ~128 datagrams' work for
+        // every transport that drives this loop. Runs after the conn
+        // lock is dropped. Delete if tokio ships #6237.
+        for _ in 0..count {
+            tokio::task::coop::consume_budget().await;
+        }
+
         for b in &mut bufs[..count] {
             b.clear();
             b.reserve(mtu);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The outside receive loop drives IO through tokio's manual readiness API (ready() + try_io), which charges no cooperative budget, so the task only yields to the scheduler when the socket empties. Under a speedtest when the socket is rarely empty, single-threaded runtime starves the TUN reader too long, and overflows the TUN txqueue with ACKs from the kernel, causing ACK loss and TCP retrans even when the packets arrived just fine.

Record one unit of budget debt per datagram received and pay it via tokio::task::coop::consume_budget() before the next readiness await, implementing the semantics proposed in tokio#6237 (operations consume budget without checking it; readiness enforces without consuming). The task now yields after at most ~128 datagrams' worth of receive work, like every budget-charged tokio IO path.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Testing found retransmissions and TUN drops in Android even without GRO features enabled.

There's a ticket and write-up on the issue when digging into the code: [CVPN-2732](https://polymoon.atlassian.net/browse/CVPN-2732) and [CVPN-2732 ticket note](https://polymoon.atlassian.net/wiki/x/RYBFHQE).

Also related: [CVPN-2667](https://polymoon.atlassian.net/browse/CVPN-2667) on increasing queue length to solve for drops.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On Android arm64 and x86_64, my read is that the TUN drops are gone with no throughput regressions. But the retransmits are still too noisy to draw conclusions.

**Android**
| 30 s cells, reps 2–4 | before | after |
|---|---|---|
| Receiver Mbit/s | 296.3 [286–307] | 296.0 [283–305] |
| Reader gaps ≥5 ms / 10 s | 856 [812–908] | **8.7 [1–13]** |
| Worst gap (ms) | 24.5 [21.4–27.4] | **8.6 [5.1–12.7]** |
| TUN `tx_dropped` (Σ 3 reps) | 8,049 (98–4,824/cell) | **0** |
| Sender retransmits | 107 [31–167] | 297 [27–698] |
| CPU (one core) | 53.3 % | 57.3 % |

Reader gaps ≥5 ms collapse ~100×, zero TUN drops in every cell now.

**x86_64**
| 12 s cells, reps 2–4 | before | after |
|---|---|---|
| iperf3 receiver Gbit/s | 2.177 [2.17–2.18] | 2.203 [2.19–2.22] |
| curl 4-stream Mbit/s | 2,202 [2,197–2,207] | 2,210 [2,207–2,216] |
| Retransmits (iperf3) | 831 [768–867] | 738 [643–897] |
| CPU (one core) | 76 % | 76.7 % |
| **Starved** gaps (≥128 writes inside) | 77.3 [73–84] | **33.0 [32–34]** |
| Starved time per 12 s | 4.00 s [3.77–4.29] | **1.91 s [1.43–2.50]** |
| Worst starved gap (ms) | 240 [231–257] | 253 [155–350] |
| Socket rxq peak | 1.05 MB | 2.12 MB |
| `RcvbufErrors` / `tx_drop` Δ | 0 / 0 | 0 / 0 |

Collapse not visible here, but starved time halves.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`


[CVPN-2732]: https://polymoon.atlassian.net/browse/CVPN-2732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ