### PR TITLE
tests: add cases for invalid, expired or corrupted certs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,7 @@ dependencies = [
  "num_enum",
  "once_cell",
  "parking_lot",
+ "pem 3.0.6",
  "pnet",
  "pnet_packet",
  "rand 0.10.2",

--- a/lightway-core/Cargo.toml
+++ b/lightway-core/Cargo.toml
@@ -49,6 +49,7 @@ async-trait.workspace = true
 cfg-if = "1.0.4"
 itertools = "0.15.0"
 lightway-app-utils.workspace = true
+pem = "3.0.4"
 rcgen.workspace = true
 test-case.workspace = true
 tokio.workspace = true

--- a/lightway-core/tests/certs.rs
+++ b/lightway-core/tests/certs.rs
@@ -1,4 +1,7 @@
 //! Certificate-chain validation tests for backend.
+//!
+//! On-the-fly generation of certs is too slow on RISCV, skip this suite.
+#![cfg(not(target_arch = "riscv64"))]
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/lightway-core/tests/certs.rs
+++ b/lightway-core/tests/certs.rs
@@ -1,0 +1,83 @@
+//! Certificate-chain validation tests for backend.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use test_case::test_matrix;
+use tokio::net::UnixStream;
+
+pub mod common;
+use crate::common::certgen::{Defect, Link, TestPki};
+use crate::common::connection::{PQCrypto, TestAuth, TestSock, TestStreamSock, client, server};
+use crate::common::get_test_timeout;
+use rcgen::RsaKeySize;
+
+async fn handshake(pki: &'static TestPki) -> Result<(), String> {
+    let attempt = tokio::spawn(async move {
+        let (client_sock, server_sock) = UnixStream::pair().expect("UnixStream");
+        let client_sock = Arc::new(TestStreamSock(client_sock));
+        let server_sock = Arc::new(TestStreamSock(server_sock));
+        let _ = client_sock.writable().await;
+
+        let auth = Arc::new(TestAuth::default());
+        let pqc = PQCrypto::default();
+        let (cert, key) = pki.server_secrets();
+        tokio::join!(
+            server(server_sock, auth, pqc, None, None, None, cert, key,),
+            client(
+                client_sock,
+                None,
+                pqc,
+                None,
+                false,
+                false,
+                false,
+                pki.root_ca(),
+            )
+        )
+    });
+
+    match tokio::time::timeout(Duration::from_millis(get_test_timeout()), attempt).await {
+        Err(_elapsed) => panic!("handshake attempt timed out"),
+        Ok(Ok(((), ()))) => Ok(()),
+        Ok(Err(join_err)) if join_err.is_panic() => {
+            let payload = join_err.into_panic();
+            let reason = payload
+                .downcast_ref::<String>()
+                .cloned()
+                .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
+                .unwrap_or_else(|| "non-string panic payload".to_string());
+            Err(reason)
+        }
+        Ok(Err(join_err)) => panic!("harness task failed: {join_err}"),
+    }
+}
+
+/// Positive control: a defect-free chain must complete the handshake.
+#[test_matrix(
+    [2, 3],
+    [RsaKeySize::_2048, RsaKeySize::_4096]
+)]
+#[tokio::test]
+async fn valid_chain_accepted(chain_len: usize, key_size: RsaKeySize) {
+    let pki = TestPki::get_valid(chain_len, key_size);
+    handshake(pki)
+        .await
+        .expect("valid chain must complete the handshake");
+}
+
+/// A chain whose root, intermediate, or leaf certificate is corrupt,
+/// untrusted, or expired must never produce a connection.
+#[test_matrix(
+    [Defect::Corrupt, Defect::Invalid, Defect::Expired],
+    [Link::Root, Link::Intermediate, Link::Leaf],
+    [RsaKeySize::_2048, RsaKeySize::_4096]
+)]
+#[tokio::test]
+async fn defective_chain_rejected(defect: Defect, link: Link, key_size: RsaKeySize) {
+    let pki = TestPki::get_defective(defect, link, key_size);
+    match handshake(pki).await {
+        Err(reason) => println!("rejected {defect:?} {link:?} {key_size:?}: {reason}"),
+        Ok(()) => panic!("handshake completed despite {defect:?} {link:?} certificate"),
+    }
+}

--- a/lightway-core/tests/certs.rs
+++ b/lightway-core/tests/certs.rs
@@ -11,7 +11,10 @@ use tokio::net::UnixStream;
 
 pub mod common;
 use crate::common::certgen::{Defect, Link, TestPki};
-use crate::common::connection::{PQCrypto, TestAuth, TestSock, TestStreamSock, client, server};
+use crate::common::connection::{
+    PQCrypto, TestAuth, TestClientConfig, TestServerConfig, TestSock, TestStreamSock, client,
+    server,
+};
 use crate::common::get_test_timeout;
 use rcgen::RsaKeySize;
 
@@ -26,16 +29,29 @@ async fn handshake(pki: &'static TestPki) -> Result<(), String> {
         let pqc = PQCrypto::default();
         let (cert, key) = pki.server_secrets();
         tokio::join!(
-            server(server_sock, auth, pqc, None, None, None, cert, key,),
+            server(
+                server_sock,
+                TestServerConfig {
+                    auth,
+                    pqc,
+                    expresslane: None,
+                    conn_out: None,
+                    metrics: None,
+                    cert,
+                    key,
+                },
+            ),
             client(
                 client_sock,
-                None,
-                pqc,
-                None,
-                false,
-                false,
-                false,
-                pki.root_ca(),
+                TestClientConfig {
+                    cipher: None,
+                    pqc,
+                    server_dn: None,
+                    enable_codec: false,
+                    enable_expresslane: false,
+                    use_versioned_token: false,
+                    root_ca: pki.root_ca(),
+                },
             )
         )
     });

--- a/lightway-core/tests/common/certgen.rs
+++ b/lightway-core/tests/common/certgen.rs
@@ -1,71 +1,271 @@
 //! On-the-fly X.509 certificate generation for tests.
+//!
+//! The main export is the [`TestPki`], which defines the everything each
+//! test connection needs. Call [`TestPki::get_valid`] to get a valid one,
+//! or [`TestPki::get_defective`] to get one with your chosen defects.
+//!
+//! Note: Every request is automatically memoized,
+//! so asking for the same PKI twice costs one keygen.
 
+use lightway_core::{RootCertificate, Secret};
 use rcgen::{
     BasicConstraints, CertificateParams, CertifiedIssuer, DnType, ExtendedKeyUsagePurpose, IsCa,
     KeyPair, KeyUsagePurpose, PKCS_RSA_SHA256, RsaKeySize,
 };
-use std::sync::LazyLock;
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex, OnceLock};
 use std::time::{Duration, SystemTime};
 
-pub const TEST_SERVER_DOMAIN: &str = "example.com";
+const DAY: Duration = Duration::from_secs(60 * 60 * 24);
+
+/// Which certificate in the chain carries the defect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Link {
+    Root,
+    Intermediate,
+    Leaf,
+}
+
+/// How a certificate is unusable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Defect {
+    /// Truncated DER, which no backend can even parse.
+    Corrupt,
+    /// Well-formed, but not part of the chain it claims to belong to.
+    Invalid,
+    /// Well-formed and correctly chained, but outside its validity window.
+    Expired,
+}
+
+/// A trust anchor and a server certificate/key issued under it.
+pub struct TestPki {
+    trust_bundle_pem: Vec<u8>,
+    server: CertifiedKey,
+}
+
+impl TestPki {
+    /// The domain generated server certificates are issued for, and so the
+    /// name a client may be told to validate.
+    pub const SERVER_DOMAIN: &'static str = "example.com";
+
+    /// A defect-free PKI of the given chain length (2 = root > leaf,
+    /// 3 = root > intermediate > leaf).
+    pub fn get_valid(chain_len: usize, key_size: RsaKeySize) -> &'static TestPki {
+        cached(PkiSpec::Valid {
+            chain_len,
+            key_size,
+        })
+    }
+
+    /// A PKI in which the certificate at `link` carries `defect`.
+    pub fn get_defective(defect: Defect, link: Link, key_size: RsaKeySize) -> &'static TestPki {
+        cached(PkiSpec::Defective {
+            defect,
+            link,
+            key_size,
+        })
+    }
+
+    fn generate_valid(chain_len: usize, key_size: RsaKeySize) -> TestPki {
+        let root = Ca::new_self_signed("test root CA", key_size, false);
+        match chain_len {
+            2 => TestPki {
+                trust_bundle_pem: pem_bundle(&[&root.cert_der()]),
+                server: root.issue_server(Self::SERVER_DOMAIN, key_size, false),
+            },
+            3 => {
+                let intermediate = root.issue_intermediate("test intermediate CA", key_size, false);
+                TestPki {
+                    trust_bundle_pem: pem_bundle(&[&root.cert_der(), &intermediate.cert_der()]),
+                    server: intermediate.issue_server(Self::SERVER_DOMAIN, key_size, false),
+                }
+            }
+            _ => unreachable!("unsupported chain length"),
+        }
+    }
+
+    fn generate_defective(defect: Defect, link: Link, key_size: RsaKeySize) -> TestPki {
+        let is_expired = matches!(defect, Defect::Expired);
+        let unrelated_ca = || Ca::new_self_signed("unrelated CA", key_size, false);
+
+        match link {
+            Link::Root => {
+                let root = Ca::new_self_signed("test root CA", key_size, is_expired);
+                let server = root.issue_server(Self::SERVER_DOMAIN, key_size, false);
+                let anchor_der = match defect {
+                    Defect::Corrupt => corrupt_der(&root.cert_der()),
+                    Defect::Invalid => unrelated_ca().cert_der(),
+                    Defect::Expired => root.cert_der(),
+                };
+                TestPki {
+                    trust_bundle_pem: pem_bundle(&[&anchor_der]),
+                    server,
+                }
+            }
+            Link::Intermediate => {
+                let root = Ca::new_self_signed("test root CA", key_size, false);
+                let intermediate =
+                    root.issue_intermediate("test intermediate CA", key_size, is_expired);
+                let server = intermediate.issue_server(Self::SERVER_DOMAIN, key_size, false);
+                let intermediate_der = match defect {
+                    Defect::Corrupt => corrupt_der(&intermediate.cert_der()),
+                    Defect::Invalid => unrelated_ca()
+                        .issue_intermediate("unrelated intermediate CA", key_size, false)
+                        .cert_der(),
+                    Defect::Expired => intermediate.cert_der(),
+                };
+                TestPki {
+                    trust_bundle_pem: pem_bundle(&[&root.cert_der(), &intermediate_der]),
+                    server,
+                }
+            }
+            Link::Leaf => {
+                let root = Ca::new_self_signed("test root CA", key_size, false);
+                let intermediate = root.issue_intermediate("test intermediate CA", key_size, false);
+                let server = match defect {
+                    Defect::Corrupt => {
+                        let sound = intermediate.issue_server(Self::SERVER_DOMAIN, key_size, false);
+                        CertifiedKey {
+                            cert_der: corrupt_der(&sound.cert_der),
+                            key_der: sound.key_der,
+                        }
+                    }
+                    Defect::Invalid => {
+                        unrelated_ca().issue_server(Self::SERVER_DOMAIN, key_size, false)
+                    }
+                    Defect::Expired => {
+                        intermediate.issue_server(Self::SERVER_DOMAIN, key_size, true)
+                    }
+                };
+                TestPki {
+                    trust_bundle_pem: pem_bundle(&[&root.cert_der(), &intermediate.cert_der()]),
+                    server,
+                }
+            }
+        }
+    }
+
+    /// The trust anchor to configure a client with.
+    pub fn root_ca(&self) -> RootCertificate<'_> {
+        RootCertificate::PemBuffer(&self.trust_bundle_pem)
+    }
+
+    /// The certificate and key for a server to present, in that order.
+    pub fn server_secrets(&self) -> (Secret<'_>, Secret<'_>) {
+        (
+            Secret::Asn1Buffer(&self.server.cert_der),
+            Secret::Asn1Buffer(&self.server.key_der),
+        )
+    }
+}
+
+/// What was asked for, and so the identity of a cache entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum PkiSpec {
+    Valid {
+        chain_len: usize,
+        key_size: RsaKeySize,
+    },
+    Defective {
+        defect: Defect,
+        link: Link,
+        key_size: RsaKeySize,
+    },
+}
+
+impl PkiSpec {
+    fn generate(self) -> TestPki {
+        match self {
+            PkiSpec::Valid {
+                chain_len,
+                key_size,
+            } => TestPki::generate_valid(chain_len, key_size),
+            PkiSpec::Defective {
+                defect,
+                link,
+                key_size,
+            } => TestPki::generate_defective(defect, link, key_size),
+        }
+    }
+}
+
+/// Every PKI generated in this test process, keyed by the request that asked
+/// for it.
+static PKI_CACHE: LazyLock<Mutex<HashMap<PkiSpec, &'static OnceLock<TestPki>>>> =
+    LazyLock::new(Mutex::default);
+
+/// The PKI for `spec`, generating it if this is the first request.
+fn cached(spec: PkiSpec) -> &'static TestPki {
+    let entry = *PKI_CACHE
+        .lock()
+        .expect("PKI cache lock")
+        .entry(spec)
+        .or_insert_with(|| Box::leak(Box::new(OnceLock::new())));
+    entry.get_or_init(|| spec.generate())
+}
 
 /// A generated certificate and its private key, both DER encoded.
-pub struct CertifiedKey {
-    pub cert_der: Vec<u8>,
-    pub key_der: Vec<u8>,
+struct CertifiedKey {
+    cert_der: Vec<u8>,
+    key_der: Vec<u8>,
 }
 
-/// Generate a key pair matching the previously checked-in test certificates
-fn generate_key() -> KeyPair {
-    KeyPair::generate_rsa_for(&PKCS_RSA_SHA256, RsaKeySize::_2048).expect("generate RSA-2048 key")
-}
-
-fn set_validity(params: &mut CertificateParams) {
-    const DAY: Duration = Duration::from_secs(60 * 60 * 24);
-    let now = SystemTime::now();
-    params.not_before = (now - DAY).into();
-    params.not_after = (now + 30 * DAY).into();
-}
-
-/// A certificate authority that can issue server certificates.
-pub struct Ca {
+/// A certificate authority that can issue server certificates and
+/// intermediate CAs.
+struct Ca {
     issuer: CertifiedIssuer<'static, KeyPair>,
 }
 
 impl Ca {
-    pub fn new_self_signed(common_name: &str) -> Self {
-        let cert_params = {
-            let mut params = CertificateParams::default();
-            set_validity(&mut params);
-            params
-                .distinguished_name
-                .push(DnType::CommonName, common_name);
-            params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-            params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
-            params
-        };
-        let key = generate_key();
-        let issuer = CertifiedIssuer::self_signed(cert_params, key).expect("self-sign CA cert");
+    fn new_self_signed(common_name: &str, key_size: RsaKeySize, is_expired: bool) -> Self {
+        let params = Self::ca_params(common_name, is_expired);
+        let key = generate_key(key_size);
+        let issuer = CertifiedIssuer::self_signed(params, key).expect("self-sign CA cert");
         Self { issuer }
     }
 
+    /// An intermediate CA signed by this CA.
+    fn issue_intermediate(
+        &self,
+        common_name: &str,
+        key_size: RsaKeySize,
+        is_expired: bool,
+    ) -> Self {
+        let params = Self::ca_params(common_name, is_expired);
+        let key = generate_key(key_size);
+        let issuer = CertifiedIssuer::signed_by(params, key, &self.issuer)
+            .expect("sign intermediate CA cert");
+        Self { issuer }
+    }
+
+    fn ca_params(common_name: &str, is_expired: bool) -> CertificateParams {
+        let mut params = CertificateParams::default();
+        set_validity(&mut params, is_expired);
+        params
+            .distinguished_name
+            .push(DnType::CommonName, common_name);
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        params
+    }
+
     /// This CA's certificate, DER encoded.
-    pub fn cert_der(&self) -> Vec<u8> {
+    fn cert_der(&self) -> Vec<u8> {
         self.issuer.der().to_vec()
     }
 
-    /// Issue an end-entity certificate for a TLS server at `domain`,
-    /// used as both the subject CN and a dNSName SAN.
-    pub fn issue_server(&self, domain: &str) -> CertifiedKey {
+    /// An end-entity TLS server certificate for `domain`, used as both the
+    /// subject CN and a dNSName SAN.
+    fn issue_server(&self, domain: &str, key_size: RsaKeySize, is_expired: bool) -> CertifiedKey {
         let cert_params = {
             let mut params = CertificateParams::new(vec![domain.to_string()]).expect("valid SAN");
-            set_validity(&mut params);
+            set_validity(&mut params, is_expired);
             params.distinguished_name.push(DnType::CommonName, domain);
             params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
             params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
             params
         };
-        let key = generate_key();
+        let key = generate_key(key_size);
         let cert = cert_params
             .signed_by(&key, &self.issuer)
             .expect("sign server cert");
@@ -76,22 +276,29 @@ impl Ca {
     }
 }
 
-/// The PKI shared by the standard connection tests: a root CA and a server
-/// certificate it issued for [`TEST_SERVER_DOMAIN`].
-pub struct TestPki {
-    pub ca_cert_der: Vec<u8>,
-    pub server: CertifiedKey,
+fn set_validity(params: &mut CertificateParams, is_expired: bool) {
+    let now = SystemTime::now();
+    let (not_before, not_after) = match is_expired {
+        false => (now - DAY, now + 30 * DAY),
+        true => (now - 30 * DAY, now - DAY),
+    };
+    params.not_before = not_before.into();
+    params.not_after = not_after.into();
 }
 
-/// The shared happy-path PKI, generated once per test process.
-pub fn gen_shared_testing_pki() -> &'static TestPki {
-    static PKI: LazyLock<TestPki> = LazyLock::new(|| {
-        let ca = Ca::new_self_signed("lightway test CA");
-        let server = ca.issue_server(TEST_SERVER_DOMAIN);
-        TestPki {
-            ca_cert_der: ca.cert_der(),
-            server,
-        }
-    });
-    &PKI
+fn generate_key(key_size: RsaKeySize) -> KeyPair {
+    KeyPair::generate_rsa_for(&PKCS_RSA_SHA256, key_size).expect("generate RSA key")
+}
+
+/// Encode DER certificates as a concatenated PEM bundle.
+fn pem_bundle(certs_der: &[&[u8]]) -> Vec<u8> {
+    certs_der
+        .iter()
+        .map(|der| pem::encode(&pem::Pem::new("CERTIFICATE", der.to_vec())))
+        .collect::<String>()
+        .into_bytes()
+}
+
+fn corrupt_der(der: &[u8]) -> Vec<u8> {
+    der[..der.len() / 2].to_vec()
 }

--- a/lightway-core/tests/common/connection.rs
+++ b/lightway-core/tests/common/connection.rs
@@ -223,17 +223,27 @@ impl OutsideIOSendCallback for TestStreamSock {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-pub async fn server<S: TestSock>(
-    sock: Arc<S>,
-    auth: Arc<TestAuth>,
-    pqc: PQCrypto,
-    expresslane: Option<std::time::Duration>,
-    conn_out: Option<oneshot::Sender<Arc<Mutex<lightway_core::Connection<ConnectionTicker>>>>>,
-    metrics: Option<ExpresslaneMetricsType>,
-    server_cert: Secret<'_>,
-    server_key: Secret<'_>,
-) {
+pub struct TestServerConfig<'a> {
+    pub auth: Arc<TestAuth>,
+    pub pqc: PQCrypto,
+    pub expresslane: Option<std::time::Duration>,
+    pub conn_out: Option<oneshot::Sender<Arc<Mutex<lightway_core::Connection<ConnectionTicker>>>>>,
+    pub metrics: Option<ExpresslaneMetricsType>,
+    pub cert: Secret<'a>,
+    pub key: Secret<'a>,
+}
+
+pub async fn server<S: TestSock>(sock: Arc<S>, config: TestServerConfig<'_>) {
+    let TestServerConfig {
+        auth,
+        pqc,
+        expresslane,
+        conn_out,
+        metrics,
+        cert: server_cert,
+        key: server_key,
+    } = config;
+
     let ip_pool = Arc::new(StaticIpPool);
 
     let (tun, mut inside_rx) = ChannelTun::new();
@@ -415,18 +425,27 @@ pub enum ClientTestState {
     MessageSent,
 }
 
-#[allow(clippy::too_many_arguments)]
-pub async fn client<S: TestSock>(
-    sock: Arc<S>,
-    cipher: Option<Cipher>,
-    pqc: PQCrypto,
-    server_dn: Option<&str>,
-    enable_codec: bool,
-    enable_expresslane: bool,
-    use_versioned_token: bool,
-    root_ca: RootCertificate<'_>,
-) {
-    let ca_cert = root_ca;
+pub struct TestClientConfig<'a> {
+    pub cipher: Option<Cipher>,
+    pub pqc: PQCrypto,
+    pub server_dn: Option<&'a str>,
+    pub enable_codec: bool,
+    pub enable_expresslane: bool,
+    pub use_versioned_token: bool,
+    pub root_ca: RootCertificate<'a>,
+}
+
+pub async fn client<S: TestSock>(sock: Arc<S>, config: TestClientConfig<'_>) {
+    let TestClientConfig {
+        cipher,
+        pqc,
+        server_dn,
+        enable_codec,
+        enable_expresslane,
+        use_versioned_token,
+        root_ca: ca_cert,
+    } = config;
+
     let (tun, mut inside_rx) = ChannelTun::new();
     let client = Arc::new(Client);
 

--- a/lightway-core/tests/common/connection.rs
+++ b/lightway-core/tests/common/connection.rs
@@ -18,8 +18,6 @@ use tokio::{
 };
 use tokio_stream::StreamExt;
 
-use crate::common::certgen::gen_shared_testing_pki;
-
 #[derive(Default)]
 pub struct TestAuth {
     /// Captures the last [`AuthMethod`] seen by [`ServerAuth::authorize`]
@@ -225,6 +223,7 @@ impl OutsideIOSendCallback for TestStreamSock {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn server<S: TestSock>(
     sock: Arc<S>,
     auth: Arc<TestAuth>,
@@ -232,10 +231,9 @@ pub async fn server<S: TestSock>(
     expresslane: Option<std::time::Duration>,
     conn_out: Option<oneshot::Sender<Arc<Mutex<lightway_core::Connection<ConnectionTicker>>>>>,
     metrics: Option<ExpresslaneMetricsType>,
+    server_cert: Secret<'_>,
+    server_key: Secret<'_>,
 ) {
-    let pki = gen_shared_testing_pki();
-    let server_key = Secret::Asn1Buffer(&pki.server.key_der);
-    let server_cert = Secret::Asn1Buffer(&pki.server.cert_der);
     let ip_pool = Arc::new(StaticIpPool);
 
     let (tun, mut inside_rx) = ChannelTun::new();
@@ -417,6 +415,7 @@ pub enum ClientTestState {
     MessageSent,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn client<S: TestSock>(
     sock: Arc<S>,
     cipher: Option<Cipher>,
@@ -425,8 +424,9 @@ pub async fn client<S: TestSock>(
     enable_codec: bool,
     enable_expresslane: bool,
     use_versioned_token: bool,
+    root_ca: RootCertificate<'_>,
 ) {
-    let ca_cert = RootCertificate::Asn1Buffer(&gen_shared_testing_pki().ca_cert_der);
+    let ca_cert = root_ca;
     let (tun, mut inside_rx) = ChannelTun::new();
     let client = Arc::new(Client);
 

--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -45,27 +45,32 @@ async fn run_test<S: TestSock>(
     let pki = TestPki::get_valid(2, RsaKeySize::_2048);
 
     let test = async move {
-        let (server_cert, server_key) = pki.server_secrets();
+        let (cert, key) = pki.server_secrets();
         tokio::join!(
             server(
                 server_sock,
-                auth,
-                pqc,
-                enable_expresslane.then_some(DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL),
-                None,
-                None,
-                server_cert,
-                server_key,
+                TestServerConfig {
+                    auth,
+                    pqc,
+                    expresslane: enable_expresslane
+                        .then_some(DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL),
+                    conn_out: None,
+                    metrics: None,
+                    cert,
+                    key,
+                },
             ),
             client(
                 client_sock,
-                cipher,
-                pqc,
-                None,
-                enable_codec,
-                enable_expresslane,
-                use_versioned_token,
-                pki.root_ca(),
+                TestClientConfig {
+                    cipher,
+                    pqc,
+                    server_dn: None,
+                    enable_codec,
+                    enable_expresslane,
+                    use_versioned_token,
+                    root_ca: pki.root_ca(),
+                },
             )
         )
     };
@@ -144,16 +149,18 @@ async fn inside_pkt_codec_stall_triggers_codec_downgrade() {
 
     // Server reflects inside data and ACKs the client's encoding requests.
     let pki = TestPki::get_valid(2, RsaKeySize::_2048);
-    let (server_cert, server_key) = pki.server_secrets();
+    let (cert, key) = pki.server_secrets();
     let mut server_task = tokio::spawn(server(
         server_sock,
-        auth,
-        pqc,
-        None,
-        None,
-        None,
-        server_cert,
-        server_key,
+        TestServerConfig {
+            auth,
+            pqc,
+            expresslane: None,
+            conn_out: None,
+            metrics: None,
+            cert,
+            key,
+        },
     ));
 
     let ca_cert = pki.root_ca();
@@ -404,27 +411,31 @@ async fn test_server_dn(server_dn: Option<&str>) {
     let test = async move {
         tokio::join!(
             {
-                let (server_cert, server_key) = pki.server_secrets();
+                let (cert, key) = pki.server_secrets();
                 server(
                     server_sock,
-                    auth,
-                    pqc,
-                    None,
-                    None,
-                    None,
-                    server_cert,
-                    server_key,
+                    TestServerConfig {
+                        auth,
+                        pqc,
+                        expresslane: None,
+                        conn_out: None,
+                        metrics: None,
+                        cert,
+                        key,
+                    },
                 )
             },
             client(
                 client_sock,
-                None,
-                pqc,
-                server_dn,
-                false,
-                false,
-                false,
-                pki.root_ca()
+                TestClientConfig {
+                    cipher: None,
+                    pqc,
+                    server_dn,
+                    enable_codec: false,
+                    enable_expresslane: false,
+                    use_versioned_token: false,
+                    root_ca: pki.root_ca(),
+                },
             )
         )
     };
@@ -509,19 +520,21 @@ async fn server_nudge_rotates_both_ends_while_client_is_idle() {
 
     let auth = Arc::new(TestAuth::default());
     let pki = TestPki::get_valid(2, RsaKeySize::_2048);
-    let (server_cert, server_key) = pki.server_secrets();
+    let (cert, key) = pki.server_secrets();
     let server_task = server(
         server_sock,
-        auth,
-        PQCrypto {
-            server_pqc: false,
-            keyshare: None,
+        TestServerConfig {
+            auth,
+            pqc: PQCrypto {
+                server_pqc: false,
+                keyshare: None,
+            },
+            expresslane: Some(INTERVAL),
+            conn_out: Some(conn_tx),
+            metrics: None,
+            cert,
+            key,
         },
-        Some(INTERVAL),
-        Some(conn_tx),
-        None,
-        server_cert,
-        server_key,
     );
 
     let client_task = async move {
@@ -671,16 +684,18 @@ async fn expresslane_health_probe(
     // A long rotation interval on purpose: rotation must not interfere with
     // the health-check windows this probe measures.
     let pki = TestPki::get_valid(2, RsaKeySize::_2048);
-    let (server_cert, server_key) = pki.server_secrets();
+    let (cert, key) = pki.server_secrets();
     let server_task = server(
         server_sock,
-        auth,
-        pqc,
-        Some(DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL),
-        None,
-        server_metrics,
-        server_cert,
-        server_key,
+        TestServerConfig {
+            auth,
+            pqc,
+            expresslane: Some(DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL),
+            conn_out: None,
+            metrics: server_metrics,
+            cert,
+            key,
+        },
     );
 
     let client_task = async move {
@@ -990,7 +1005,18 @@ async fn pmtud_reports_status_changes() {
 
     // The server answers every probe Ping with a Pong.
     let (cert, key) = pki.server_secrets();
-    let mut server_task = tokio::spawn(server(server_sock, auth, pqc, None, None, None, cert, key));
+    let mut server_task = tokio::spawn(server(
+        server_sock,
+        TestServerConfig {
+            auth,
+            pqc,
+            expresslane: None,
+            conn_out: None,
+            metrics: None,
+            cert,
+            key,
+        },
+    ));
 
     let log: Log = Default::default();
     let ca_cert = pki.root_ca();

--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -3,6 +3,7 @@ use lightway_app_utils::{
     ConnectionTicker, EventStreamCallback, PacketCodecFactory, connection_ticker_cb,
 };
 use lightway_core::*;
+use rcgen::RsaKeySize;
 use std::{
     collections::HashSet,
     sync::{Arc, Mutex},
@@ -15,7 +16,7 @@ use tokio::{
 };
 use tokio_stream::StreamExt;
 pub mod common;
-use crate::common::{certgen::gen_shared_testing_pki, packet_codec::BlackHolePacketCodecFactory};
+use crate::common::{certgen::TestPki, packet_codec::BlackHolePacketCodecFactory};
 use crate::common::{connection::*, get_test_timeout};
 
 async fn run_test_tcp<S: TestSock>(
@@ -39,11 +40,12 @@ async fn run_test<S: TestSock>(
 ) -> Arc<Mutex<Option<AuthMethod>>> {
     let (auth, last_method) = TestAuth::new();
 
-    // Generate the shared test PKI before the timeout window.
-    // RSA keygen is very slow on QEMU. (especially on RISCV).
-    gen_shared_testing_pki();
+    // Take the shared test PKI before the timeout window: RSA keygen is very
+    // slow on QEMU (especially on RISCV) and only happens on first use.
+    let pki = TestPki::get_valid(2, RsaKeySize::_2048);
 
     let test = async move {
+        let (server_cert, server_key) = pki.server_secrets();
         tokio::join!(
             server(
                 server_sock,
@@ -52,6 +54,8 @@ async fn run_test<S: TestSock>(
                 enable_expresslane.then_some(DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL),
                 None,
                 None,
+                server_cert,
+                server_key,
             ),
             client(
                 client_sock,
@@ -61,6 +65,7 @@ async fn run_test<S: TestSock>(
                 enable_codec,
                 enable_expresslane,
                 use_versioned_token,
+                pki.root_ca(),
             )
         )
     };
@@ -138,9 +143,20 @@ async fn inside_pkt_codec_stall_triggers_codec_downgrade() {
     };
 
     // Server reflects inside data and ACKs the client's encoding requests.
-    let mut server_task = tokio::spawn(server(server_sock, auth, pqc, None, None, None));
+    let pki = TestPki::get_valid(2, RsaKeySize::_2048);
+    let (server_cert, server_key) = pki.server_secrets();
+    let mut server_task = tokio::spawn(server(
+        server_sock,
+        auth,
+        pqc,
+        None,
+        None,
+        None,
+        server_cert,
+        server_key,
+    ));
 
-    let ca_cert = RootCertificate::Asn1Buffer(&gen_shared_testing_pki().ca_cert_der);
+    let ca_cert = pki.root_ca();
     let (tun, _inside_rx) = ChannelTun::new();
     let (event_cb, mut event_stream) = EventStreamCallback::new();
 
@@ -366,7 +382,7 @@ async fn test_stream_connection_versioned_token() {
 }
 
 #[test_case(None; "No server domain name")]
-#[test_case(Some(common::certgen::TEST_SERVER_DOMAIN); "Valid server domain name")]
+#[test_case(Some(TestPki::SERVER_DOMAIN); "Valid server domain name")]
 #[cfg_attr(boringssl, test_case(Some("invalid") => panics "TLS Error: Fatal error: DomainNameMismatch"; "Invalid server domain name"))]
 #[cfg_attr(wolfssl, test_case(Some("invalid") => panics "TLS Error: Fatal: Domain name mismatch"; "Invalid server domain name"))]
 #[tokio::test]
@@ -382,13 +398,34 @@ async fn test_server_dn(server_dn: Option<&str>) {
 
     let auth = Arc::new(TestAuth::default());
 
-    // Generate the shared test PKI *before the timed window* to prevent flaky tests. (see run_test).
-    gen_shared_testing_pki();
+    // Take the shared test PKI *before the timed window* to prevent flaky tests. (see run_test).
+    let pki = TestPki::get_valid(2, RsaKeySize::_2048);
 
     let test = async move {
         tokio::join!(
-            server(server_sock, auth, pqc, None, None, None),
-            client(client_sock, None, pqc, server_dn, false, false, false)
+            {
+                let (server_cert, server_key) = pki.server_secrets();
+                server(
+                    server_sock,
+                    auth,
+                    pqc,
+                    None,
+                    None,
+                    None,
+                    server_cert,
+                    server_key,
+                )
+            },
+            client(
+                client_sock,
+                None,
+                pqc,
+                server_dn,
+                false,
+                false,
+                false,
+                pki.root_ca()
+            )
         )
     };
 
@@ -408,7 +445,7 @@ async fn mark_offload_activity_bumps_by_rule() {
     let (client_sock, _server_sock) = UnixStream::pair().expect("UnixStream");
     let client_sock = Arc::new(TestStreamSock(client_sock));
 
-    let ca_cert = RootCertificate::Asn1Buffer(&gen_shared_testing_pki().ca_cert_der);
+    let ca_cert = TestPki::get_valid(2, RsaKeySize::_2048).root_ca();
     let (ticker, _ticker_task) = ConnectionTicker::new();
     let state = ConnectionState { ticker };
 
@@ -471,6 +508,8 @@ async fn server_nudge_rotates_both_ends_while_client_is_idle() {
     let (conn_tx, conn_rx) = oneshot::channel();
 
     let auth = Arc::new(TestAuth::default());
+    let pki = TestPki::get_valid(2, RsaKeySize::_2048);
+    let (server_cert, server_key) = pki.server_secrets();
     let server_task = server(
         server_sock,
         auth,
@@ -481,6 +520,8 @@ async fn server_nudge_rotates_both_ends_while_client_is_idle() {
         Some(INTERVAL),
         Some(conn_tx),
         None,
+        server_cert,
+        server_key,
     );
 
     let client_task = async move {
@@ -488,7 +529,7 @@ async fn server_nudge_rotates_both_ends_while_client_is_idle() {
         // cannot deadlock.
         let server_conn = conn_rx.await.expect("server conn handle");
 
-        let ca_cert = RootCertificate::Asn1Buffer(&gen_shared_testing_pki().ca_cert_der);
+        let ca_cert = pki.root_ca();
         let (tun, _inside_rx) = ChannelTun::new();
         let (ticker, ticker_task) = ConnectionTicker::new();
         let state = ConnectionState { ticker };
@@ -629,6 +670,8 @@ async fn expresslane_health_probe(
     let auth = Arc::new(TestAuth::default());
     // A long rotation interval on purpose: rotation must not interfere with
     // the health-check windows this probe measures.
+    let pki = TestPki::get_valid(2, RsaKeySize::_2048);
+    let (server_cert, server_key) = pki.server_secrets();
     let server_task = server(
         server_sock,
         auth,
@@ -636,10 +679,12 @@ async fn expresslane_health_probe(
         Some(DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL),
         None,
         server_metrics,
+        server_cert,
+        server_key,
     );
 
     let client_task = async move {
-        let ca_cert = RootCertificate::Asn1Buffer(&gen_shared_testing_pki().ca_cert_der);
+        let ca_cert = pki.root_ca();
         let (tun, mut inside_rx) = ChannelTun::new();
         let (ticker, ticker_task) = ConnectionTicker::new();
         let state = ConnectionState { ticker };
@@ -929,9 +974,9 @@ async fn pmtud_reports_status_changes() {
         }
     }
 
-    // Generate the shared test PKI before the timeout window (RSA keygen is
-    // very slow on QEMU).
-    gen_shared_testing_pki();
+    // Take the shared test PKI before the timeout window (RSA keygen is very
+    // slow on QEMU, and only happens on first use).
+    let pki = TestPki::get_valid(2, RsaKeySize::_2048);
 
     let (client_sock, server_sock) = UnixDatagram::pair().expect("UnixDatagram");
     let server_sock = Arc::new(TestDatagramSock(server_sock));
@@ -944,10 +989,11 @@ async fn pmtud_reports_status_changes() {
     };
 
     // The server answers every probe Ping with a Pong.
-    let mut server_task = tokio::spawn(server(server_sock, auth, pqc, None, None, None));
+    let (cert, key) = pki.server_secrets();
+    let mut server_task = tokio::spawn(server(server_sock, auth, pqc, None, None, None, cert, key));
 
     let log: Log = Default::default();
-    let ca_cert = RootCertificate::Asn1Buffer(&gen_shared_testing_pki().ca_cert_der);
+    let ca_cert = pki.root_ca();
     let (tun, _inside_rx) = ChannelTun::new();
     let (event_cb, mut event_stream) = EventStreamCallback::new();
     let (ticker, ticker_task) = ConnectionTicker::new();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add negative tests for certs validation. Negative tests include corrupt, expired and invalid certs, on root intermediate and leaf.

Note: These tests are currently disabled on RISCV, as generating certs on RISCV runner is taking too long (sometimes over 13 extra minutes). Since these tests already run on other platforms, it is not worth it to run them on RISCV now.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensure certs validate correctly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
CI passing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] The correct base branch is being used, if not `main`
