### PR TITLE
nix: add cmake and git to devshells

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -5,6 +5,8 @@
   autoconf,
   automake,
   libtool,
+  cmake,
+  git,
   cargo-deny,
   cargo-make,
   cargo-nextest,
@@ -40,6 +42,8 @@ mkShell (
       autoconf
       automake
       libtool
+      cmake
+      git
       rustPlatform.bindgenHook
 
       # Development tools


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

lightway-boring pulls in boring-sys, whose build script compiles BoringSSL from source using cmake. The package derivation in nix/default.nix already carries these, but the devshells never got them, so any cargo build in the shell died with:

  is `cmake` not installed?

git happened to leak in from the user profile on NixOS; add it explicitly so the shell is self-contained. boring-sys needs it to apply its post-quantum patch, and cargo needs it to fetch the boring git dependency.

## Motivation and Context

Local nix devshell was failing to compile

## How Has This Been Tested?

Verified compilation succeeded after the fix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
