### PR TITLE
core; client; server: report PMTUD status changes to the application

### DIFF
--- a/docs/pmtu_discovery.md
+++ b/docs/pmtu_discovery.md
@@ -28,7 +28,9 @@ estimate changes, and `Connection::pmtud_status()` returns the current `PmtudSta
 when PMTUD is not enabled). `PmtudStatus::max_packet_size` is the largest inside packet the
 connection sends in a single `Data` frame at the discovered PLPMTU; it is `None` while there is
 no estimate (`Disabled`, `Base`, `Error`). An application that sends packets outside the
-`Connection` (an offloaded data plane) can use it to clamp TCP MSS and size its own packets.
+`Connection` (an offloaded data plane) can use it to size its own packets and to clamp TCP MSS,
+which is `max_packet_size - 40` for IPv4 (the IP and TCP headers), exactly as the connection
+does for the packets it sends itself.
 
 At present, PMTU discovery is only enabled on client side. In future, we may enable
 it in Server.

--- a/docs/pmtu_discovery.md
+++ b/docs/pmtu_discovery.md
@@ -22,6 +22,14 @@ After calculating Path MTU, `Lightway` uses it for handling inside packets (from
 1. Fragment UDP packets inside lightway protocol if the size is larger than PMTU,
    which will be reassembled at the other end. Ref: `lightway_core::wire::DataFrag`
 
+The application can observe the outcome of discovery. The connection emits
+`Event::PmtudStateChanged(PmtudStatus)` on every state transition and whenever the PLPMTU
+estimate changes, and `Connection::pmtud_status()` returns the current `PmtudStatus` (`None`
+when PMTUD is not enabled). `PmtudStatus::max_packet_size` is the largest inside packet the
+connection sends in a single `Data` frame at the discovered PLPMTU; it is `None` while there is
+no estimate (`Disabled`, `Base`, `Error`). An application that sends packets outside the
+`Connection` (an offloaded data plane) can use it to clamp TCP MSS and size its own packets.
+
 At present, PMTU discovery is only enabled on client side. In future, we may enable
 it in Server.
 

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -574,6 +574,9 @@ async fn handle_events<A: 'static + Send + EventCallback, ExtAppState: Send + Sy
             Event::EncodingStateChanged { enabled } => {
                 info!("Encoding state changed to {enabled}");
             }
+            Event::PmtudStateChanged(status) => {
+                info!(?status, "Path MTU discovery status changed");
+            }
 
             // Server only events
             Event::SessionIdRotationStarted { .. }

--- a/lightway-client/src/mobile/lightway.rs
+++ b/lightway-client/src/mobile/lightway.rs
@@ -806,6 +806,9 @@ async fn handle_events<A: 'static + Send + EventCallback>(
                 continue;
             }
             Event::FirstPacketReceived | Event::EncodingStateChanged { .. } => (), // will be handled by handle_global_events
+            Event::PmtudStateChanged(status) => {
+                info!(?status, "Path MTU discovery status changed");
+            }
 
             // Server-only events
             Event::SessionIdRotationAcknowledged { .. }

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -763,10 +763,7 @@ impl<AppState: Send> Connection<AppState> {
             self.rotate_expresslane_key()?;
 
             // Start PMTU discovery
-            if let Some(ref mut pmtud) = self.pmtud {
-                let action = pmtud.online(&mut self.app_state);
-                self.handle_pmtud_action(action)?;
-            }
+            self.drive_pmtud(|pmtud, state| pmtud.online(state))?;
         }
 
         if matches!(new_state, State::LinkUp)
@@ -1663,6 +1660,28 @@ impl<AppState: Send> Connection<AppState> {
         }
     }
 
+    /// Run one DPLPMTUD step, notify the application if the PMTUD status
+    /// changed, then carry out the action the step requested.
+    ///
+    /// The notification precedes the send: the state machine has already
+    /// moved on even if the probe cannot be sent, and the application must
+    /// see the same status the connection now applies to its own traffic.
+    fn drive_pmtud(
+        &mut self,
+        step: impl FnOnce(&mut dplpmtud::Dplpmtud<AppState>, &mut AppState) -> dplpmtud::Action,
+    ) -> ConnectionResult<()> {
+        let Some(pmtud) = self.pmtud.as_mut() else {
+            return Ok(());
+        };
+        let before = pmtud.status();
+        let action = step(pmtud, &mut self.app_state);
+        let after = pmtud.status();
+        if before != after {
+            self.event(Event::PmtudStateChanged(after));
+        }
+        self.handle_pmtud_action(action)
+    }
+
     /// Inject a tick to PMTUD (after timer started with
     /// [`crate::DplpmtudTimer::start`] expires).
     pub fn pmtud_tick(&mut self) -> ConnectionResult<()> {
@@ -1670,12 +1689,17 @@ impl<AppState: Send> Connection<AppState> {
             return Ok(());
         };
 
-        let Some(pmtud) = self.pmtud.as_mut() else {
-            return Ok(());
-        };
+        self.drive_pmtud(|pmtud, state| pmtud.tick(state))
+    }
 
-        let action = pmtud.tick(&mut self.app_state);
-        self.handle_pmtud_action(action)
+    /// Current path MTU discovery status, or `None` when PMTUD is not
+    /// enabled on this connection (no timer was supplied via
+    /// [`crate::ClientConnectionBuilder::with_pmtud_timer`], or the
+    /// connection is not a datagram connection).
+    ///
+    /// Changes are also delivered as [`Event::PmtudStateChanged`].
+    pub fn pmtud_status(&self) -> Option<dplpmtud::Status> {
+        self.pmtud.as_ref().map(|pmtud| pmtud.status())
     }
 
     /// Update the session id (only the one we wanted to rotate to) after the connection is validated.
@@ -1942,10 +1966,7 @@ impl<AppState: Send> Connection<AppState> {
             self.check_expresslane_health(&pong.payload)?;
         }
 
-        if let Some(ref mut pmtud) = self.pmtud {
-            let action = pmtud.pong_received(&pong, &mut self.app_state);
-            self.handle_pmtud_action(action)?;
-        }
+        self.drive_pmtud(|pmtud, state| pmtud.pong_received(&pong, state))?;
 
         Ok(())
     }

--- a/lightway-core/src/connection/dplpmtud.rs
+++ b/lightway-core/src/connection/dplpmtud.rs
@@ -170,6 +170,7 @@ pub enum State {
 /// [`crate::Event::PmtudStateChanged`] and returned by
 /// [`crate::Connection::pmtud_status`].
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Status {
     /// Current state.
     pub state: State,
@@ -179,8 +180,9 @@ pub struct Status {
     /// estimate ([`State::Disabled`], [`State::Base`], [`State::Error`]).
     pub plpmtu: Option<u16>,
     /// Largest inside (application) packet that fits a single `Data`
-    /// frame at `plpmtu` — the size the connection uses to clamp TCP MSS
-    /// and above which it fragments. `None` whenever `plpmtu` is.
+    /// frame at `plpmtu`: the connection fragments inside packets above
+    /// it and clamps TCP MSS to `max_packet_size - 40` (the IPv4 and TCP
+    /// headers). `None` whenever `plpmtu` is.
     pub max_packet_size: Option<usize>,
 }
 

--- a/lightway-core/src/connection/dplpmtud.rs
+++ b/lightway-core/src/connection/dplpmtud.rs
@@ -148,12 +148,40 @@ pub(crate) enum Action {
 }
 
 /// DPLPMTUD states as defined in the RFC.
-enum State {
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum State {
+    /// PMTUD is not running (the connection is not online yet).
     Disabled,
+    /// Probing the base PLPMTU to confirm basic connectivity. No
+    /// estimate is available.
     Base,
+    /// The base PLPMTU could not be confirmed; it is re-probed until
+    /// connectivity returns. No estimate is available.
     Error,
+    /// Searching upward for a larger PLPMTU. The current estimate has
+    /// been confirmed and is in use.
     Searching,
+    /// The search has converged. The estimate is periodically
+    /// re-confirmed and a raise is attempted.
     SearchComplete,
+}
+
+/// A snapshot of DPLPMTUD, delivered with
+/// [`crate::Event::PmtudStateChanged`] and returned by
+/// [`crate::Connection::pmtud_status`].
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Status {
+    /// Current state.
+    pub state: State,
+    /// Current PLPMTU estimate: the largest lightway datagram (frame
+    /// header plus payload, before D/TLS and IP/UDP encapsulation) the
+    /// path is believed to carry. `None` while there is no usable
+    /// estimate ([`State::Disabled`], [`State::Base`], [`State::Error`]).
+    pub plpmtu: Option<u16>,
+    /// Largest inside (application) packet that fits a single `Data`
+    /// frame at `plpmtu` — the size the connection uses to clamp TCP MSS
+    /// and above which it fragments. `None` whenever `plpmtu` is.
+    pub max_packet_size: Option<usize>,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -227,6 +255,15 @@ impl<AppState> Dplpmtud<AppState> {
         match self.state {
             State::Searching | State::SearchComplete => Some(self.plpmtu as usize),
             _ => None,
+        }
+    }
+
+    /// Snapshot of the current state and estimate.
+    pub(crate) fn status(&self) -> Status {
+        Status {
+            state: self.state,
+            plpmtu: self.current_plpmtu().map(|plpmtu| plpmtu as u16),
+            max_packet_size: self.maximum_packet_sizes().map(|(mps, _)| mps),
         }
     }
 
@@ -557,6 +594,167 @@ mod tests {
         for id in (0..3 * u16::MAX as usize).map(|_| pmtud.next_probe_id()) {
             assert!(!id.is_zero());
         }
+    }
+
+    #[test]
+    fn status_tracks_state_and_estimate() {
+        let timer = FakeTimer::new();
+        let mut pmtud = Dplpmtud::new(BASE_PLPMTU, TEST_MAX_PLPMTU, timer.clone());
+        let none = |state| Status {
+            state,
+            plpmtu: None,
+            max_packet_size: None,
+        };
+        assert_eq!(pmtud.status(), none(State::Disabled));
+
+        // Base probing: no usable estimate yet.
+        let _ = pmtud.online(&mut ());
+        assert_eq!(pmtud.status(), none(State::Base));
+
+        // Every confirmed probe raises the estimate while Searching ...
+        let mut expected = BASE_PLPMTU;
+        loop {
+            let id = pmtud.pending_probe.as_ref().unwrap().id;
+            let _ = pmtud.pong_received(
+                &wire::Pong {
+                    id: id.as_u16(),
+                    payload: Default::default(),
+                },
+                &mut (),
+            );
+            let status = pmtud.status();
+            assert_eq!(status.plpmtu, Some(expected));
+            assert_eq!(
+                status.max_packet_size,
+                Some(wire::Data::maximum_packet_size_for_plpmtu(
+                    expected as usize
+                ))
+            );
+            if expected == TEST_MAX_PLPMTU {
+                break;
+            }
+            assert_eq!(status.state, State::Searching);
+            expected = std::cmp::min(expected + PROBE_BIG_STEP, TEST_MAX_PLPMTU);
+        }
+        // ... until the search converges on the maximum.
+        assert_eq!(pmtud.status().state, State::SearchComplete);
+
+        // Losing the base probe MAX_PROBES times enters Error with no
+        // estimate; the next confirmed base probe restores one.
+        let mut pmtud = Dplpmtud::new(BASE_PLPMTU, TEST_MAX_PLPMTU, timer.clone());
+        let _ = pmtud.online(&mut ());
+        for _ in 0..MAX_PROBES {
+            let _ = pmtud.tick(&mut ());
+        }
+        assert_eq!(pmtud.status(), none(State::Error));
+        let id = pmtud.pending_probe.as_ref().unwrap().id;
+        let _ = pmtud.pong_received(
+            &wire::Pong {
+                id: id.as_u16(),
+                payload: Default::default(),
+            },
+            &mut (),
+        );
+        assert_eq!(
+            pmtud.status(),
+            Status {
+                state: State::Searching,
+                plpmtu: Some(BASE_PLPMTU),
+                max_packet_size: Some(wire::Data::maximum_packet_size_for_plpmtu(
+                    BASE_PLPMTU as usize
+                )),
+            }
+        );
+    }
+
+    /// The status snapshot (and therefore `Event::PmtudStateChanged`, which
+    /// fires only when it changes) must stay put across probe retries and the
+    /// big-to-small step switch, and must move on every genuine transition
+    /// including the ones that leave `SearchComplete`.
+    #[test]
+    fn status_changes_only_on_state_or_estimate_transitions() {
+        let timer = FakeTimer::new();
+        let mut pmtud = Dplpmtud::new(BASE_PLPMTU, TEST_MAX_PLPMTU, timer.clone());
+        fn pong_pending(pmtud: &mut Dplpmtud<()>) {
+            let id = pmtud.pending_probe.as_ref().unwrap().id;
+            let _ = pmtud.pong_received(
+                &wire::Pong {
+                    id: id.as_u16(),
+                    payload: Default::default(),
+                },
+                &mut (),
+            );
+        }
+
+        // Base probe retries are silent.
+        let _ = pmtud.online(&mut ());
+        let base = pmtud.status();
+        for _ in 1..MAX_PROBES {
+            let _ = pmtud.tick(&mut ());
+            assert_eq!(pmtud.status(), base);
+        }
+
+        // Confirming the base yields the first estimate ...
+        pong_pending(&mut pmtud);
+        let searching = pmtud.status();
+        assert_eq!(searching.state, State::Searching);
+        assert_eq!(searching.plpmtu, Some(BASE_PLPMTU));
+
+        // ... which losing the first search probe MAX_PROBES times (the switch
+        // from big to small steps) does not disturb ...
+        for _ in 0..MAX_PROBES {
+            let _ = pmtud.tick(&mut ());
+            assert_eq!(pmtud.status(), searching);
+        }
+        assert!(matches!(pmtud.step_size, StepSize::Small));
+
+        // ... until the small-step probe is lost as well and the search
+        // converges on the confirmed estimate.
+        for _ in 0..MAX_PROBES {
+            let _ = pmtud.tick(&mut ());
+        }
+        let complete = Status {
+            state: State::SearchComplete,
+            ..searching
+        };
+        assert_eq!(pmtud.status(), complete);
+        timer.expect_pending(PMTU_RAISE_TIMER_TIMEOUT);
+
+        // The raise timer sends a CONFIRM probe at the current estimate: silent.
+        let _ = pmtud.tick(&mut ());
+        assert_eq!(pmtud.status(), complete);
+        assert_eq!(pmtud.pending_probe.as_ref().unwrap().size, BASE_PLPMTU);
+
+        // Its success restarts the search: the state changes, the estimate
+        // does not.
+        pong_pending(&mut pmtud);
+        assert_eq!(
+            pmtud.status(),
+            Status {
+                state: State::Searching,
+                ..complete
+            }
+        );
+
+        // Converge again, then black-hole the CONFIRM probe: back to Base with
+        // the estimate withdrawn.
+        for _ in 0..2 * MAX_PROBES {
+            let _ = pmtud.tick(&mut ());
+        }
+        assert_eq!(pmtud.status(), complete);
+        let _ = pmtud.tick(&mut ()); // raise timer -> CONFIRM probe
+        for _ in 0..MAX_PROBES {
+            let _ = pmtud.tick(&mut ()); // lost, lost, given up
+        }
+        assert_eq!(
+            pmtud.status(),
+            Status {
+                state: State::Base,
+                plpmtu: None,
+                max_packet_size: None,
+            }
+        );
+        timer.expect_pending(PROBE_TIME_TIMEOUT);
     }
 
     #[test_case(State::Base, 1250 => None)]

--- a/lightway-core/src/connection/dplpmtud.rs
+++ b/lightway-core/src/connection/dplpmtud.rs
@@ -182,7 +182,7 @@ pub struct Status {
     /// Largest inside (application) packet that fits a single `Data`
     /// frame at `plpmtu`: the connection fragments inside packets above
     /// it and clamps TCP MSS to `max_packet_size - 40` (the IPv4 and TCP
-    /// headers). `None` whenever `plpmtu` is.
+    /// headers). `None` whenever `plpmtu` is `None`.
     pub max_packet_size: Option<usize>,
 }
 

--- a/lightway-core/src/connection/event.rs
+++ b/lightway-core/src/connection/event.rs
@@ -52,24 +52,9 @@ pub enum Event {
     },
     /// Expresslane state changed
     ExpresslaneStateChanged(ExpresslaneState),
-    /// Path MTU discovery state or estimate changed.
+    /// Path MTU discovery state or estimate changed; see [`PmtudStatus`].
+    /// [`crate::Connection::pmtud_status`] returns the current snapshot.
     ///
-    /// Fired on every DPLPMTUD state transition and whenever the PLPMTU
-    /// estimate changes within a state (each confirmed search probe).
-    /// [`PmtudStatus::max_packet_size`] is the largest inside packet the
-    /// connection now sends unfragmented; `None` means no estimate is
-    /// available and the connection sizes packets by its configured
-    /// outside MTU instead.
-    ///
-    /// Only client datagram connections built with a PMTUD timer
-    /// ([`crate::ClientConnectionBuilder::with_pmtud_timer`]) emit this
-    /// event; servers and stream connections never do.
-    ///
-    /// The event is a notification of a change, delivered synchronously
-    /// from the call that drove the state machine. A consumer that
-    /// receives events through an asynchronous bridge which does not
-    /// preserve their order (for example one that spawns a task per
-    /// event) should read [`crate::Connection::pmtud_status`] for the
-    /// current snapshot rather than apply the event's payload.
+    /// Client datagram connections built with a PMTUD timer only
     PmtudStateChanged(PmtudStatus),
 }

--- a/lightway-core/src/connection/event.rs
+++ b/lightway-core/src/connection/event.rs
@@ -1,5 +1,5 @@
 use crate::connection::ExpresslaneState;
-use crate::{SessionId, State};
+use crate::{PmtudStatus, SessionId, State};
 
 /// A lightway event
 #[derive(Debug)]
@@ -52,4 +52,15 @@ pub enum Event {
     },
     /// Expresslane state changed
     ExpresslaneStateChanged(ExpresslaneState),
+    /// Path MTU discovery state or estimate changed.
+    ///
+    /// Fired on every DPLPMTUD state transition and whenever the PLPMTU
+    /// estimate changes within a state (each confirmed search probe).
+    /// [`PmtudStatus::max_packet_size`] is the largest inside packet the
+    /// connection now sends unfragmented; `None` means no estimate is
+    /// available and the connection sizes packets by its configured
+    /// outside MTU instead.
+    ///
+    /// Client datagram connections built with a PMTUD timer only
+    PmtudStateChanged(PmtudStatus),
 }

--- a/lightway-core/src/connection/event.rs
+++ b/lightway-core/src/connection/event.rs
@@ -61,6 +61,15 @@ pub enum Event {
     /// available and the connection sizes packets by its configured
     /// outside MTU instead.
     ///
-    /// Client datagram connections built with a PMTUD timer only
+    /// Only client datagram connections built with a PMTUD timer
+    /// ([`crate::ClientConnectionBuilder::with_pmtud_timer`]) emit this
+    /// event; servers and stream connections never do.
+    ///
+    /// The event is a notification of a change, delivered synchronously
+    /// from the call that drove the state machine. A consumer that
+    /// receives events through an asynchronous bridge which does not
+    /// preserve their order (for example one that spawns a task per
+    /// event) should read [`crate::Connection::pmtud_status`] for the
+    /// current snapshot rather than apply the event's payload.
     PmtudStateChanged(PmtudStatus),
 }

--- a/lightway-core/src/lib.rs
+++ b/lightway-core/src/lib.rs
@@ -31,7 +31,9 @@ pub use cipher::Cipher;
 pub use connection::{
     ClientConnectionBuilder, Connection, ConnectionActivity, ConnectionBuilderError,
     ConnectionError, ConnectionResult, Event, EventCallback, EventCallbackArg, ExpresslaneState,
-    ServerConnectionBuilder, State, dplpmtud::Timer as DplpmtudTimer, expresslane::*,
+    ServerConnectionBuilder, State,
+    dplpmtud::{State as PmtudState, Status as PmtudStatus, Timer as DplpmtudTimer},
+    expresslane::*,
 };
 pub use context::{
     ClientContext, ClientContextBuilder, ConnectionType, ContextError, ExpresslaneTickData,

--- a/lightway-core/tests/common/connection.rs
+++ b/lightway-core/tests/common/connection.rs
@@ -530,6 +530,9 @@ pub async fn client<S: TestSock>(
                 Event::EncodingStateChanged { enabled } => {
                     println!("Encoding state change to {enabled}")
                 }
+                Event::PmtudStateChanged(status) => {
+                    println!("PMTUD status change to {status:?}")
+                }
             }
         }
     });

--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -860,3 +860,227 @@ async fn peer_that_stops_reporting_degrades() {
         "the first two windows must be tolerated (skip) and the third fail-safe"
     );
 }
+
+/// PMTUD reports its progress to the application: `Event::PmtudStateChanged`
+/// fires once per state or estimate change (never for a no-op step), the
+/// getter agrees with the last event, and for every step that requests a
+/// probe the event is delivered before that probe reaches the outside I/O.
+#[tokio::test]
+async fn pmtud_reports_status_changes() {
+    /// One entry per PMTUD event and per outside send, in the order the
+    /// connection produced them: both happen synchronously inside the call
+    /// that drives the state machine, so the log preserves their ordering.
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    enum Entry {
+        Online,
+        Pmtud(PmtudStatus),
+        Send(usize),
+    }
+    type Log = Arc<Mutex<Vec<Entry>>>;
+
+    struct RecordingSock {
+        inner: Arc<TestDatagramSock>,
+        log: Log,
+    }
+
+    impl OutsideIOSendCallback for RecordingSock {
+        fn send(&self, buf: &[u8]) -> IOCallbackResult<usize> {
+            self.log.lock().unwrap().push(Entry::Send(buf.len()));
+            self.inner.send(buf)
+        }
+
+        fn send_gso(
+            &self,
+            bufs: &[std::io::IoSlice<'_>],
+            gso_size: u16,
+        ) -> IOCallbackResult<usize> {
+            self.inner.send_gso(bufs, gso_size)
+        }
+
+        fn peer_addr(&self) -> std::net::SocketAddr {
+            self.inner.peer_addr()
+        }
+
+        // Unix datagram sockets have no DF bit; accept the probe bracket.
+        fn enable_pmtud_probe(&self) -> std::io::Result<()> {
+            Ok(())
+        }
+
+        fn disable_pmtud_probe(&self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct RecordingEvents {
+        inner: EventStreamCallback,
+        log: Log,
+    }
+
+    impl EventCallback for RecordingEvents {
+        fn event(&mut self, event: Event) {
+            match &event {
+                Event::StateChanged(State::Online) => self.log.lock().unwrap().push(Entry::Online),
+                Event::PmtudStateChanged(status) => {
+                    self.log.lock().unwrap().push(Entry::Pmtud(*status))
+                }
+                _ => {}
+            }
+            self.inner.event(event);
+        }
+    }
+
+    // Generate the shared test PKI before the timeout window (RSA keygen is
+    // very slow on QEMU).
+    gen_shared_testing_pki();
+
+    let (client_sock, server_sock) = UnixDatagram::pair().expect("UnixDatagram");
+    let server_sock = Arc::new(TestDatagramSock(server_sock));
+    let client_sock = Arc::new(TestDatagramSock(client_sock));
+
+    let (auth, _last_method) = TestAuth::new();
+    let pqc = PQCrypto {
+        server_pqc: false,
+        keyshare: None,
+    };
+
+    // The server answers every probe Ping with a Pong.
+    let mut server_task = tokio::spawn(server(server_sock, auth, pqc, None, None, None));
+
+    let log: Log = Default::default();
+    let ca_cert = RootCertificate::Asn1Buffer(&gen_shared_testing_pki().ca_cert_der);
+    let (tun, _inside_rx) = ChannelTun::new();
+    let (event_cb, mut event_stream) = EventStreamCallback::new();
+    let (ticker, ticker_task) = ConnectionTicker::new();
+    let (pmtud_timer, pmtud_timer_task) = lightway_app_utils::DplpmtudTimer::new();
+    let state = ConnectionState { ticker };
+    let outside: OutsideIOSendCallbackArg = Arc::new(RecordingSock {
+        inner: client_sock.clone(),
+        log: log.clone(),
+    });
+
+    let client = ClientContextBuilder::new(
+        client_sock.connection_type(),
+        ca_cert,
+        Some(Arc::new(tun)),
+        Arc::new(Client),
+        connection_ticker_cb,
+    )
+    .unwrap()
+    .build()
+    .start_connect(outside, MAX_OUTSIDE_MTU)
+    .unwrap()
+    .with_auth_token("LET ME IN")
+    .with_event_cb(Box::new(RecordingEvents {
+        inner: event_cb,
+        log: log.clone(),
+    }))
+    .with_pmtud_timer(pmtud_timer)
+    .connect(state)
+    .unwrap();
+    let client = Arc::new(Mutex::new(client));
+
+    let mut join_set = JoinSet::new();
+    ticker_task.spawn_in(Arc::downgrade(&client), &mut join_set);
+    pmtud_timer_task.spawn(Arc::downgrade(&client), &mut join_set);
+
+    // Drain events so the stream never backpressures the connection.
+    tokio::spawn(async move { while event_stream.next().await.is_some() {} });
+
+    // Pump the client until the search converges. Nothing is lost on the
+    // socket pair, so no probe timer ever fires and every probe is confirmed.
+    let driver = async {
+        loop {
+            client_sock
+                .readable()
+                .await
+                .expect("client socket readable");
+            let mut buf = BytesMut::with_capacity(MAX_OUTSIDE_MTU);
+            match client_sock.try_recv_buf(&mut buf) {
+                Ok(0) => panic!("EOF"),
+                Ok(_) => {}
+                Err(e) if matches!(e.kind(), std::io::ErrorKind::WouldBlock) => continue,
+                Err(e) => panic!("client recv: {e}"),
+            }
+            let mut c = client.lock().unwrap();
+            let pkt = OutsidePacket::Wire(&mut buf, client_sock.connection_type());
+            c.outside_data_received(pkt).expect("outside data received");
+            if c.pmtud_status()
+                .is_some_and(|s| s.state == PmtudState::SearchComplete)
+            {
+                return;
+            }
+        }
+    };
+
+    tokio::time::timeout(
+        std::time::Duration::from_millis(get_test_timeout()),
+        async {
+            tokio::select! {
+                _ = driver => {}
+                r = &mut server_task => panic!("server task ended early: {r:?}"),
+            }
+        },
+    )
+    .await
+    .expect("test timed out");
+
+    let log = log.lock().unwrap().clone();
+    let online = log
+        .iter()
+        .position(|e| *e == Entry::Online)
+        .expect("Online was reported");
+    let pmtud: Vec<(usize, PmtudStatus)> = log
+        .iter()
+        .enumerate()
+        .filter_map(|(i, e)| match e {
+            Entry::Pmtud(s) => Some((i, *s)),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        pmtud.first().is_some_and(|(i, _)| *i > online),
+        "discovery starts once Online: {log:?}"
+    );
+
+    // One event per change, none for a no-op step: base 1250, big steps of
+    // 32 up to max_dtls_mtu(MAX_OUTSIDE_MTU) = 1419, at which point the
+    // search converges without an intermediate Searching(1419).
+    let expected = [
+        (PmtudState::Base, None),
+        (PmtudState::Searching, Some(1250)),
+        (PmtudState::Searching, Some(1282)),
+        (PmtudState::Searching, Some(1314)),
+        (PmtudState::Searching, Some(1346)),
+        (PmtudState::Searching, Some(1378)),
+        (PmtudState::Searching, Some(1410)),
+        (PmtudState::SearchComplete, Some(1419)),
+    ];
+    let observed: Vec<_> = pmtud.iter().map(|(_, s)| (s.state, s.plpmtu)).collect();
+    assert_eq!(observed, expected, "full log: {log:?}");
+    for (_, s) in &pmtud {
+        // wire::Data frame overhead: kind byte plus 2-byte length.
+        assert_eq!(s.max_packet_size, s.plpmtu.map(|p| p as usize - 3), "{s:?}");
+    }
+
+    // The getter reports the same snapshot as the last event.
+    assert_eq!(
+        client.lock().unwrap().pmtud_status(),
+        pmtud.last().map(|(_, s)| *s)
+    );
+
+    // Every snapshot that requests a probe is delivered BEFORE that probe
+    // is sent: the next log entry after it is the probe itself (an
+    // encrypted datagram at least as large as the probed PLPMTU, which here
+    // is never below the base).
+    for (i, s) in &pmtud {
+        if s.state == PmtudState::SearchComplete {
+            continue;
+        }
+        match log.get(i + 1) {
+            Some(Entry::Send(len)) => {
+                assert!(*len >= 1250, "probe after {s:?} was only {len} bytes")
+            }
+            other => panic!("expected the probe send right after {s:?}, found {other:?}"),
+        }
+    }
+}

--- a/lightway-server/src/connection_manager.rs
+++ b/lightway-server/src/connection_manager.rs
@@ -198,7 +198,7 @@ async fn handle_events(
             Event::ExpresslaneStateChanged(s) => {
                 info!("Setting expresslane state to {:?}", s);
             }
-            Event::FirstPacketReceived => {
+            Event::FirstPacketReceived | Event::PmtudStateChanged(_) => {
                 unreachable!("client only event received");
             }
             Event::EncodingStateChanged { enabled } => handle_encoding_state_changed(enabled),


### PR DESCRIPTION
## Description

DPLPMTUD (`lightway-core/src/connection/dplpmtud.rs`) is a black box to the embedder: an
application can turn it on with `with_pmtud_timer`, but the state machine, its `State`,
`effective_pmtu()` and `maximum_packet_sizes()` are crate-private and `Event` has no PMTUD
variant, so the application never learns what discovery found. This PR exposes the outcome
without changing how discovery works:

- `dplpmtud::State` becomes public, re-exported as `lightway_core::PmtudState`, with
  per-variant docs.
- New public `dplpmtud::Status`, re-exported as `lightway_core::PmtudStatus`:
  `{ state, plpmtu: Option<u16>, max_packet_size: Option<usize> }`. `plpmtu` is the current
  PLPMTU estimate. `max_packet_size` is the largest inside packet that fits a single `Data`
  frame at that PLPMTU: the threshold above which `send_to_outside` fragments, and the size
  from which `inside_data_received` derives its TCP MSS clamp (`max_packet_size - 40`). Both
  are `None` in `Disabled` / `Base` / `Error`, where the connection applies no clamp and no
  fragmentation and sizes datagrams by the configured outside MTU.
- New `Event::PmtudStateChanged(PmtudStatus)`, fired on every state transition and whenever
  the estimate changes within a state (each confirmed search probe). It is delivered before the
  probe the step requested is sent, so an application observes the status the connection is
  about to apply to its own traffic.
- New `Connection::pmtud_status() -> Option<PmtudStatus>` for polling; `None` when PMTUD is
  not configured on the connection. Note that nothing currently drives `Dplpmtud::offline`
  on disconnect (it is `#[allow(dead_code)]`), so a disconnected `Connection` that has not
  been dropped keeps reporting its last estimate; unchanged here.

Shape: the event carries a `PmtudStatus` snapshot rather than a bare `PmtudState` because the
state alone is not actionable; the estimate moves within `Searching` on every confirmed probe
and that is what an embedder has to react to. This follows `EncodingStateChanged { enabled }`
and `SessionIdRotationAcknowledged { old, new }`, which carry the data the consumer needs, and a
struct lets fields be added later without a new variant. `State` and `Status` are `pub` items
in the `pub(crate) mod dplpmtud`, re-exported at the crate root the same way `ExpresslaneState`
is from `pub(crate) mod expresslane`.

Implementation: the three places that step the state machine (`set_state(Online)`,
`pmtud_tick`, `handle_pong`) now go through one helper, `Connection::drive_pmtud`, which
snapshots `status()` before and after the step and emits the event only when the snapshot
changed. Probe retries and the big-to-small step switch therefore stay silent; entering or
leaving `SearchComplete`, a raise, and a black-hole fallback to `Base` all fire.

`Event` is not `#[non_exhaustive]`, so the new variant needs an arm in every exhaustive match
in the workspace. `lightway-client` (`handle_events`, and the mobile `handle_events`) log it at
`info` and, like the other client events, forward it to the application's `EventCallback`.
`lightway-server` treats it as a client-only event next to `FirstPacketReceived`
(`unreachable!`, which is safe because `ServerConnectionBuilder` never installs a PMTUD timer).
The integration test harness prints it.

`docs/pmtu_discovery.md` gains a paragraph on observing the outcome.

## Motivation and Context

An embedder whose data plane bypasses `Connection` (for example a kernel or driver offload of
the ExpressLane fast path) never benefits from the MSS clamp and fragmentation that
`inside_data_received` / `send_to_outside` apply, because those packets are not routed through
core. To size its own traffic correctly it needs the discovered PLPMTU, and it needs to know
when the estimate is withdrawn (black hole) so it can fall back. There is currently no way to
get either.

Even for a conventional client the outcome of discovery is hard to see: search starts and probe
sends are logged at `info`, but convergence (`PMTU discovery complete`) and the black-hole
fallback are `debug` only, which makes low-MTU problems hard to diagnose from default logs. The
new `info!` log in `lightway-client` closes that gap.

I did not find an existing issue for this; happy to open one if you prefer to track it that way.

## How Has This Been Tested?

- `cargo test -p lightway-core --lib` passes apart from the pre-existing Windows-only failure
  in `cipher::tests::ensure_supported_group_list` (it fails identically on `main`). This
  includes two new tests in `dplpmtud.rs`: `status_tracks_state_and_estimate` walks
  Disabled → Base → Searching (1250, 1282, … 1419) → SearchComplete and Base → Error →
  Searching, asserting `plpmtu` and `max_packet_size` at every step;
  `status_changes_only_on_state_or_estimate_transitions` asserts the snapshot is unchanged
  across base-probe retries, across the big-to-small step switch and across the
  `SearchComplete` re-confirm probe, and that it changes on the raise (`SearchComplete` →
  `Searching`, same estimate) and on the black-hole fallback (`SearchComplete` → `Base`,
  estimate withdrawn).
- `RUSTDOCFLAGS="-D warnings" cargo doc -p lightway-core --no-deps --document-private-items`
  is clean (the new public items are documented and their intra-doc links resolve).
- `cargo fmt --check` and `cargo check -p lightway-client --all-targets` are clean. The mobile
  `handle_events` arm is behind `feature = "mobile"`, which I did not build locally; CI's
  `nix-mobile-build` job (`cargo clippy --features=mobile --all-targets -- -D warnings`)
  covers it.
- Developed on Windows, where `lightway-server` and the `connection` integration test target do
  not build (Unix-only sockets), so those two arms were verified by inspection only; please rely
  on CI for them.
- End-to-end, outside this repo: the event was exercised through a C ABI shim against an
  in-process `lightway-core` server (client built with `with_pmtud_timer`, probes and pongs
  flowing through real `Connection`s). Seven tests assert the exact probe sizes and event
  sequences for a full search to 1419 on a 1500-byte outside MTU, convergence below a
  simulated narrow path within small-step granularity, a raise after the path widens, the
  black-hole fallback (`Base` with no estimate, then re-convergence lower), and disconnect /
  reconnect.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
  `Event` is not `#[non_exhaustive]`, so downstream code that matches on it exhaustively
  needs a `PmtudStateChanged` arm; in-tree consumers are updated here.

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`

## Related

Two pre-existing PMTUD issues came up while working on this. They are unrelated to the API
added here, so they are filed separately rather than mixed into this PR:

- #539: `PathMtuDiscoveryRequired` fires when PMTUD is *present* (polarity of the check).
- #540: PMTUD probe ceiling assumes an IPv4 header on IPv6 outside paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
