### PR TITLE
client: pin outside socket egress on Windows via `IP_UNICAST_IF`

### DIFF
--- a/lightway-client/src/config.rs
+++ b/lightway-client/src/config.rs
@@ -233,6 +233,20 @@ pub struct Config {
     #[schemars(extend("x-cfg" = "linux"))]
     pub fwmark: u32,
 
+    #[cfg(windows)]
+    #[patch(attribute(clap(long)))]
+    #[patch(empty_value = false)]
+    #[patch(attribute(serde(default)))]
+    #[patch(
+        attribute(doc = r#"Disable pinning the outside socket's egress interface
+    via IP_UNICAST_IF / IPV6_UNICAST_IF.
+    Pinning is enabled by default to prevent the tunnel's own default route from
+    capturing outside traffic. Set this flag only when the platform routing policy
+    handles egress selection externally."#)
+    )]
+    #[schemars(extend("x-cfg" = "windows"))]
+    pub disable_pin_egress_interface: bool,
+
     #[cfg(desktop)]
     #[patch(attribute(clap(long, value_enum)))]
     #[patch(attribute(doc = r#"DNS configuration mode
@@ -558,6 +572,8 @@ impl Default for Config {
             route_mode: RouteMode::default(),
             #[cfg(linux)]
             fwmark: 0,
+            #[cfg(windows)]
+            disable_pin_egress_interface: false,
             #[cfg(desktop)]
             dns_config_mode: DnsConfigMode::default(),
             log_level: LogLevel::Info,

--- a/lightway-client/src/io/outside.rs
+++ b/lightway-client/src/io/outside.rs
@@ -80,6 +80,20 @@ pub trait OutsideIO: Sync + Send {
     #[cfg(apple)]
     fn reconnect(&self) {}
 
+    /// Re-pin the socket's egress interface after a network change.
+    ///
+    /// On Windows the outside socket is pinned with
+    /// `IP_UNICAST_IF`/`IPV6_UNICAST_IF` so that egress selection does not
+    /// depend on the routing table. A roam normally keeps the same interface
+    /// index, but switching adapters (Wi-Fi to Ethernet, docking) does not, so
+    /// the pin is refreshed from the interface of the freshly installed server
+    /// route. `if_index` of `0` means "unknown", and is ignored.
+    ///
+    /// Default is a no-op for transports that do not pin (TCP pins once,
+    /// before `connect`, after which the option has no effect).
+    #[cfg(windows)]
+    fn pin_egress_interface(&self, _if_index: u32) {}
+
     /// Returns the underlying socket tagged with its transport type.
     /// `None` when the transport has no single OS socket to name.
     fn socket(&self) -> Option<OutsideSocket>;

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -352,7 +352,7 @@ impl OutsideIO for Udp {
         }
     }
 
-    #[cfg(all(windows, not(feature = "mobile")))]
+    #[cfg(windows)]
     fn pin_egress_interface(&self, if_index: u32) {
         use std::os::windows::io::AsRawSocket;
 

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -7,6 +7,8 @@ use lightway_core::{IOCallbackResult, OutsideIOSendCallback, OutsideIOSendCallba
 use std::sync::OnceLock;
 #[cfg(apple)]
 use std::sync::atomic::AtomicBool;
+#[cfg(windows)]
+use std::sync::atomic::AtomicU32;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
@@ -41,6 +43,12 @@ pub struct Udp {
     /// instance.
     #[cfg(any(ios, tvos, all(test, apple)))]
     dead: AtomicBool,
+    /// Interface index this socket's egress is pinned to via
+    /// `IP_UNICAST_IF`/`IPV6_UNICAST_IF`, or `0` when unpinned. Re-applied on
+    /// every network change by [`OutsideIO::pin_egress_interface`]. Windows
+    /// only.
+    #[cfg(windows)]
+    pinned_if_index: AtomicU32,
     /// Consecutive swallowed send errors, reset by a successful send; see
     /// [`Udp::note_swallowed_send`].
     swallowed_sends: AtomicU64,
@@ -100,6 +108,8 @@ impl Udp {
             dead_socket_cb: OnceLock::new(),
             #[cfg(any(ios, tvos, all(test, apple)))]
             dead: AtomicBool::new(false),
+            #[cfg(windows)]
+            pinned_if_index: AtomicU32::new(0),
             swallowed_sends: AtomicU64::new(0),
             #[cfg(batch_receive)]
             batch_receive_enabled: false,
@@ -342,6 +352,35 @@ impl OutsideIO for Udp {
         }
     }
 
+    #[cfg(all(windows, not(feature = "mobile")))]
+    fn pin_egress_interface(&self, if_index: u32) {
+        use std::os::windows::io::AsRawSocket;
+
+        if if_index == 0 {
+            return;
+        }
+        let previous = self.pinned_if_index.load(Ordering::Relaxed);
+        if previous == if_index {
+            return;
+        }
+
+        match crate::platform::windows::egress::set_unicast_if(
+            self.sock.as_raw_socket(),
+            if_index,
+            self.peer_addr.is_ipv6(),
+        ) {
+            Ok(()) => {
+                self.pinned_if_index.store(if_index, Ordering::Relaxed);
+                tracing::info!(
+                    "Re-pinned outside UDP socket egress after network change: interface {previous} -> {if_index}"
+                );
+            }
+            Err(e) => tracing::warn!(
+                "Failed to re-pin outside UDP socket egress to interface {if_index}, keeping {previous}: {e}"
+            ),
+        }
+    }
+
     fn socket(&self) -> Option<OutsideSocket> {
         #[cfg(unix)]
         use std::os::fd::AsRawFd;
@@ -474,6 +513,27 @@ impl OutsideIOSendCallback for Udp {
                 {
                     cb();
                 }
+                self.note_swallowed_send(&err);
+                IOCallbackResult::Ok(buf.len())
+            }
+            #[cfg(windows)]
+            Err(err)
+                if matches!(
+                    err.kind(),
+                    std::io::ErrorKind::AddrNotAvailable | std::io::ErrorKind::HostUnreachable
+                ) =>
+            {
+                // A roam that changes the local address makes Windows fail
+                // sends with WSAEADDRNOTAVAIL (10049) or, once the routes
+                // pinned to the old address are torn down, WSAEHOSTUNREACH
+                // (10065). Both are transient: the socket is unconnected, so
+                // the next send re-selects a source address on the pinned
+                // interface, and DTLS retransmission covers the gap.
+                //
+                // Letting these reach wolfSSL is fatal in a way the network
+                // is not: the send callback error latches the session in
+                // error state (-308) and no later recovery can revive it.
+                // `keepalive_timeout` remains the liveness backstop.
                 self.note_swallowed_send(&err);
                 IOCallbackResult::Ok(buf.len())
             }

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -216,6 +216,13 @@ pub struct ClientConfig<ExtAppState: Send + Sync> {
     #[cfg(linux)]
     pub fwmark: u32,
 
+    /// Disable pinning the outside socket to the physical egress interface via
+    /// `IP_UNICAST_IF`/`IPV6_UNICAST_IF` (Windows desktop).
+    /// Pinning is on by default; set this to `true` only when external routing
+    /// policy handles egress selection.
+    #[cfg(windows)]
+    pub disable_pin_egress_interface: bool,
+
     /// DNS configuration mode
     #[cfg(desktop)]
     pub dns_config_mode: DnsConfigMode,
@@ -362,6 +369,8 @@ impl<ExtAppState: Send + Sync> ClientConfig<ExtAppState> {
             route_mode: config.route_mode,
             #[cfg(linux)]
             fwmark: config.fwmark,
+            #[cfg(windows)]
+            disable_pin_egress_interface: config.disable_pin_egress_interface,
             #[cfg(desktop)]
             dns_config_mode: config.dns_config_mode,
             enable_pmtud: config.enable_pmtud,
@@ -866,6 +875,7 @@ async fn network_event_coordinator(
     nudge_on_route_event: bool,
     #[cfg(apple)] nudge_on_route_update: bool,
     #[cfg(any(apple, windows))] outside_io: Weak<dyn OutsideIO>,
+    #[cfg(windows)] pin_egress_interface: bool,
     network_change_signal: mpsc::Sender<()>,
 ) {
     tracing::info!("Reacting to network change events...");
@@ -927,7 +937,8 @@ async fn network_event_coordinator(
         // index usually does not change (a Wi-Fi roam keeps the adapter), but
         // switching adapters entirely does change it.
         #[cfg(windows)]
-        if let Some(if_index) = route_updater.server_route_if_index()
+        if pin_egress_interface
+            && let Some(if_index) = route_updater.server_route_if_index()
             && let Some(io) = outside_io.upgrade()
         {
             io.pin_egress_interface(if_index);
@@ -1090,6 +1101,7 @@ impl<ExtAppState: Send + Sync> ClientConnection<ExtAppState> {
         transition_rx: Option<watch::Receiver<()>>,
         nudge_on_route_event: bool,
         #[cfg(apple)] nudge_on_route_update: bool,
+        #[cfg(windows)] pin_egress_interface: bool,
     ) -> Result<()> {
         let server_ip = self.outside_io.peer_addr().ip();
         let tun_index = self.inside_io.if_index()?;
@@ -1117,6 +1129,8 @@ impl<ExtAppState: Send + Sync> ClientConnection<ExtAppState> {
             nudge_on_route_update,
             #[cfg(any(apple, windows))]
             Arc::downgrade(&self.outside_io),
+            #[cfg(windows)]
+            pin_egress_interface,
             self.network_change_signal.clone(),
         )));
 
@@ -1836,6 +1850,8 @@ pub async fn client<
                 nudge_on_route_event,
                 #[cfg(apple)]
                 nudge_on_route_update,
+                #[cfg(windows)]
+                !config.disable_pin_egress_interface,
             )
             .await?;
     }

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -852,7 +852,8 @@ async fn handle_network_change<ExtAppState: Send + Sync>(
 
 /// Single consumer for network-change wake-ups. Reacts to each one with the
 /// steps in order: refresh the server route, re-`connect()` the outside
-/// socket (Apple platforms) and, when the wake-up represents a network transition,
+/// socket (Apple platforms), and re-pin its egress interface (Windows), when
+/// the wake-up represents a network transition,
 /// nudge the connection-level network-change handler. On Apple platforms the
 /// nudge also fires when the server route was actually replaced (Datagram
 /// wiring only). Owns the [`RouteUpdater`], so aborting the task removes the
@@ -864,7 +865,7 @@ async fn network_event_coordinator(
     mut transition_rx: Option<watch::Receiver<()>>,
     nudge_on_route_event: bool,
     #[cfg(apple)] nudge_on_route_update: bool,
-    #[cfg(apple)] outside_io: Weak<dyn OutsideIO>,
+    #[cfg(any(apple, windows))] outside_io: Weak<dyn OutsideIO>,
     network_change_signal: mpsc::Sender<()>,
 ) {
     tracing::info!("Reacting to network change events...");
@@ -920,6 +921,16 @@ async fn network_event_coordinator(
         #[cfg(apple)]
         if let Some(io) = outside_io.upgrade() {
             io.reconnect();
+        }
+
+        // Refresh the egress pin from the server route we just validated. The
+        // index usually does not change (a Wi-Fi roam keeps the adapter), but
+        // switching adapters entirely does change it.
+        #[cfg(windows)]
+        if let Some(if_index) = route_updater.server_route_if_index()
+            && let Some(io) = outside_io.upgrade()
+        {
+            io.pin_egress_interface(if_index);
         }
 
         if nudge && let Err(e) = network_change_signal.send(()).await {
@@ -1104,7 +1115,7 @@ impl<ExtAppState: Send + Sync> ClientConnection<ExtAppState> {
             nudge_on_route_event,
             #[cfg(apple)]
             nudge_on_route_update,
-            #[cfg(apple)]
+            #[cfg(any(apple, windows))]
             Arc::downgrade(&self.outside_io),
             self.network_change_signal.clone(),
         )));

--- a/lightway-client/src/platform/windows.rs
+++ b/lightway-client/src/platform/windows.rs
@@ -1,3 +1,4 @@
 pub mod crypto;
 pub mod dns_manager;
+pub mod egress;
 pub mod utils;

--- a/lightway-client/src/platform/windows/egress.rs
+++ b/lightway-client/src/platform/windows/egress.rs
@@ -1,0 +1,109 @@
+//! Pin the outside socket to the physical egress interface.
+//!
+//! Windows use `IP_UNICAST_IF` / `IPV6_UNICAST_IF` to constrain the
+//! route lookup for a socket to a single interface.
+//!
+//! Pinning makes egress selection independent of the routing table, so a
+//! missing or stale host route can no longer divert outside traffic into the
+//! tunnel. The interface index does not change when an adapter roams between
+//! access points, so the pin survives exactly the event that breaks the route.
+
+use std::io;
+use std::net::{IpAddr, SocketAddr};
+use std::os::windows::io::RawSocket;
+
+use windows_sys::Win32::NetworkManagement::IpHelper::GetBestInterfaceEx;
+use windows_sys::Win32::Networking::WinSock::{
+    AF_INET, AF_INET6, IN_ADDR, IN_ADDR_0, IN6_ADDR, IN6_ADDR_0, IP_UNICAST_IF, IPPROTO_IP,
+    IPPROTO_IPV6, IPV6_UNICAST_IF, SOCKADDR, SOCKADDR_IN, SOCKADDR_IN6, SOCKADDR_IN6_0, SOCKET,
+    SOCKET_ERROR, setsockopt,
+};
+
+/// The interface index Windows would currently use to reach `dst`.
+pub fn best_interface_index(dst: IpAddr) -> io::Result<u32> {
+    // Storage for whichever sockaddr flavour is needed; declared here so it
+    // outlives the call the raw pointer is handed to.
+    let v4_addr;
+    let v6_addr;
+
+    let addr: *const SOCKADDR = match dst {
+        IpAddr::V4(ip) => {
+            v4_addr = SOCKADDR_IN {
+                sin_family: AF_INET,
+                sin_port: 0,
+                sin_addr: IN_ADDR {
+                    // `S_addr` holds the address in network byte order, which
+                    // is the in-memory order of `octets()`.
+                    S_un: IN_ADDR_0 {
+                        S_addr: u32::from_ne_bytes(ip.octets()),
+                    },
+                },
+                sin_zero: [0; 8],
+            };
+            (&raw const v4_addr).cast()
+        }
+        IpAddr::V6(ip) => {
+            v6_addr = SOCKADDR_IN6 {
+                sin6_family: AF_INET6,
+                sin6_port: 0,
+                sin6_flowinfo: 0,
+                sin6_addr: IN6_ADDR {
+                    u: IN6_ADDR_0 { Byte: ip.octets() },
+                },
+                Anonymous: SOCKADDR_IN6_0 { sin6_scope_id: 0 },
+            };
+            (&raw const v6_addr).cast()
+        }
+    };
+
+    let mut if_index: u32 = 0;
+
+    #[allow(unsafe_code)]
+    // SAFETY: `addr` points at a fully initialised sockaddr of the family
+    // named in its `sa_family` field, owned by this frame and live for the
+    // whole call. `GetBestInterfaceEx` only reads through it, and writes the
+    // result through the exclusive `&mut if_index` borrow.
+    let result = unsafe { GetBestInterfaceEx(addr, &mut if_index) };
+
+    if result != 0 {
+        return Err(io::Error::from_raw_os_error(result as i32));
+    }
+    Ok(if_index)
+}
+
+/// Constrain `socket`'s egress to interface `if_index`.
+pub fn set_unicast_if(socket: RawSocket, if_index: u32, ipv6: bool) -> io::Result<()> {
+    let (level, optname, value) = if ipv6 {
+        (IPPROTO_IPV6, IPV6_UNICAST_IF, if_index)
+    } else {
+        (IPPROTO_IP, IP_UNICAST_IF, if_index.to_be())
+    };
+
+    #[allow(unsafe_code)]
+    // SAFETY: `value` is a live `u32` and `optlen` matches its size, so
+    // `setsockopt` reads exactly the bytes it is told about. The socket handle
+    // is owned by the caller and valid for the duration of the call.
+    let result = unsafe {
+        setsockopt(
+            socket as SOCKET,
+            level,
+            optname,
+            (&raw const value).cast::<u8>(),
+            size_of::<u32>() as i32,
+        )
+    };
+
+    if result == SOCKET_ERROR {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Pin `socket` to the interface currently used to reach `peer`.
+///
+/// Returns the interface index that was pinned.
+pub fn pin_to_peer_interface(socket: RawSocket, peer: SocketAddr) -> io::Result<u32> {
+    let if_index = best_interface_index(peer.ip())?;
+    set_unicast_if(socket, if_index, peer.is_ipv6())?;
+    Ok(if_index)
+}

--- a/lightway-client/src/route_manager.rs
+++ b/lightway-client/src/route_manager.rs
@@ -192,6 +192,12 @@ impl RouteUpdater {
         }
         self.inner.check_and_update_server_route().await
     }
+
+    /// Interface index of the currently installed server route, if any.
+    #[cfg(windows)]
+    pub fn server_route_if_index(&self) -> Option<u32> {
+        self.inner.server_route.as_ref().and_then(|r| r.if_index())
+    }
 }
 
 impl RouteManagerInner {


### PR DESCRIPTION
## Description

Pin the Windows outside socket to the physical egress interface using `IP_UNICAST_IF`/`IPV6_UNICAST_IF` so that routing-table changes (including the tunnel's own default route) cannot redirect outside traffic back into the tunnel. Re-pin on every network-change event and swallow transient send errors that occur mid-roam.  The encapsulation loop from outside packet back to tunnel cause issues in CVPN-2746, CVPN-2747 and CVPN-2748.  

This is possible to apply on Linux but won't do, because the roaming in `NoExec` mode from wifi only work in different subnet.  The deep reason for this is `IP_UNICAST_IF` is evaluated on every send call on Windows (Winsock), and it overrides routing table decisions per-packet, regardless of whether the socket has previously called `connect()`.  However, `IP_UNICAST_IF` sets `sk->sk_bound_dev_if`, only consulted during a route lookup on Linux. For a connected UDP socket, the route is cached in `sk_dst_cache` at `connect()` time, re-calling `setsockopt(IP_UNICAST_IF, same_index)` updates the flag but does not flush the route cache.  #492 still needed no mater we have have this feature on Linux or not.
 
### Change details

- **`platform/windows/egress.rs`** *(new)*: wraps `GetBestInterfaceEx` + `setsockopt(IP_UNICAST_IF/IPV6_UNICAST_IF)` into three helpers — `best_interface_index`, `set_unicast_if`, and `pin_to_peer_interface`.
- **`io/outside/udp.rs`**: pins the UDP socket at creation; stores the current `pinned_if_index` (AtomicU32) and implements `OutsideIO::pin_egress_interface` to re-pin on network change; swallows transient `WSAEADDRNOTAVAIL`/`WSAEHOSTUNREACH` send errors that arise mid-roam before the next send re-selects a source address.
- **`io/outside/tcp.rs`**: pins the TCP socket before `connect()` (the option has no effect afterwards, so this is the only opportunity).
- **`io/outside.rs`**: adds `OutsideIO::pin_egress_interface` (Windows only, default no-op).
- **`lib.rs`**: calls `pin_egress_interface` from `network_event_coordinator` after each successful route refresh; extends the `outside_io` weak reference from Apple-only to `any(apple, windows)`.
- **`route_manager.rs`**: adds `RouteUpdater::server_route_if_index()` to expose the interface index of the currently installed server route.

## Motivation and Context

On Windows without pinning, once the tunnel's default route is installed the OS may route outside packets back into the tunnel, causing a routing loop. Pinning the socket to the physical interface that currently reaches the server makes egress selection independent of the routing table. The pin is refreshed after each network-change event so that switching adapters (Wi-Fi → Ethernet, docking) is handled correctly.

## How Has This Been Tested?

- [X] Follow current CI testcases 
- [X] Manual Windows Wi-Fi roam test

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (internal restructuring, no behaviour change for end users)
- [ ] CI / infrastructure change (no production code affected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
- [ ] Any update to `xenon/libxenon-src` is accompanied by a reference to the specific commit in the git changelog
