### PR TITLE
client; server: use apply_with_log for config patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3509,23 +3509,23 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "struct-patch"
-version = "0.13.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a820f68a123e0ddbcd5215c95bd7d865482d3ad7a9ae463bf2adaf541746ec"
+checksum = "562b5d730abba4c29316f65c76f4939ae63ac998a761fbd99c61ed543d183e23"
 dependencies = [
  "struct-patch-derive",
 ]
 
 [[package]]
 name = "struct-patch-derive"
-version = "0.13.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01189c2d9e14bea08d9dcac1e4e347e91f027d68617096d83a19017e2a7b070"
+checksum = "f4761d4848bf2b974f0a5a93fc69ee63c9f89816c618b3c3c12b8b13690524f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
- "syn-serde",
+ "syn 3.0.4",
+ "syn-serde3",
 ]
 
 [[package]]
@@ -3589,16 +3589,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn-serde"
-version = "0.3.2"
+name = "syn-serde3"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bac52f98dc6afb9d7d51d325cf6611cab08f283b6b6c20ba57298fd9db509ef"
+checksum = "f83a664220cc243a8f57ead67942c052ce7d618af7f2b6aea3c0f7f8e039e382"
 dependencies = [
  "proc-macro2",
  "serde",
  "serde_derive",
  "serde_json",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ serde-env = "0.3"
 serde-saphyr = "0.0.22"
 serial_test = "3.4.0"
 socket2 = "0.6.0"
-struct-patch = { version =  "0.13.2", features= ["catalyst"] }
+struct-patch = { version =  "0.14.1", features= ["substrate"] }
 test-case = "3.1.0"
 thiserror = "2.0.3"
 tokio = { version = "1.33.0", features = ["rt-multi-thread", "macros", "net", "time", "sync", "io-util", "fs", "signal"] }

--- a/lightway-client/src/config.rs
+++ b/lightway-client/src/config.rs
@@ -11,9 +11,12 @@ use lightway_core::{AuthMethod, MAX_OUTSIDE_MTU, Version};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::OnceLock;
 use std::time::Duration as StdDuration;
 use std::{net::Ipv4Addr, path::PathBuf};
 use struct_patch::{Patch, Substrate};
+
+static CLI_OPTIONS: OnceLock<ConfigPatch> = OnceLock::new();
 
 const DEFAULT_SNDBUF: ByteSize = ByteSize::mib(8);
 const DEFAULT_RCVBUF: ByteSize = ByteSize::mib(8);
@@ -714,6 +717,89 @@ fn byte_size_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Sche
         "^[0-9]+(\\.[0-9]+)?\\s*(EB|EIB|GB|GIB|KB|KIB|MB|MIB|PB|PIB|TB|TIB|eb|eib|gb|gib|kb|kib|mb|mib|pb|pib|tb|tib)$".into(),
     );
     schema
+}
+
+impl Config {
+    pub fn cli_options() -> &'static ConfigPatch {
+        CLI_OPTIONS.get_or_init(ConfigPatch::parse)
+    }
+
+    pub async fn load(config_file: Option<&PathBuf>) -> anyhow::Result<(Self, Vec<String>)> {
+        let cli_options = Self::cli_options();
+
+        let path = match config_file {
+            Some(p) => p,
+            None => cli_options
+                .config_file
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("Config file not specified"))?,
+        };
+
+        #[cfg(windows)]
+        let file_patch = {
+            use crate::platform::windows::crypto::decrypt_dpapi_config_file;
+            use windows_dpapi::Scope::User;
+
+            let content = if cli_options.enable_dpapi {
+                tracing::info!("DPAPI decryption enabled for config file");
+                decrypt_dpapi_config_file(path, User).map_err(|e| {
+                    anyhow::anyhow!("Failed to decrypt DPAPI-protected config file: {e}")
+                })?
+            } else {
+                tracing::debug!("Loading config file directly (no DPAPI)");
+                tokio::fs::read_to_string(path).await?
+            };
+            serde_saphyr::from_str::<ConfigPatch>(&content)?
+        };
+        #[cfg(not(windows))]
+        let file_patch = {
+            let content = tokio::fs::read_to_string(path).await?;
+            serde_saphyr::from_str::<ConfigPatch>(&content)?
+        };
+
+        let env_patch: ConfigPatch = serde_env::from_env_with_prefix("LW_CLIENT")?;
+        let mut cli_patch = cli_options.clone();
+        cli_patch.config_file = None;
+        cli_patch.generate = None;
+
+        let mut config = Config {
+            config_file: path.to_path_buf(),
+            ..Default::default()
+        };
+
+        let mut file_fields = String::new();
+        let mut env_fields = String::new();
+        let mut cli_fields = String::new();
+
+        config.apply_with_log(file_patch, |field| {
+            if field != "unknowns" {
+                file_fields.push_str(&format!(", {field}"))
+            }
+        });
+        config.apply_with_log(env_patch, |field| {
+            if field != "unknowns" {
+                env_fields.push_str(&format!(", {field}"))
+            }
+        });
+        config.apply_with_log(cli_patch, |field| {
+            if field != "unknowns" {
+                cli_fields.push_str(&format!(", {field}"))
+            }
+        });
+
+        let mut logs = Vec::new();
+        if !file_fields.is_empty() {
+            logs.push(format!("config file set: {}", &file_fields[2..]));
+        }
+        if !env_fields.is_empty() {
+            logs.push(format!("environment var: {}", &env_fields[2..]));
+        }
+        if !cli_fields.is_empty() {
+            logs.push(format!("commandline arg: {}", &cli_fields[2..]));
+        }
+
+        Ok((config, logs))
+    }
 }
 
 // Note: it easier to see what is different from default in each validate testcase

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -1,11 +1,8 @@
-use clap::Parser;
 use std::path::PathBuf;
-use struct_patch::Patch;
 
 use anyhow::{Context, Result, anyhow};
 use futures::future::join_all;
 use lightway_core::{Event, EventCallback};
-use tokio::fs::read_to_string;
 use tokio::sync::mpsc;
 
 use lightway_app_utils::{
@@ -15,7 +12,7 @@ use lightway_app_utils::{
 };
 use lightway_client::*;
 
-use lightway_client::config::{Config, ConfigPatch};
+use lightway_client::config::Config;
 
 struct EventHandler;
 
@@ -31,25 +28,6 @@ impl EventCallback for EventHandler {
             _ => {}
         }
     }
-}
-
-#[cfg(windows)]
-async fn load_patch(options: &ConfigPatch, config_file: &PathBuf) -> Result<ConfigPatch> {
-    use crate::platform::windows::crypto::decrypt_dpapi_config_file;
-    use windows_dpapi::Scope::User;
-
-    // Fetch whether DPAPI is enabled from CLI args
-    let enable_dpapi = options.enable_dpapi;
-
-    let content = if enable_dpapi {
-        tracing::info!("DPAPI decryption enabled for config file");
-        decrypt_dpapi_config_file(config_file, User)
-            .context("Failed to decrypt DPAPI-protected config file")?
-    } else {
-        tracing::debug!("Loading config file directly (no DPAPI)");
-        read_to_string(config_file).await?
-    };
-    Ok(serde_saphyr::from_str::<ConfigPatch>(&content)?)
 }
 
 fn generate_config(format: ConfigFormat, config_file: &PathBuf) -> Result<()> {
@@ -75,58 +53,28 @@ fn generate_config(format: ConfigFormat, config_file: &PathBuf) -> Result<()> {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
-    let mut options = ConfigPatch::parse();
-
-    // Fetch the config filepath from CLI and load it as config
-    let Some(config_file) = options.config_file.take() else {
-        return Err(anyhow!("Config file not present"));
-    };
-
-    if let Some(config_format) = options.generate.take() {
-        return generate_config(config_format, &config_file);
+    if let Some(config_format) = Config::cli_options().generate {
+        return match Config::cli_options().config_file {
+            Some(ref path) => generate_config(config_format, path),
+            None => Err(anyhow!("Please provide path via --config-file to write")),
+        };
     }
 
-    validate_configuration_file_path(&config_file, Validate::OwnerOnly)
-        .with_context(|| format!("Invalid configuration file {}", config_file.display()))?;
+    let (mut config, startup_logs) = Config::load(None).await?;
 
-    let mut config = Config::default();
+    validate_configuration_file_path(&config.config_file, Validate::OwnerOnly).with_context(
+        || {
+            format!(
+                "Invalid configuration file {}",
+                config.config_file.display()
+            )
+        },
+    )?;
+
     // NOTE:
     // RootCertificate of TLS library is not a self handled Struct
     // we need keep the PathBuf live outside
     let mut _root_ca_cert_path: Option<PathBuf> = None;
-
-    let mut file_fields = String::new();
-    let mut env_fields = String::new();
-    let mut cli_fields = String::new();
-
-    // Load config patch with DPAPI support
-    #[cfg(windows)]
-    config.apply_with_log(load_patch(&options, &config_file).await?, |field| {
-        if field != "unknowns" {
-            file_fields.push_str(&format!(", {field}"))
-        }
-    });
-    #[cfg(not(windows))]
-    config.apply_with_log(
-        serde_saphyr::from_str::<ConfigPatch>(&read_to_string(&config_file).await?)?,
-        |field| {
-            if field != "unknowns" {
-                file_fields.push_str(&format!(", {field}"))
-            }
-        },
-    );
-    let env_patch: ConfigPatch = serde_env::from_env_with_prefix("LW_CLIENT")?;
-    config.apply_with_log(env_patch.clone(), |field| {
-        if field != "unknowns" {
-            env_fields.push_str(&format!(", {field}"))
-        }
-    });
-    let cli_patch = options.clone();
-    config.apply_with_log(options, |field| {
-        if field != "unknowns" {
-            cli_fields.push_str(&format!(", {field}"))
-        }
-    });
 
     let level: tracing::level_filters::LevelFilter = config.log_level.into();
     let filter = tracing_subscriber::EnvFilter::builder()
@@ -140,14 +88,8 @@ async fn main() -> Result<()> {
 
     LogFormat::Full.init_with_env_filter(fmt);
 
-    if !file_fields.is_empty() {
-        tracing::debug!("config file set: {}", &file_fields[2..]);
-    }
-    if !env_fields.is_empty() {
-        tracing::debug!("environment var: {}", &env_fields[2..]);
-    }
-    if !cli_fields.is_empty() {
-        tracing::debug!("commandline arg: {}", &cli_fields[2..]);
+    for log in startup_logs {
+        tracing::debug!("{log}");
     }
 
     let (ctrlc_tx, mut ctrlc_rx) = tokio::sync::oneshot::channel();
@@ -179,8 +121,7 @@ async fn main() -> Result<()> {
         })?;
     }
 
-    let config_reload_signal =
-        spawn_reload_event_handler(&config, config_file.clone(), env_patch, cli_patch);
+    let config_reload_signal = spawn_reload_event_handler(&config, config.config_file.clone());
 
     let servers = config.take_servers()?;
 
@@ -213,46 +154,13 @@ async fn main() -> Result<()> {
 }
 
 #[cfg(any(unix, windows))]
-async fn reload_config(
-    path: &PathBuf,
-    env_patch: &ConfigPatch,
-    cli_patch: &ConfigPatch,
-) -> Option<Config> {
-    let content = tokio::fs::read_to_string(path)
+async fn reload_config(path: &PathBuf) -> Option<Config> {
+    let (config, logs) = Config::load(Some(path))
         .await
-        .map_err(|e| tracing::error!("Failed to read config: {e}"))
+        .map_err(|e| tracing::error!("Failed to reload config: {e}"))
         .ok()?;
-    let file_patch = serde_saphyr::from_str::<ConfigPatch>(&content)
-        .map_err(|e| tracing::error!("Failed to parse config on reload: {e}"))
-        .ok()?;
-
-    let mut config = Config::default();
-    let mut file_fields = String::new();
-    let mut env_fields = String::new();
-    let mut cli_fields = String::new();
-    config.apply_with_log(file_patch, |field| {
-        if field != "unknowns" {
-            file_fields.push_str(&format!(", {field}"))
-        }
-    });
-    config.apply_with_log(env_patch.clone(), |field| {
-        if field != "unknowns" {
-            env_fields.push_str(&format!(", {field}"))
-        }
-    });
-    config.apply_with_log(cli_patch.clone(), |field| {
-        if field != "unknowns" {
-            cli_fields.push_str(&format!(", {field}"))
-        }
-    });
-    if !file_fields.is_empty() {
-        tracing::debug!("config file set: {}", &file_fields[2..]);
-    }
-    if !env_fields.is_empty() {
-        tracing::debug!("environment var: {}", &env_fields[2..]);
-    }
-    if !cli_fields.is_empty() {
-        tracing::debug!("commandline arg: {}", &cli_fields[2..]);
+    for log in logs {
+        tracing::debug!("{log}");
     }
     Some(config)
 }
@@ -287,8 +195,6 @@ fn warn_non_reloadable_changes(old: &Config, new: &Config) {
 fn spawn_reload_event_handler(
     config: &Config,
     config_file: PathBuf,
-    env_patch: ConfigPatch,
-    cli_patch: ConfigPatch,
 ) -> Option<mpsc::Receiver<ReloadableClientConfig>> {
     let mut sighup = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup())
         .expect("Failed to register SIGHUP handler");
@@ -303,7 +209,7 @@ fn spawn_reload_event_handler(
         while sighup.recv().await.is_some() {
             tracing::info!("SIGHUP received, reloading config");
 
-            let Some(new_config) = reload_config(&config_file, &env_patch, &cli_patch).await else {
+            let Some(new_config) = reload_config(&config_file).await else {
                 continue;
             };
 
@@ -333,8 +239,6 @@ fn spawn_reload_event_handler(
 fn spawn_reload_event_handler(
     config: &Config,
     config_file: PathBuf,
-    env_patch: ConfigPatch,
-    cli_patch: ConfigPatch,
 ) -> Option<mpsc::Receiver<ReloadableClientConfig>> {
     use windows_sys::Win32::{
         Foundation::{CloseHandle, WAIT_OBJECT_0, WAIT_TIMEOUT},
@@ -405,7 +309,7 @@ fn spawn_reload_event_handler(
 
             tracing::info!("Reload event signaled, reloading config");
 
-            let Some(new_config) = reload_config(&config_file, &env_patch, &cli_patch).await else {
+            let Some(new_config) = reload_config(&config_file).await else {
                 continue;
             };
 
@@ -438,8 +342,6 @@ fn spawn_reload_event_handler(
 fn spawn_reload_event_handler(
     _config: &Config,
     _config_file: PathBuf,
-    _env_patch: ConfigPatch,
-    _cli_patch: ConfigPatch,
 ) -> Option<mpsc::Receiver<ReloadableClientConfig>> {
     None
 }

--- a/lightway-client/src/main.rs
+++ b/lightway-client/src/main.rs
@@ -95,17 +95,38 @@ async fn main() -> Result<()> {
     // we need keep the PathBuf live outside
     let mut _root_ca_cert_path: Option<PathBuf> = None;
 
+    let mut file_fields = String::new();
+    let mut env_fields = String::new();
+    let mut cli_fields = String::new();
+
     // Load config patch with DPAPI support
     #[cfg(windows)]
-    config.apply(load_patch(&options, &config_file).await?);
+    config.apply_with_log(load_patch(&options, &config_file).await?, |field| {
+        if field != "unknowns" {
+            file_fields.push_str(&format!(", {field}"))
+        }
+    });
     #[cfg(not(windows))]
-    config.apply(serde_saphyr::from_str::<ConfigPatch>(
-        &read_to_string(&config_file).await?,
-    )?);
+    config.apply_with_log(
+        serde_saphyr::from_str::<ConfigPatch>(&read_to_string(&config_file).await?)?,
+        |field| {
+            if field != "unknowns" {
+                file_fields.push_str(&format!(", {field}"))
+            }
+        },
+    );
     let env_patch: ConfigPatch = serde_env::from_env_with_prefix("LW_CLIENT")?;
-    config.apply(env_patch.clone());
+    config.apply_with_log(env_patch.clone(), |field| {
+        if field != "unknowns" {
+            env_fields.push_str(&format!(", {field}"))
+        }
+    });
     let cli_patch = options.clone();
-    config.apply(options);
+    config.apply_with_log(options, |field| {
+        if field != "unknowns" {
+            cli_fields.push_str(&format!(", {field}"))
+        }
+    });
 
     let level: tracing::level_filters::LevelFilter = config.log_level.into();
     let filter = tracing_subscriber::EnvFilter::builder()
@@ -118,6 +139,16 @@ async fn main() -> Result<()> {
     let fmt = tracing_subscriber::fmt().with_env_filter(filter);
 
     LogFormat::Full.init_with_env_filter(fmt);
+
+    if !file_fields.is_empty() {
+        tracing::debug!("config file set: {}", &file_fields[2..]);
+    }
+    if !env_fields.is_empty() {
+        tracing::debug!("environment var: {}", &env_fields[2..]);
+    }
+    if !cli_fields.is_empty() {
+        tracing::debug!("commandline arg: {}", &cli_fields[2..]);
+    }
 
     let (ctrlc_tx, mut ctrlc_rx) = tokio::sync::oneshot::channel();
 
@@ -196,9 +227,33 @@ async fn reload_config(
         .ok()?;
 
     let mut config = Config::default();
-    config.apply(file_patch);
-    config.apply(env_patch.clone());
-    config.apply(cli_patch.clone());
+    let mut file_fields = String::new();
+    let mut env_fields = String::new();
+    let mut cli_fields = String::new();
+    config.apply_with_log(file_patch, |field| {
+        if field != "unknowns" {
+            file_fields.push_str(&format!(", {field}"))
+        }
+    });
+    config.apply_with_log(env_patch.clone(), |field| {
+        if field != "unknowns" {
+            env_fields.push_str(&format!(", {field}"))
+        }
+    });
+    config.apply_with_log(cli_patch.clone(), |field| {
+        if field != "unknowns" {
+            cli_fields.push_str(&format!(", {field}"))
+        }
+    });
+    if !file_fields.is_empty() {
+        tracing::debug!("config file set: {}", &file_fields[2..]);
+    }
+    if !env_fields.is_empty() {
+        tracing::debug!("environment var: {}", &env_fields[2..]);
+    }
+    if !cli_fields.is_empty() {
+        tracing::debug!("commandline arg: {}", &cli_fields[2..]);
+    }
     Some(config)
 }
 

--- a/lightway-server/src/config.rs
+++ b/lightway-server/src/config.rs
@@ -4,6 +4,7 @@ use std::{
     path::PathBuf,
 };
 
+use anyhow::Context;
 use bytesize::ByteSize;
 use clap::Parser;
 use ipnet::Ipv4Net;
@@ -11,8 +12,10 @@ use serde::Deserialize;
 use std::time::Duration as StdDuration;
 use struct_patch::{Patch, Substrate};
 
-use lightway_app_utils::args::{
-    ConnectionType, Duration, IpMap, LogFormat, LogLevel, NonZeroDuration,
+use lightway_app_utils::{
+    Validate,
+    args::{ConnectionType, Duration, IpMap, LogFormat, LogLevel, NonZeroDuration},
+    validate_configuration_file_path,
 };
 
 // NOTE
@@ -300,6 +303,59 @@ impl Config {
         }
 
         Ok(())
+    }
+}
+
+impl Config {
+    pub async fn load() -> anyhow::Result<(Self, Vec<String>)> {
+        let mut cli_patch = ConfigPatch::parse();
+
+        let path = cli_patch
+            .config_file
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("Config file not specified"))?;
+
+        validate_configuration_file_path(&path, Validate::AllowWorldRead)
+            .with_context(|| format!("Invalid configuration file {}", path.display()))?;
+
+        let content = tokio::fs::read_to_string(&path).await?;
+        let file_patch = serde_saphyr::from_str::<ConfigPatch>(&content)?;
+
+        let env_patch: ConfigPatch = serde_env::from_env_with_prefix("LW_SERVER")?;
+
+        let mut config = Config::default();
+        let mut file_fields = String::new();
+        let mut env_fields = String::new();
+        let mut cli_fields = String::new();
+
+        config.apply_with_log(file_patch, |field| {
+            if field != "unknowns" {
+                file_fields.push_str(&format!(", {field}"))
+            }
+        });
+        config.apply_with_log(env_patch, |field| {
+            if field != "unknowns" {
+                env_fields.push_str(&format!(", {field}"))
+            }
+        });
+        config.apply_with_log(cli_patch, |field| {
+            if field != "unknowns" {
+                cli_fields.push_str(&format!(", {field}"))
+            }
+        });
+
+        let mut logs = Vec::new();
+        if !file_fields.is_empty() {
+            logs.push(format!("config file set: {}", &file_fields[2..]));
+        }
+        if !env_fields.is_empty() {
+            logs.push(format!("environment var: {}", &env_fields[2..]));
+        }
+        if !cli_fields.is_empty() {
+            logs.push(format!("commandline arg: {}", &cli_fields[2..]));
+        }
+
+        Ok((config, logs))
     }
 }
 

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -1,18 +1,15 @@
 mod auth;
 
-use anyhow::{Context, Result, anyhow};
-use clap::Parser;
-use struct_patch::Patch;
+use anyhow::{Context, Result};
 
 use metrics_util::debugging::DebuggingRecorder;
-use tokio::fs::read_to_string;
 use tokio_stream::StreamExt;
 use tracing::{error, trace};
 
 use lightway_app_utils::{Validate, validate_configuration_file_path};
 #[cfg(feature = "debug")]
 use lightway_core::set_logging_callback;
-use lightway_server::config::{Config, ConfigPatch};
+use lightway_server::config::Config;
 use lightway_server::*;
 
 async fn metrics_debug() {
@@ -73,38 +70,7 @@ async fn metrics_debug() {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
-    let mut options = ConfigPatch::parse();
-
-    // Fetch the config filepath from CLI and load it as config
-    let Some(config_file) = options.config_file.take() else {
-        return Err(anyhow!("Config file not present"));
-    };
-
-    validate_configuration_file_path(&config_file, Validate::AllowWorldRead)
-        .with_context(|| format!("Invalid configuration file {}", config_file.display()))?;
-
-    let mut config = Config::default();
-    let mut file_fields = String::new();
-    let mut env_fields = String::new();
-    let mut cli_fields = String::new();
-    config.apply_with_log(
-        serde_saphyr::from_str(&read_to_string(config_file).await?)?,
-        |field| {
-            if field != "unknowns" {
-                file_fields.push_str(&format!(", {field}"))
-            }
-        },
-    );
-    config.apply_with_log(serde_env::from_env_with_prefix("LW_SERVER")?, |field| {
-        if field != "unknowns" {
-            env_fields.push_str(&format!(", {field}"))
-        }
-    });
-    config.apply_with_log(options, |field| {
-        if field != "unknowns" {
-            cli_fields.push_str(&format!(", {field}"))
-        }
-    });
+    let (config, startup_logs) = Config::load().await?;
 
     validate_configuration_file_path(&config.server_key, Validate::OwnerOnly)
         .with_context(|| format!("Invalid server key file {}", config.server_key.display()))?;
@@ -133,14 +99,8 @@ async fn main() -> Result<()> {
 
     config.log_format.init_with_env_filter(fmt);
 
-    if !file_fields.is_empty() {
-        tracing::debug!("config file set: {}", &file_fields[2..]);
-    }
-    if !env_fields.is_empty() {
-        tracing::debug!("environment var: {}", &env_fields[2..]);
-    }
-    if !cli_fields.is_empty() {
-        tracing::debug!("commandline arg: {}", &cli_fields[2..]);
+    for log in startup_logs {
+        tracing::debug!("{log}");
     }
 
     let server_config = crate::ServerConfig::try_from_auth_and_config(

--- a/lightway-server/src/main.rs
+++ b/lightway-server/src/main.rs
@@ -84,9 +84,27 @@ async fn main() -> Result<()> {
         .with_context(|| format!("Invalid configuration file {}", config_file.display()))?;
 
     let mut config = Config::default();
-    config.apply(serde_saphyr::from_str(&read_to_string(config_file).await?)?);
-    config.apply(serde_env::from_env_with_prefix("LW_SERVER")?);
-    config.apply(options);
+    let mut file_fields = String::new();
+    let mut env_fields = String::new();
+    let mut cli_fields = String::new();
+    config.apply_with_log(
+        serde_saphyr::from_str(&read_to_string(config_file).await?)?,
+        |field| {
+            if field != "unknowns" {
+                file_fields.push_str(&format!(", {field}"))
+            }
+        },
+    );
+    config.apply_with_log(serde_env::from_env_with_prefix("LW_SERVER")?, |field| {
+        if field != "unknowns" {
+            env_fields.push_str(&format!(", {field}"))
+        }
+    });
+    config.apply_with_log(options, |field| {
+        if field != "unknowns" {
+            cli_fields.push_str(&format!(", {field}"))
+        }
+    });
 
     validate_configuration_file_path(&config.server_key, Validate::OwnerOnly)
         .with_context(|| format!("Invalid server key file {}", config.server_key.display()))?;
@@ -114,6 +132,17 @@ async fn main() -> Result<()> {
     let fmt = tracing_subscriber::fmt().with_env_filter(filter);
 
     config.log_format.init_with_env_filter(fmt);
+
+    if !file_fields.is_empty() {
+        tracing::debug!("config file set: {}", &file_fields[2..]);
+    }
+    if !env_fields.is_empty() {
+        tracing::debug!("environment var: {}", &env_fields[2..]);
+    }
+    if !cli_fields.is_empty() {
+        tracing::debug!("commandline arg: {}", &cli_fields[2..]);
+    }
+
     let server_config = crate::ServerConfig::try_from_auth_and_config(
         crate::auth::Auth::new(
             config.user_db.as_ref().map(AsRef::as_ref),


### PR DESCRIPTION
## Description

Add the log and eliminate duplicated loading logic across client and server and keep DRY.

### Log config fields by source at startup 

Switch from `apply` to `apply_with_log` when loading config patches so
each field that actually receives a value is tracked. At startup and on
config reload, emit one debug line per source listing only the fields
that were set. The internal `unknowns` field is excluded since it is
handled separately by `validate()`.

```
DEBUG config file set: server, cipher, ca_cert, ...
DEBUG environment var: log_level, accept_unknowns
DEBUG commandline arg: mode
```

### Consolidate config loading into `Config::load()`

Move all loading logic out of `main()` into a single `Config::load()`
method, making `main()` cleaner and the reload path trivial.

## Motivation and Context

Add log for config patching.  Meanwhile, centralizing this in `Config::load()` removes the duplication to avoid 
## How Has This Been Tested?
- [x] Existing unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`
