### PR TITLE
CVPN-2754: Support IPv6 outside socket in ip_mtu_discover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,6 +1867,7 @@ dependencies = [
  "serde",
  "serde_with",
  "serde_yaml",
+ "socket2",
  "test-case",
  "thiserror 2.0.18",
  "tokio",

--- a/lightway-app-utils/Cargo.toml
+++ b/lightway-app-utils/Cargo.toml
@@ -52,6 +52,9 @@ route_manager.workspace = true
 # Address-change watching (PF_ROUTE doorbell + getifaddrs snapshot diff).
 netwatcher = { version = "0.7.1", features = ["tokio"] }
 
+[target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))'.dependencies]
+socket2.workspace = true
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",

--- a/lightway-app-utils/src/sockopt/ip_mtu_discover.rs
+++ b/lightway-app-utils/src/sockopt/ip_mtu_discover.rs
@@ -10,8 +10,7 @@ use std::mem::MaybeUninit;
 use libc::socklen_t;
 
 #[cfg(unix)]
-use std::os::fd::{AsRawFd, RawFd};
-
+use std::os::fd::{AsFd, AsRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::AsRawSocket;
 
@@ -164,30 +163,42 @@ mod internal {
     }
 }
 
-fn get_level_and_optname() -> (i32, i32) {
-    let level: i32;
-    let optname: i32;
+#[cfg(apple)]
+const LEVEL_AND_OPTNAME_V4: (i32, i32) = (libc::IPPROTO_IP, libc::IP_DONTFRAG);
+#[cfg(apple)]
+const LEVEL_AND_OPTNAME_V6: (i32, i32) = (libc::IPPROTO_IPV6, libc::IPV6_DONTFRAG);
 
-    #[cfg(apple)]
-    {
-        level = libc::IPPROTO_IP;
-        optname = libc::IP_DONTFRAG;
+#[cfg(all(not(apple), unix))]
+const LEVEL_AND_OPTNAME: (i32, i32) = (libc::SOL_IP, libc::IP_MTU_DISCOVER);
+
+#[cfg(windows)]
+const LEVEL_AND_OPTNAME: (i32, i32) = (
+    windows_sys::Win32::Networking::WinSock::IPPROTO_IP,
+    windows_sys::Win32::Networking::WinSock::IP_MTU_DISCOVER,
+);
+
+/// On Apple platforms the don't-fragment option lives at a different
+/// level/name for IPv4 and IPv6 sockets, so inspect the socket's
+/// address family to pick the right pair.
+#[cfg(apple)]
+fn get_level_and_optname(sock: &impl AsGenericHandle) -> std::io::Result<(i32, i32)> {
+    let addr = socket2::SockRef::from(sock).local_addr()?;
+
+    if addr.is_ipv4() {
+        Ok(LEVEL_AND_OPTNAME_V4)
+    } else if addr.is_ipv6() {
+        Ok(LEVEL_AND_OPTNAME_V6)
+    } else {
+        Err(std::io::Error::other(format!(
+            "unexpected address family: {:?}",
+            addr.family()
+        )))
     }
+}
 
-    #[cfg(all(not(apple), unix))]
-    {
-        level = libc::SOL_IP;
-        optname = libc::IP_MTU_DISCOVER;
-    }
-
-    #[cfg(windows)]
-    {
-        use windows_sys::Win32::Networking::WinSock::{IP_MTU_DISCOVER, IPPROTO_IP};
-        level = IPPROTO_IP;
-        optname = IP_MTU_DISCOVER;
-    }
-
-    (level, optname)
+#[cfg(not(apple))]
+fn get_level_and_optname(_sock: &impl AsGenericHandle) -> std::io::Result<(i32, i32)> {
+    Ok(LEVEL_AND_OPTNAME)
 }
 
 #[allow(non_camel_case_types)]
@@ -214,14 +225,22 @@ type SetOptValType = libc::c_void;
 type GenericHandle = RawFd;
 
 #[cfg(unix)]
-impl<T: AsRawFd> AsGenericHandle for T {
+impl<T: AsFd> AsGenericHandle for T {
     fn as_generic_handle(&self) -> GenericHandle {
-        self.as_raw_fd()
+        self.as_fd().as_raw_fd()
     }
 }
 
 pub use internal::*;
 
+#[cfg(unix)]
+/// Generic handle to use in sockopt
+pub trait AsGenericHandle: AsFd {
+    /// Generic handle to use in sockopt
+    fn as_generic_handle(&self) -> GenericHandle;
+}
+
+#[cfg(windows)]
 /// Generic handle to use in sockopt
 pub trait AsGenericHandle {
     /// Generic handle to use in sockopt
@@ -233,7 +252,7 @@ pub fn get_ip_mtu_discover(sock: &impl AsGenericHandle) -> std::io::Result<IpPmt
     let mut value: MaybeUninit<libc::c_int> = MaybeUninit::uninit();
     let mut len = std::mem::size_of::<libc::c_int>() as socklen_t;
 
-    let (level, optname) = get_level_and_optname();
+    let (level, optname) = get_level_and_optname(sock)?;
 
     // SAFETY: `getsockopt` requires a socket/fd and a valid buffer of `c_int` size
     let res = unsafe {
@@ -269,7 +288,7 @@ pub fn set_ip_mtu_discover(
     let pmtudisc: libc::c_int = pmtudisc.into();
     let len = std::mem::size_of::<libc::c_int>() as socklen_t;
 
-    let (level, optname) = get_level_and_optname();
+    let (level, optname) = get_level_and_optname(sock)?;
 
     // SAFETY: `setsockopt` requires a socket and a valid buffer of `c_int` size
     let res = unsafe {
@@ -286,5 +305,40 @@ pub fn set_ip_mtu_discover(
         Err(std::io::Error::last_os_error())
     } else {
         Ok(())
+    }
+}
+
+#[cfg(all(test, unix, not(miri)))]
+mod tests {
+    use super::*;
+
+    fn roundtrip(sock: &std::net::UdpSocket) {
+        set_ip_mtu_discover(sock, IpPmtudisc::Probe).unwrap();
+        assert!(matches!(
+            get_ip_mtu_discover(sock).unwrap(),
+            IpPmtudisc::Probe
+        ));
+
+        set_ip_mtu_discover(sock, IpPmtudisc::Dont).unwrap();
+        assert!(matches!(
+            get_ip_mtu_discover(sock).unwrap(),
+            IpPmtudisc::Dont
+        ));
+    }
+
+    #[test]
+    fn ipv4_socket() {
+        let sock = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        roundtrip(&sock);
+    }
+
+    // On non-apple platforms an AF_INET6 socket takes the
+    // don't-fragment option via a different level/optname which we
+    // don't support (yet).
+    #[cfg(apple)]
+    #[test]
+    fn ipv6_socket() {
+        let sock = std::net::UdpSocket::bind("[::1]:0").unwrap();
+        roundtrip(&sock);
     }
 }

--- a/lightway-app-utils/src/sockopt/ip_mtu_discover.rs
+++ b/lightway-app-utils/src/sockopt/ip_mtu_discover.rs
@@ -16,7 +16,7 @@ use std::os::fd::{AsRawFd, RawFd};
 use std::os::windows::io::AsRawSocket;
 
 // All Unix other than apple devices
-#[cfg(all(not(target_vendor = "apple"), target_family = "unix"))]
+#[cfg(all(not(apple), unix))]
 mod internal {
     use libc::{IP_PMTUDISC_DO, IP_PMTUDISC_DONT, IP_PMTUDISC_PROBE, IP_PMTUDISC_WANT};
     #[cfg(target_os = "linux")]
@@ -125,7 +125,7 @@ mod internal {
     }
 }
 
-#[cfg(target_vendor = "apple")]
+#[cfg(apple)]
 mod internal {
     const IP_ALLOW_FRAG: i32 = 0;
     const IP_DONT_FRAG: i32 = 1;
@@ -168,13 +168,13 @@ fn get_level_and_optname() -> (i32, i32) {
     let level: i32;
     let optname: i32;
 
-    #[cfg(target_vendor = "apple")]
+    #[cfg(apple)]
     {
         level = libc::IPPROTO_IP;
         optname = libc::IP_DONTFRAG;
     }
 
-    #[cfg(all(not(target_vendor = "apple"), target_family = "unix"))]
+    #[cfg(all(not(apple), unix))]
     {
         level = libc::SOL_IP;
         optname = libc::IP_MTU_DISCOVER;

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -1,5 +1,5 @@
 use super::{OutsideIO, OutsideSocket};
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use lightway_app_utils::sockopt;
 use lightway_core::{IOCallbackResult, OutsideIOSendCallback, OutsideIOSendCallbackArg};
@@ -82,7 +82,8 @@ impl Udp {
             }
         }
 
-        let default_ip_pmtudisc = sockopt::get_ip_mtu_discover(&sock)?;
+        let default_ip_pmtudisc = sockopt::get_ip_mtu_discover(&sock)
+            .context("Failed to get IP MTU Discovery sockopt")?;
         // Check for the socket's writable ready status, so that it can be used
         // successfuly in TLS's `OutsideIOSendCallback` callback
         sock.writable().await?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Return IPv6 level and optname for Apple platform if the socket is using IPv6.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Right now if we're using IPv6 socket on Apple devices, getsockopt(IPPROTO_IP, IP_DONTFRAG) will fail as it only works with IPv4 sockets.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests to run on all platforms to verify getsockopt won't fail when we're using IPv6 sockets

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
