### PR TITLE
CVPN-2761: Make OutsideIO injectable in server, client

### DIFF
--- a/docs/logs_and_metrics.md
+++ b/docs/logs_and_metrics.md
@@ -58,7 +58,6 @@ Lightway server also supports metrics to monitor. The following are the metrics 
 | udp_bad_packet_version | server | Counter | Counts UDP packets where the the version in the wire protocol header was not a version supported by the server |
 | udp_rejected_session | server | Counter | Counts UDP packets which were rejected due to the session id in the wire protocol header not being recognised |
 | udp_parse_wire_failed | server | Counter | Counts UDP packets which could not be parsed. Indicates plugin ingress chain failed |
-| udp_no_header | server | Counter | Counts UDP packets where the wire protocol header was not found/could not be found |
 | udp_session_rotation_begin | server | Counter | Counts connections which started a session ID rotation |
 | udp_session_rotation_finalized | server | Counter | Counts connections which completed a session ID rotation |
 | to_link_up_time | server | Histogram | Measures time between a connection being started (on first packet) and the Link Up state (i.e. (D)TLS negotiation complete) |

--- a/lightway-app-utils/src/cmsg.rs
+++ b/lightway-app-utils/src/cmsg.rs
@@ -34,8 +34,6 @@ impl<const N: usize> Buffer<N> {
         N
     }
 
-    pub fn reset(&mut self) {}
-
     /// Iterate over the control messages the kernel wrote.
     ///
     /// # Safety

--- a/lightway-client/src/io/outside.rs
+++ b/lightway-client/src/io/outside.rs
@@ -81,5 +81,6 @@ pub trait OutsideIO: Sync + Send {
     fn reconnect(&self) {}
 
     /// Returns the underlying socket tagged with its transport type.
-    fn socket(&self) -> OutsideSocket;
+    /// `None` when the transport has no single OS socket to name.
+    fn socket(&self) -> Option<OutsideSocket>;
 }

--- a/lightway-client/src/io/outside/tcp.rs
+++ b/lightway-client/src/io/outside/tcp.rs
@@ -110,7 +110,7 @@ impl OutsideIO for Tcp {
         self.peer_addr()
     }
 
-    fn socket(&self) -> OutsideSocket {
+    fn socket(&self) -> Option<OutsideSocket> {
         #[cfg(unix)]
         use std::os::fd::AsRawFd;
         #[cfg(windows)]
@@ -119,7 +119,7 @@ impl OutsideIO for Tcp {
         let handle = self.0.as_raw_fd();
         #[cfg(windows)]
         let handle = self.0.as_raw_socket();
-        OutsideSocket::Tcp(handle)
+        Some(OutsideSocket::Tcp(handle))
     }
 }
 

--- a/lightway-client/src/io/outside/udp.rs
+++ b/lightway-client/src/io/outside/udp.rs
@@ -342,7 +342,7 @@ impl OutsideIO for Udp {
         }
     }
 
-    fn socket(&self) -> OutsideSocket {
+    fn socket(&self) -> Option<OutsideSocket> {
         #[cfg(unix)]
         use std::os::fd::AsRawFd;
         #[cfg(windows)]
@@ -351,7 +351,7 @@ impl OutsideIO for Udp {
         let handle = self.sock.as_raw_fd();
         #[cfg(windows)]
         let handle = self.sock.as_raw_socket();
-        OutsideSocket::Udp(handle)
+        Some(OutsideSocket::Udp(handle))
     }
 }
 

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -130,8 +130,9 @@ pub enum LightwayError {
 /// to the live socket without reopening it.
 #[derive(Debug, Clone, Copy)]
 pub struct ConnectionInfo {
-    /// The underlying socket, tagged with its transport type.
-    pub socket: io::outside::OutsideSocket,
+    /// The underlying socket, tagged with its transport type. `None` when
+    /// the outside IO has no single OS socket to name.
+    pub socket: Option<io::outside::OutsideSocket>,
     /// Remote peer address the connection is established to.
     pub peer_addr: std::net::SocketAddr,
 }

--- a/lightway-client/src/lib.rs
+++ b/lightway-client/src/lib.rs
@@ -78,6 +78,12 @@ use tracing::info;
 pub enum ClientConnectionMode {
     Stream(Option<TcpStream>),
     Datagram(Option<UdpSocket>),
+    /// A datagram transport supplied by the application, in place of the
+    /// socket the client otherwise creates. Every socket option in the
+    /// client config goes unused.
+    DatagramIo(Arc<dyn io::outside::OutsideIO>),
+    /// A stream transport supplied by the application; see `DatagramIo`.
+    StreamIo(Arc<dyn io::outside::OutsideIO>),
 }
 
 impl std::fmt::Debug for ClientConnectionMode {
@@ -85,6 +91,8 @@ impl std::fmt::Debug for ClientConnectionMode {
         match self {
             Self::Stream(_) => f.debug_tuple("Stream").finish(),
             Self::Datagram(_) => f.debug_tuple("Datagram").finish(),
+            Self::DatagramIo(_) => f.debug_tuple("DatagramIo").finish(),
+            Self::StreamIo(_) => f.debug_tuple("StreamIo").finish(),
         }
     }
 }
@@ -1162,6 +1170,8 @@ pub async fn connect<
 
     let (connection_type, outside_io): (ConnectionType, Arc<dyn io::outside::OutsideIO>) =
         match mode {
+            ClientConnectionMode::DatagramIo(io) => (ConnectionType::Datagram, io),
+            ClientConnectionMode::StreamIo(io) => (ConnectionType::Stream, io),
             ClientConnectionMode::Datagram(maybe_sock) => {
                 #[cfg_attr(not(batch_receive), allow(unused_mut))]
                 let mut sock = io::outside::Udp::new(

--- a/lightway-server/src/connection_manager/connection_map.rs
+++ b/lightway-server/src/connection_manager/connection_map.rs
@@ -148,7 +148,6 @@ impl<T: Value> ConnectionMap<T> {
     }
 }
 
-// Tests START -> panic, unwrap, expect allowed
 #[cfg(test)]
 mod tests {
     use test_case::test_case;
@@ -405,5 +404,3 @@ mod tests {
         }
     }
 }
-
-// Tests END -> panic, unwrap, expect allowed

--- a/lightway-server/src/io/outside.rs
+++ b/lightway-server/src/io/outside.rs
@@ -1,3 +1,4 @@
+pub(crate) mod datagram;
 pub(crate) mod tcp;
 pub(crate) mod udp;
 

--- a/lightway-server/src/io/outside.rs
+++ b/lightway-server/src/io/outside.rs
@@ -2,13 +2,150 @@ pub(crate) mod datagram;
 pub(crate) mod tcp;
 pub(crate) mod udp;
 
+pub(crate) use datagram::DatagramServer;
 pub(crate) use tcp::TcpServer;
-pub(crate) use udp::UdpServer;
+pub(crate) use udp::UdpIo;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use bytes::BytesMut;
+use lightway_core::{
+    IOCallbackResult, MAX_IO_BATCH_SIZE, MAX_OUTSIDE_MTU, OutsideIOSendCallbackArg,
+};
+use std::net::SocketAddr;
 
 #[async_trait]
 pub(crate) trait Server {
     async fn run(&mut self) -> Result<()>;
+}
+
+/// Where one received wire packet came from.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RecvMeta {
+    /// Address the packet was received from.
+    ///
+    /// The server routes by this address before it consults the session
+    /// id, so this is the demultiplex key. It must be unique per client
+    /// and stable for the life of a connection. Two clients that report
+    /// one address collide: the server delivers the second client's
+    /// packets to the first connection, where decryption fails. A
+    /// transport that demultiplexes for itself must synthesize a
+    /// unique, stable address per client.
+    pub peer: SocketAddr,
+
+    /// Local address the packet was received on.
+    pub local: SocketAddr,
+}
+
+/// Application provided outside IO.
+///
+/// The server owns the receive loop and all of the dispatch: parsing the
+/// wire header, routing to a connection, and delivering. An implementation
+/// supplies only the transport.
+///
+#[async_trait]
+pub(crate) trait OutsideIO: Send {
+    /// Receive one wire packet into `buf`, which the implementation
+    /// clears and reserves [`lightway_core::MAX_OUTSIDE_MTU`] on first.
+    ///
+    /// Return `WouldBlock` only after awaiting readiness. The server loop
+    /// retries immediately, so a `WouldBlock` that awaited nothing burns a
+    /// core without making progress.
+    ///
+    /// The loop charges tokio's cooperative budget per datagram received,
+    /// so an implementation that receives through a manual readiness API
+    /// does not have to.
+    async fn recv(&mut self, buf: &mut BytesMut) -> IOCallbackResult<RecvMeta>;
+
+    /// Receive up to [`lightway_core::MAX_IO_BATCH_SIZE`] packets,
+    /// appending one [`RecvMeta`] to `metas` per buffer filled, in the
+    /// same order. `metas` arrives empty, and `metas.len()` is the count.
+    ///
+    /// Implementations must only wait when no packet is available. When
+    /// packets are already queued they return what is ready without
+    /// waiting, so batching adds no latency.
+    ///
+    /// The `WouldBlock` rule on [`Self::recv`] applies here too. Override
+    /// when the transport has a batch receive syscall; the default reads a
+    /// single packet.
+    async fn recv_many(
+        &mut self,
+        bufs: &mut [BytesMut; MAX_IO_BATCH_SIZE],
+        metas: &mut Vec<RecvMeta>,
+    ) -> IOCallbackResult<()> {
+        bufs[0].clear();
+        bufs[0].reserve(MAX_OUTSIDE_MTU);
+        match self.recv(&mut bufs[0]).await {
+            IOCallbackResult::Ok(meta) => {
+                metas.push(meta);
+                IOCallbackResult::Ok(())
+            }
+            IOCallbackResult::WouldBlock => IOCallbackResult::WouldBlock,
+            IOCallbackResult::Err(err) => IOCallbackResult::Err(err),
+        }
+    }
+
+    /// Build the send callback for a connection being created.
+    ///
+    /// Called once per connection, with the metadata of the packet that
+    /// caused the connection to be created.
+    ///
+    /// When a peer roams, the server calls `set_peer_addr` on this
+    /// callback to redirect sends. A transport that routes internally
+    /// can keep the default no-op; the server keys its connection map
+    /// from its own record, not from this callback.
+    fn send_callback(&self, meta: &RecvMeta) -> OutsideIOSendCallbackArg;
+
+    /// Send an already-encoded frame to a peer that has no connection.
+    /// Failures are expected to be ignored: there is no connection to
+    /// report them against.
+    fn send_unconnected(&self, meta: &RecvMeta, buf: &[u8]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    const PEER: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1)), 5000);
+    const LOCAL: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1)), 27690);
+
+    /// Implements only the required methods, so the defaults are what
+    /// the tests below observe.
+    struct MinimalIO;
+
+    #[async_trait]
+    impl OutsideIO for MinimalIO {
+        async fn recv(&mut self, buf: &mut BytesMut) -> IOCallbackResult<RecvMeta> {
+            buf.extend_from_slice(b"one packet");
+            IOCallbackResult::Ok(RecvMeta {
+                peer: PEER,
+                local: LOCAL,
+            })
+        }
+
+        fn send_callback(&self, _meta: &RecvMeta) -> OutsideIOSendCallbackArg {
+            unimplemented!("not needed for default-method tests")
+        }
+
+        fn send_unconnected(&self, _meta: &RecvMeta, _buf: &[u8]) {
+            unimplemented!("not needed for default-method tests")
+        }
+    }
+
+    #[tokio::test]
+    async fn default_recv_many_reads_one_packet() {
+        let mut io = MinimalIO;
+        let mut bufs: [BytesMut; MAX_IO_BATCH_SIZE] =
+            std::array::from_fn(|_| BytesMut::with_capacity(MAX_OUTSIDE_MTU));
+        let mut metas = Vec::new();
+
+        assert!(matches!(
+            io.recv_many(&mut bufs, &mut metas).await,
+            IOCallbackResult::Ok(())
+        ));
+        assert_eq!(metas.len(), 1);
+        assert_eq!(metas[0].peer, PEER);
+        assert_eq!(&bufs[0][..], b"one packet");
+    }
 }

--- a/lightway-server/src/io/outside.rs
+++ b/lightway-server/src/io/outside.rs
@@ -21,7 +21,7 @@ pub(crate) trait Server {
 
 /// Where one received wire packet came from.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct RecvMeta {
+pub struct RecvMeta {
     /// Address the packet was received from.
     ///
     /// The server routes by this address before it consults the session
@@ -43,10 +43,12 @@ pub(crate) struct RecvMeta {
 /// wire header, routing to a connection, and delivering. An implementation
 /// supplies only the transport.
 ///
+/// Pass it as `ServerConnectionMode::DatagramIo`. Datagram transports
+/// only: `TcpServer` is accept-based and does not fit the shared loop.
 #[async_trait]
-pub(crate) trait OutsideIO: Send {
-    /// Receive one wire packet into `buf`, which the implementation
-    /// clears and reserves [`lightway_core::MAX_OUTSIDE_MTU`] on first.
+pub trait OutsideIO: Send {
+    /// Receive one wire packet into `buf`. The implementation clears `buf`
+    /// and reserves [`lightway_core::MAX_OUTSIDE_MTU`] before it receives.
     ///
     /// Return `WouldBlock` only after awaiting readiness. The server loop
     /// retries immediately, so a `WouldBlock` that awaited nothing burns a

--- a/lightway-server/src/io/outside/datagram.rs
+++ b/lightway-server/src/io/outside/datagram.rs
@@ -1,0 +1,113 @@
+//! Carrier-independent datagram dispatch.
+
+use bytes::BytesMut;
+use lightway_core::{
+    ConnectionType, Header, OutsideIOSendCallbackArg, OutsidePacket, SessionId, Version,
+};
+use std::{net::SocketAddr, sync::Arc};
+use tracing::warn;
+
+use crate::{connection_manager::ConnectionManager, metrics};
+
+/// Parse one wire packet, route it to its connection, and hand it over.
+///
+/// `mint` builds the send callback for a connection being created.
+/// `reject` sends an already-encoded reject frame to a peer with no
+/// connection.
+pub(crate) fn data_received(
+    conn_manager: &Arc<ConnectionManager>,
+    buf: &mut BytesMut,
+    peer_addr: SocketAddr,
+    local_addr: SocketAddr,
+    mint: impl FnOnce() -> OutsideIOSendCallbackArg,
+    reject: impl FnOnce(&[u8]),
+) {
+    let pkt = OutsidePacket::Wire(buf, ConnectionType::Datagram);
+    let pkt = match conn_manager.parse_raw_outside_packet(pkt) {
+        Ok(pkt) => pkt,
+        Err(e) => {
+            metrics::udp_parse_wire_failed();
+            warn!("Extracting header from packet failed: {e}");
+            return;
+        }
+    };
+    let Some(hdr) = pkt.header() else {
+        metrics::udp_no_header();
+        warn!("Packet parsing error: Not a UDP frame");
+        return;
+    };
+    let hdr = *hdr;
+
+    if !conn_manager.is_supported_version(hdr.version) {
+        // If the protocol version is not supported then drop
+        // the packet.
+        metrics::udp_bad_packet_version(hdr.version);
+        return;
+    }
+
+    // A peer-address hit delivers even when the session id in `hdr` does
+    // not match, which `find_or_create_datagram_connection_with` would
+    // reject. Do not fold this into the call below.
+    let (conn, roamed) = match conn_manager.find_datagram_connection_with(peer_addr) {
+        Some(conn) => (conn, false),
+        None => match conn_manager.find_or_create_datagram_connection_with(
+            peer_addr,
+            hdr.version,
+            hdr.session,
+            local_addr,
+            mint,
+        ) {
+            Ok(routed) => routed,
+            Err(_e) => {
+                send_reject(reject);
+                return;
+            }
+        },
+    };
+
+    match conn.outside_data_received(pkt) {
+        Ok(0) => {
+            // We will hit this case when there is UDP packet duplication.
+            // TLS library skips duplicate packets and thus no frames read.
+            // It is also possible that adversary can capture the packet
+            // and replay it. In any case, skip processing further
+            if roamed {
+                metrics::udp_session_rotation_attempted_via_replay();
+            }
+        }
+        Ok(_) => {
+            // NOTE: We wait until the first successful TLS
+            // decrypt to protect against the case where a crafted
+            // packet with a session ID causes us to change the
+            // connection IP without verifying the SSL connection
+            // first
+            if roamed {
+                metrics::udp_conn_recovered_via_session(hdr.session);
+                // Address first: the rotation announce must go to the
+                // address the client roamed to.
+                conn_manager.set_peer_addr(&conn, peer_addr);
+                conn.begin_session_id_rotation();
+            }
+        }
+        Err(err) => {
+            warn!("Failed to process outside data: {err}");
+            let _ = conn.handle_outside_data_error(&err);
+            // Fatal or not, we are done with this packet.
+        }
+    }
+}
+
+fn send_reject(reject: impl FnOnce(&[u8])) {
+    metrics::udp_rejected_session();
+    let msg = Header {
+        version: Version::MINIMUM,
+        aggressive_mode: false,
+        session: SessionId::REJECTED,
+        expresslane_data: false,
+    };
+
+    let mut buf = BytesMut::with_capacity(Header::WIRE_SIZE);
+    msg.append_to_wire(&mut buf);
+
+    reject(&buf);
+}

--- a/lightway-server/src/io/outside/datagram.rs
+++ b/lightway-server/src/io/outside/datagram.rs
@@ -31,12 +31,7 @@ pub(crate) fn data_received(
             return;
         }
     };
-    let Some(hdr) = pkt.header() else {
-        metrics::udp_no_header();
-        warn!("Packet parsing error: Not a UDP frame");
-        return;
-    };
-    let hdr = *hdr;
+    let hdr = *pkt.header().expect("a parsed datagram carries a header");
 
     if !conn_manager.is_supported_version(hdr.version) {
         // If the protocol version is not supported then drop

--- a/lightway-server/src/io/outside/datagram.rs
+++ b/lightway-server/src/io/outside/datagram.rs
@@ -1,108 +1,450 @@
-//! Carrier-independent datagram dispatch.
+//! Datagram dispatch and receive loop.
 
+use anyhow::Result;
+use async_trait::async_trait;
 use bytes::BytesMut;
 use lightway_core::{
-    ConnectionType, Header, OutsideIOSendCallbackArg, OutsidePacket, SessionId, Version,
+    ConnectionType, Header, IOCallbackResult, MAX_IO_BATCH_SIZE, MAX_OUTSIDE_MTU, OutsidePacket,
+    SessionId, Version,
 };
-use std::{net::SocketAddr, sync::Arc};
+use std::sync::Arc;
 use tracing::warn;
 
-use crate::{connection_manager::ConnectionManager, metrics};
+use super::{OutsideIO, RecvMeta, Server};
+use crate::{connection::Connection, connection_manager::ConnectionManager, metrics};
 
-/// Parse one wire packet, route it to its connection, and hand it over.
+/// Runs a datagram [`OutsideIO`] against the connection manager.
 ///
-/// `mint` builds the send callback for a connection being created.
-/// `reject` sends an already-encoded reject frame to a peer with no
-/// connection.
-pub(crate) fn data_received(
-    conn_manager: &Arc<ConnectionManager>,
-    buf: &mut BytesMut,
-    peer_addr: SocketAddr,
-    local_addr: SocketAddr,
-    mint: impl FnOnce() -> OutsideIOSendCallbackArg,
-    reject: impl FnOnce(&[u8]),
-) {
-    let pkt = OutsidePacket::Wire(buf, ConnectionType::Datagram);
-    let pkt = match conn_manager.parse_raw_outside_packet(pkt) {
-        Ok(pkt) => pkt,
-        Err(e) => {
-            metrics::udp_parse_wire_failed();
-            warn!("Extracting header from packet failed: {e}");
-            return;
-        }
-    };
-    let hdr = *pkt.header().expect("a parsed datagram carries a header");
+/// Owns the carrier so a receive can hold scratch across iterations
+/// without a lock.
+pub(crate) struct DatagramServer {
+    io: Box<dyn OutsideIO>,
+    conn_manager: Arc<ConnectionManager>,
+}
 
-    if !conn_manager.is_supported_version(hdr.version) {
-        // If the protocol version is not supported then drop
-        // the packet.
-        metrics::udp_bad_packet_version(hdr.version);
-        return;
+impl DatagramServer {
+    pub(crate) fn new(io: Box<dyn OutsideIO>, conn_manager: Arc<ConnectionManager>) -> Self {
+        Self { io, conn_manager }
     }
 
-    // A peer-address hit delivers even when the session id in `hdr` does
-    // not match, which `find_or_create_datagram_connection_with` would
-    // reject. Do not fold this into the call below.
-    let (conn, roamed) = match conn_manager.find_datagram_connection_with(peer_addr) {
-        Some(conn) => (conn, false),
-        None => match conn_manager.find_or_create_datagram_connection_with(
-            peer_addr,
+    /// Parse and validate one wire packet.
+    ///
+    /// `None` means the packet was dropped and the reason was metered.
+    fn parse<'pkt>(&self, buf: &'pkt mut BytesMut) -> Option<(OutsidePacket<'pkt>, Header)> {
+        let pkt = OutsidePacket::Wire(buf, ConnectionType::Datagram);
+        let pkt = match self.conn_manager.parse_raw_outside_packet(pkt) {
+            Ok(pkt) => pkt,
+            Err(e) => {
+                metrics::udp_parse_wire_failed();
+                warn!("Extracting header from packet failed: {e}");
+                return None;
+            }
+        };
+        let hdr = *pkt.header().expect("a parsed datagram carries a header");
+
+        if !self.conn_manager.is_supported_version(hdr.version) {
+            // If the protocol version is not supported then drop
+            // the packet.
+            metrics::udp_bad_packet_version(hdr.version);
+            return None;
+        }
+
+        Some((pkt, hdr))
+    }
+
+    /// Find the connection this packet belongs to, keyed by peer address
+    /// and falling back to the session id in `hdr`. The `bool` is set
+    /// when the peer roamed.
+    ///
+    /// `None` means the packet was dropped and the peer answered, if it
+    /// was owed an answer.
+    fn route(&self, hdr: Header, meta: &RecvMeta) -> Option<(Arc<Connection>, bool)> {
+        // A peer address hit delivers even when the session id in `hdr`
+        // does not match. The create path below rejects that mismatch,
+        // so do not fold the two together.
+        if let Some(conn) = self.conn_manager.find_datagram_connection_with(meta.peer) {
+            return Some((conn, false));
+        }
+
+        match self.conn_manager.find_or_create_datagram_connection_with(
+            meta.peer,
             hdr.version,
             hdr.session,
-            local_addr,
-            mint,
+            meta.local,
+            || self.io.send_callback(meta),
         ) {
-            Ok(routed) => routed,
+            Ok(routed) => Some(routed),
             Err(_e) => {
-                send_reject(reject);
-                return;
+                self.send_reject(meta);
+                None
             }
-        },
-    };
+        }
+    }
 
-    match conn.outside_data_received(pkt) {
-        Ok(0) => {
-            // We will hit this case when there is UDP packet duplication.
-            // TLS library skips duplicate packets and thus no frames read.
-            // It is also possible that adversary can capture the packet
-            // and replay it. In any case, skip processing further
-            if roamed {
-                metrics::udp_session_rotation_attempted_via_replay();
+    /// Parse, route and deliver one received packet.
+    fn dispatch(&self, buf: &mut BytesMut, meta: &RecvMeta) {
+        let Some((pkt, hdr)) = self.parse(buf) else {
+            return;
+        };
+
+        let Some((conn, roamed)) = self.route(hdr, meta) else {
+            return;
+        };
+
+        match conn.outside_data_received(pkt) {
+            Ok(0) => {
+                // We will hit this case when there is UDP packet duplication.
+                // TLS library skips duplicate packets and thus no frames read.
+                // It is also possible that adversary can capture the packet
+                // and replay it. In any case, skip processing further
+                if roamed {
+                    metrics::udp_session_rotation_attempted_via_replay();
+                }
+            }
+            Ok(_) => {
+                // NOTE: We wait until the first successful TLS
+                // decrypt to protect against the case where a crafted
+                // packet with a session ID causes us to change the
+                // connection IP without verifying the SSL connection
+                // first
+                if roamed {
+                    metrics::udp_conn_recovered_via_session(hdr.session);
+                    // Address first: the rotation announce must go to the
+                    // address the client roamed to.
+                    self.conn_manager.set_peer_addr(&conn, meta.peer);
+                    conn.begin_session_id_rotation();
+                }
+            }
+            Err(err) => {
+                warn!("Failed to process outside data: {err}");
+                let _ = conn.handle_outside_data_error(&err);
+                // Fatal or not, we are done with this packet.
             }
         }
-        Ok(_) => {
-            // NOTE: We wait until the first successful TLS
-            // decrypt to protect against the case where a crafted
-            // packet with a session ID causes us to change the
-            // connection IP without verifying the SSL connection
-            // first
-            if roamed {
-                metrics::udp_conn_recovered_via_session(hdr.session);
-                // Address first: the rotation announce must go to the
-                // address the client roamed to.
-                conn_manager.set_peer_addr(&conn, peer_addr);
-                conn.begin_session_id_rotation();
+    }
+
+    /// Tell a peer with no connection to restart, rather than let it wait
+    /// out a timeout.
+    fn send_reject(&self, meta: &RecvMeta) {
+        metrics::udp_rejected_session();
+        let msg = Header {
+            version: Version::MINIMUM,
+            aggressive_mode: false,
+            session: SessionId::REJECTED,
+            expresslane_data: false,
+        };
+
+        let mut buf = BytesMut::with_capacity(Header::WIRE_SIZE);
+        msg.append_to_wire(&mut buf);
+
+        self.io.send_unconnected(meta, &buf);
+    }
+}
+
+#[async_trait]
+impl Server for DatagramServer {
+    async fn run(&mut self) -> Result<()> {
+        let mut bufs: [BytesMut; MAX_IO_BATCH_SIZE] =
+            std::array::from_fn(|_| BytesMut::with_capacity(MAX_OUTSIDE_MTU));
+        let mut metas: Vec<RecvMeta> = Vec::with_capacity(MAX_IO_BATCH_SIZE);
+        loop {
+            metas.clear();
+
+            match self.io.recv_many(&mut bufs, &mut metas).await {
+                IOCallbackResult::Ok(()) => {}
+                IOCallbackResult::WouldBlock => continue,
+                IOCallbackResult::Err(err) => return Err(err.into()),
             }
-        }
-        Err(err) => {
-            warn!("Failed to process outside data: {err}");
-            let _ = conn.handle_outside_data_error(&err);
-            // Fatal or not, we are done with this packet.
+
+            for (buf, meta) in bufs.iter_mut().zip(metas.iter()) {
+                self.dispatch(buf, meta);
+            }
+
+            // A carrier that receives through a manual readiness API charges
+            // no cooperative budget. A backlog of ready packets then never
+            // parks this task and starves the inside loop. Charge one unit
+            // per datagram, as tokio's own charged IO paths do. See
+            // `CVPN-2732` for the same fix on the client.
+            for _ in 0..metas.len() {
+                tokio::task::coop::consume_budget().await;
+            }
         }
     }
 }
 
-fn send_reject(reject: impl FnOnce(&[u8])) {
-    metrics::udp_rejected_session();
-    let msg = Header {
-        version: Version::MINIMUM,
-        aggressive_mode: false,
-        session: SessionId::REJECTED,
-        expresslane_data: false,
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::ConnectionState;
+    use crate::ip_manager::IpManager;
+    use ipnet::Ipv4Net;
+    use lightway_app_utils::connection_ticker_cb;
+    use lightway_core::{
+        AuthMethod, IOCallbackResult, InsideIOSendCallback, InsideIpConfig,
+        OutsideIOSendCallbackArg, Secret, ServerAuth, ServerAuthResult, ServerContextBuilder,
     };
+    use std::collections::HashMap;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::path::Path;
+    use std::sync::Mutex;
+    use std::time::Duration;
 
-    let mut buf = BytesMut::with_capacity(Header::WIRE_SIZE);
-    msg.append_to_wire(&mut buf);
+    const PEER_A: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1)), 5000);
+    const PEER_B: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 2)), 5001);
+    const LOCAL: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1)), 27690);
 
-    reject(&buf);
+    struct StubAuth;
+
+    impl ServerAuth<ConnectionState> for StubAuth {
+        fn authorize(
+            &self,
+            _method: &AuthMethod,
+            _app_state: &mut ConnectionState,
+        ) -> ServerAuthResult {
+            // No test packet here carries valid DTLS, so no handshake
+            // ever completes and nothing calls this.
+            unimplemented!("dispatch tests never reach authorization")
+        }
+    }
+
+    struct StubInsideIo;
+
+    impl InsideIOSendCallback<ConnectionState> for StubInsideIo {
+        fn send(&self, buf: BytesMut, _state: &mut ConnectionState) -> IOCallbackResult<usize> {
+            IOCallbackResult::Ok(buf.len())
+        }
+
+        fn mtu(&self) -> usize {
+            1350
+        }
+
+        fn if_index(&self) -> std::io::Result<u32> {
+            Ok(0)
+        }
+
+        fn name(&self) -> std::io::Result<String> {
+            Ok("stub".to_string())
+        }
+    }
+
+    fn test_conn_manager() -> Arc<ConnectionManager> {
+        test_conn_manager_with_minimum_version(Version::MINIMUM)
+    }
+
+    fn test_conn_manager_with_minimum_version(minimum: Version) -> Arc<ConnectionManager> {
+        let cert = Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../tests/certs/server.crt"
+        ));
+        let key = Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../tests/certs/server.key"
+        ));
+
+        let pool: Ipv4Net = "10.125.0.0/16".parse().unwrap();
+        let ip_manager = Arc::new(IpManager::new(
+            pool,
+            HashMap::new(),
+            std::iter::empty::<Ipv4Addr>(),
+            InsideIpConfig {
+                client_ip: Ipv4Addr::new(10, 125, 0, 5),
+                server_ip: Ipv4Addr::new(10, 125, 0, 6),
+                dns_ip: Ipv4Addr::new(10, 125, 0, 1),
+            },
+            false,
+            true,
+        ));
+
+        let ctx = ServerContextBuilder::new(
+            ConnectionType::Datagram,
+            Secret::PemFile(cert),
+            Secret::PemFile(key),
+            Arc::new(StubAuth),
+            ip_manager,
+            Arc::new(StubInsideIo),
+            connection_ticker_cb,
+        )
+        .unwrap()
+        .with_minimum_protocol_version(minimum)
+        .unwrap()
+        .build()
+        .unwrap();
+
+        ConnectionManager::new(ctx, None, None, Duration::from_secs(60))
+    }
+
+    /// Outside IO that records what the dispatch asked of it.
+    #[derive(Default)]
+    struct MockIo {
+        minted: Mutex<Vec<SocketAddr>>,
+        unconnected: Mutex<Vec<(SocketAddr, Vec<u8>)>>,
+    }
+
+    fn meta(peer: SocketAddr) -> RecvMeta {
+        RecvMeta { peer, local: LOCAL }
+    }
+
+    struct MockSend(SocketAddr);
+
+    impl lightway_core::OutsideIOSendCallback for MockSend {
+        fn send(&self, buf: &[u8]) -> IOCallbackResult<usize> {
+            IOCallbackResult::Ok(buf.len())
+        }
+
+        fn send_gso(
+            &self,
+            _bufs: &[std::io::IoSlice<'_>],
+            _gso_size: u16,
+        ) -> IOCallbackResult<usize> {
+            IOCallbackResult::Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+        }
+
+        fn peer_addr(&self) -> SocketAddr {
+            self.0
+        }
+    }
+
+    #[async_trait]
+    impl OutsideIO for Arc<MockIo> {
+        async fn recv(&mut self, _buf: &mut BytesMut) -> IOCallbackResult<RecvMeta> {
+            unimplemented!("dispatch tests drive the dispatch directly")
+        }
+
+        fn send_callback(&self, meta: &RecvMeta) -> OutsideIOSendCallbackArg {
+            self.minted.lock().unwrap().push(meta.peer);
+            Arc::new(MockSend(meta.peer))
+        }
+
+        fn send_unconnected(&self, meta: &RecvMeta, buf: &[u8]) {
+            self.unconnected
+                .lock()
+                .unwrap()
+                .push((meta.peer, buf.to_vec()));
+        }
+    }
+
+    fn server(io: &Arc<MockIo>, manager: Arc<ConnectionManager>) -> DatagramServer {
+        DatagramServer::new(Box::new(io.clone()), manager)
+    }
+
+    /// A wire packet with a valid lightway header and an opaque body.
+    ///
+    /// The body is never valid DTLS, so `outside_data_received` always
+    /// fails. That is enough to exercise parsing, routing and the rule
+    /// that a failed decrypt must not move a peer address.
+    fn wire_packet(version: Version, session: SessionId) -> BytesMut {
+        let mut buf = BytesMut::with_capacity(MAX_OUTSIDE_MTU);
+        Header {
+            version,
+            aggressive_mode: false,
+            session,
+            expresslane_data: false,
+        }
+        .append_to_wire(&mut buf);
+        buf.extend_from_slice(&[0xab; 64]);
+        buf
+    }
+
+    #[tokio::test]
+    async fn unparseable_packet_is_dropped() {
+        let manager = test_conn_manager();
+        let io = Arc::new(MockIo::default());
+        let server = server(&io, manager.clone());
+
+        // No `He` magic, so the header never parses.
+        let mut buf = BytesMut::from(&[0u8; 32][..]);
+        server.dispatch(&mut buf, &meta(PEER_A));
+
+        assert_eq!(manager.total_sessions(), 0);
+        assert!(io.minted.lock().unwrap().is_empty());
+        assert!(io.unconnected.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn unsupported_version_is_dropped() {
+        // A version the wire parser accepts but this server does not. A
+        // malformed version such as 0.0 fails `Version::try_new` inside
+        // `Header::try_from_wire` and never reaches the gate.
+        let manager = test_conn_manager_with_minimum_version(Version::MAXIMUM);
+        let io = Arc::new(MockIo::default());
+        let server = server(&io, manager.clone());
+
+        let mut buf = wire_packet(Version::MINIMUM, SessionId::EMPTY);
+        server.dispatch(&mut buf, &meta(PEER_A));
+
+        assert_eq!(manager.total_sessions(), 0);
+        assert!(io.minted.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn peer_addr_keying_creates_a_connection_for_an_empty_session() {
+        let manager = test_conn_manager();
+        let io = Arc::new(MockIo::default());
+        let server = server(&io, manager.clone());
+
+        let mut buf = wire_packet(Version::MINIMUM, SessionId::EMPTY);
+        server.dispatch(&mut buf, &meta(PEER_A));
+
+        assert_eq!(manager.total_sessions(), 1);
+        assert!(
+            manager.find_datagram_connection_with(PEER_A).is_some(),
+            "total_sessions counts every session ever, so check the map too"
+        );
+        assert_eq!(&io.minted.lock().unwrap()[..], &[PEER_A]);
+        assert!(io.unconnected.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn peer_addr_keying_rejects_an_unknown_session() {
+        let manager = test_conn_manager();
+        let io = Arc::new(MockIo::default());
+        let server = server(&io, manager.clone());
+
+        // A client claiming a session the server has never seen.
+        let unknown = SessionId::from_const([9u8; 8]);
+        let mut buf = wire_packet(Version::MINIMUM, unknown);
+        server.dispatch(&mut buf, &meta(PEER_A));
+
+        assert_eq!(manager.total_sessions(), 0);
+        assert!(io.minted.lock().unwrap().is_empty());
+
+        let sent = io.unconnected.lock().unwrap();
+        assert_eq!(sent.len(), 1, "an unknown session must be rejected");
+        assert_eq!(sent[0].0, PEER_A);
+
+        let mut frame = BytesMut::from(&sent[0].1[..]);
+        let hdr = Header::try_from_wire(&mut frame).expect("reject frame must parse");
+        assert_eq!(hdr.session, SessionId::REJECTED);
+    }
+
+    #[tokio::test]
+    async fn a_failed_decrypt_does_not_move_the_peer_address() {
+        let manager = test_conn_manager();
+        let io = Arc::new(MockIo::default());
+        let server = server(&io, manager.clone());
+
+        let mut buf = wire_packet(Version::MINIMUM, SessionId::EMPTY);
+        server.dispatch(&mut buf, &meta(PEER_A));
+
+        let conn = manager
+            .find_datagram_connection_with(PEER_A)
+            .expect("connection created for PEER_A");
+        let session = conn.session_id();
+        assert_eq!(conn.peer_addr(), PEER_A);
+
+        // The same session arriving from a new address. The body is not
+        // valid DTLS, so the decrypt fails and the address must stay put.
+        let mut buf = wire_packet(Version::MINIMUM, session);
+        server.dispatch(&mut buf, &meta(PEER_B));
+
+        assert_eq!(
+            conn.peer_addr(),
+            PEER_A,
+            "peer address must only move after a successful decrypt"
+        );
+        assert!(
+            manager.find_datagram_connection_with(PEER_B).is_none(),
+            "the routing index must not have moved either"
+        );
+    }
 }

--- a/lightway-server/src/io/outside/udp.rs
+++ b/lightway-server/src/io/outside/udp.rs
@@ -9,7 +9,10 @@ use lightway_app_utils::cmsg;
 #[cfg(target_os = "linux")]
 use lightway_app_utils::sockopt;
 use lightway_app_utils::sockopt::socket_enable_pktinfo;
-use lightway_core::{IOCallbackResult, MAX_IO_BATCH_SIZE, MAX_OUTSIDE_MTU, OutsideIOSendCallback};
+use lightway_core::{
+    IOCallbackResult, MAX_IO_BATCH_SIZE, MAX_OUTSIDE_MTU, OutsideIOSendCallback,
+    OutsideIOSendCallbackArg,
+};
 use socket2::{MaybeUninitSlice, MsgHdr, MsgHdrMut, SockAddr, SockRef};
 use std::os::fd::AsRawFd;
 use std::{
@@ -20,11 +23,10 @@ use std::{
 use tokio::io::Interest;
 use tracing::info;
 
-use super::Server;
-use crate::io::outside::datagram;
+use super::{OutsideIO, RecvMeta};
 use crate::io::outside::udp::batch_receive::{BatchRecvSlot, recv_multiple_with_metadata};
 use crate::io::outside::udp::send_queue::SendQueue;
-use crate::{connection_manager::ConnectionManager, metrics};
+use crate::metrics;
 
 enum BindMode {
     UnspecifiedAddress { local_port: u16 },
@@ -152,23 +154,29 @@ impl OutsideIOSendCallback for UdpSocket {
     }
 }
 
-pub(crate) struct UdpServer {
-    conn_manager: Arc<ConnectionManager>,
+/// Control-buffer size for one `IP_PKTINFO` control message.
+const PKTINFO_CONTROL_SIZE: usize = cmsg::Message::space::<libc::in_pktinfo>();
+
+/// Outside IO over one UDP socket.
+pub(crate) struct UdpIo {
     sock: Arc<tokio::net::UdpSocket>,
     bind_mode: BindMode,
     batch_receive_enabled: bool,
     send_queue: Option<Arc<SendQueue>>,
+    /// Scratch for the batch receive path: per-packet control buffers and
+    /// source-address storage, reused across calls. The payload buffers
+    /// come from the caller.
+    batch_slots: [BatchRecvSlot; MAX_IO_BATCH_SIZE],
 }
 
-impl UdpServer {
+impl UdpIo {
     pub(crate) async fn new(
-        conn_manager: Arc<ConnectionManager>,
         bind_address: SocketAddr,
         udp_buffer_size: ByteSize,
         enable_batch_receive: bool,
         enable_batch_send: bool,
         sock: Option<tokio::net::UdpSocket>,
-    ) -> Result<UdpServer> {
+    ) -> Result<UdpIo> {
         let sock = match sock {
             Some(s) => s,
             None => tokio::net::UdpSocket::bind(bind_address).await?,
@@ -222,12 +230,14 @@ impl UdpServer {
             false
         };
 
+        info!("Accepting traffic on {bind_mode}");
+
         Ok(Self {
-            conn_manager,
             sock,
             bind_mode,
             batch_receive_enabled,
             send_queue,
+            batch_slots: std::array::from_fn(|_| BatchRecvSlot::new()),
         })
     }
 
@@ -263,96 +273,82 @@ impl UdpServer {
             ipi_addr: libc::in_addr { s_addr: 0 },
         })
     }
-
-    fn data_received(&self, peer_addr: SocketAddr, local_addr: SocketAddr, buf: &mut BytesMut) {
-        let reply_pktinfo = self.reply_pktinfo(local_addr);
-
-        datagram::data_received(
-            &self.conn_manager,
-            buf,
-            peer_addr,
-            local_addr,
-            || {
-                Arc::new(UdpSocket {
-                    sock: self.sock.clone(),
-                    peer_addr: RwLock::new((peer_addr, peer_addr.into())),
-                    reply_pktinfo,
-                    send_queue: self.send_queue.clone(),
-                })
-            },
-            |frame| {
-                // Ignore failure to send.
-                let _ = send_to_socket(
-                    &self.sock,
-                    &[IoSlice::new(frame)],
-                    &peer_addr.into(),
-                    reply_pktinfo,
-                    None,
-                );
-            },
-        );
-    }
-}
-
-impl UdpServer {
-    /// Receive and process one packet at a time using `recvmsg`.
-    async fn run_single(&mut self) -> Result<()> {
-        let mut buf = BytesMut::with_capacity(MAX_OUTSIDE_MTU);
-        loop {
-            // Recover full capacity
-            buf.clear();
-            buf.reserve(MAX_OUTSIDE_MTU);
-
-            let (peer_addr, local_addr) = self
-                .sock
-                .async_io(Interest::READABLE, || {
-                    read_single_from_socket(&self.sock, &mut buf, &self.bind_mode)
-                })
-                .await?;
-
-            self.data_received(peer_addr, local_addr, &mut buf);
-        }
-    }
-
-    /// Receive and process packets in batches using the platform batch-receive
-    /// syscall (`recvmmsg` on Linux, `recvmsg_x` on macOS).
-    async fn run_batch(&mut self) -> Result<()> {
-        let mut buf_slots: [BatchRecvSlot; MAX_IO_BATCH_SIZE] =
-            std::array::from_fn(|_| BatchRecvSlot::new());
-        let mut bufs: [BytesMut; MAX_IO_BATCH_SIZE] =
-            std::array::from_fn(|_| BytesMut::with_capacity(MAX_OUTSIDE_MTU));
-        loop {
-            let pkt_metadata = self
-                .sock
-                .async_io(Interest::READABLE, || {
-                    read_multiple_from_socket(
-                        &self.sock,
-                        &mut bufs,
-                        &mut buf_slots,
-                        &self.bind_mode,
-                    )
-                })
-                .await?;
-            // `zip` stops at the shorter iterator, so this processes exactly the
-            // slots that batch receive filled (one metadata entry per slot).
-            for (buf, meta) in bufs.iter_mut().zip(pkt_metadata) {
-                self.data_received(meta.0, meta.1, buf);
-            }
-        }
-    }
 }
 
 #[async_trait]
-impl Server for UdpServer {
-    async fn run(&mut self) -> Result<()> {
-        info!("Accepting traffic on {}", self.bind_mode);
+impl OutsideIO for UdpIo {
+    async fn recv(&mut self, buf: &mut BytesMut) -> IOCallbackResult<RecvMeta> {
+        buf.clear();
+        buf.reserve(MAX_OUTSIDE_MTU);
 
-        if self.batch_receive_enabled {
-            info!("Using batch receive");
-            return self.run_batch().await;
+        let res = self
+            .sock
+            .async_io(Interest::READABLE, || {
+                read_single_from_socket(&self.sock, buf, &self.bind_mode)
+            })
+            .await;
+
+        match res {
+            Ok(meta) => IOCallbackResult::Ok(meta),
+            Err(err) => IOCallbackResult::Err(err),
+        }
+    }
+
+    async fn recv_many(
+        &mut self,
+        bufs: &mut [BytesMut; MAX_IO_BATCH_SIZE],
+        metas: &mut Vec<RecvMeta>,
+    ) -> IOCallbackResult<()> {
+        if !self.batch_receive_enabled {
+            return match self.recv(&mut bufs[0]).await {
+                IOCallbackResult::Ok(meta) => {
+                    metas.push(meta);
+                    IOCallbackResult::Ok(())
+                }
+                IOCallbackResult::WouldBlock => IOCallbackResult::WouldBlock,
+                IOCallbackResult::Err(err) => IOCallbackResult::Err(err),
+            };
         }
 
-        self.run_single().await
+        // Split the borrow so the closure can hold the scratch slots
+        // mutably while reading `sock` and `bind_mode`.
+        let Self {
+            sock,
+            bind_mode,
+            batch_slots,
+            ..
+        } = self;
+
+        let res = sock
+            .async_io(Interest::READABLE, || {
+                read_multiple_from_socket(sock, bufs, batch_slots, bind_mode, metas)
+            })
+            .await;
+
+        match res {
+            Ok(()) => IOCallbackResult::Ok(()),
+            Err(err) => IOCallbackResult::Err(err),
+        }
+    }
+
+    fn send_callback(&self, meta: &RecvMeta) -> OutsideIOSendCallbackArg {
+        Arc::new(UdpSocket {
+            sock: self.sock.clone(),
+            peer_addr: RwLock::new((meta.peer, meta.peer.into())),
+            reply_pktinfo: self.reply_pktinfo(meta.local),
+            send_queue: self.send_queue.clone(),
+        })
+    }
+
+    fn send_unconnected(&self, meta: &RecvMeta, buf: &[u8]) {
+        // Ignore failure to send: there is no connection to report against.
+        let _ = send_to_socket(
+            &self.sock,
+            &[IoSlice::new(buf)],
+            &meta.peer.into(),
+            self.reply_pktinfo(meta.local),
+            None,
+        );
     }
 }
 
@@ -360,8 +356,7 @@ impl Server for UdpServer {
 /// control message.
 ///
 /// The reply `IP_PKTINFO` is not returned: it is a function of this
-/// address, rebuilt by [`UdpServer::reply_pktinfo`] when a reply is
-/// needed.
+/// address, rebuilt by [`UdpIo::reply_pktinfo`] when a reply is needed.
 fn find_local_addr_from_iter(mut iter: cmsg::Iter<'_>, local_port: u16) -> Option<SocketAddr> {
     iter.find_map(|cmsg| {
         match cmsg {
@@ -385,7 +380,7 @@ fn read_single_from_socket(
     sock: &Arc<tokio::net::UdpSocket>,
     buf: &mut BytesMut,
     bind_mode: &BindMode,
-) -> std::io::Result<(SocketAddr, SocketAddr)> {
+) -> std::io::Result<RecvMeta> {
     let sock = SockRef::from(sock.as_ref());
     let mut raw_buf = [MaybeUninitSlice::new(buf.spare_capacity_mut())];
 
@@ -416,8 +411,7 @@ fn read_single_from_socket(
     // should be small compared with the conditional
     // logic and dynamically sized buffer needed to
     // allow omitting it.
-    const SIZE: usize = cmsg::Message::space::<libc::in_pktinfo>();
-    let mut control = cmsg::Buffer::<SIZE>::new();
+    let mut control = cmsg::Buffer::<PKTINFO_CONTROL_SIZE>::new();
 
     let mut msg = MsgHdrMut::new()
         .with_addr(&mut peer_sock_addr)
@@ -465,23 +459,23 @@ fn read_single_from_socket(
         BindMode::SpecificAddress { local_addr } => local_addr,
     };
 
-    Ok((peer_addr, local_addr))
+    Ok(RecvMeta {
+        peer: peer_addr,
+        local: local_addr,
+    })
 }
 
 fn read_multiple_from_socket(
     sock: &Arc<tokio::net::UdpSocket>,
     bufs: &mut [BytesMut; MAX_IO_BATCH_SIZE],
-    buf_slots: &mut [BatchRecvSlot; MAX_IO_BATCH_SIZE],
+    slots: &mut [BatchRecvSlot; MAX_IO_BATCH_SIZE],
     bind_mode: &BindMode,
-) -> std::io::Result<Vec<(SocketAddr, SocketAddr)>> {
+    metas: &mut Vec<RecvMeta>,
+) -> std::io::Result<()> {
     let sock = SockRef::from(sock.as_ref());
+    let n = recv_multiple_with_metadata(sock.as_raw_fd(), bufs, slots)?;
 
-    let fd = sock.as_raw_fd();
-    let n = recv_multiple_with_metadata(fd, bufs, buf_slots)?;
-
-    let mut metadata = Vec::with_capacity(n);
-
-    for slot in buf_slots.iter_mut().take(n) {
+    for slot in slots.iter_mut().take(n) {
         if slot.truncated {
             metrics::udp_recv_truncated();
         }
@@ -501,8 +495,8 @@ fn read_multiple_from_socket(
                     .control_messages()
                     .and_then(|iter| find_local_addr_from_iter(iter, local_port))
                 else {
-                    // We bind the socket and set the IP_PKTINFO sockopt, so
-                    // this should not happen.
+                    // The socket is bound and has the IP_PKTINFO sockopt
+                    // set, so this does not happen.
                     metrics::udp_recv_missing_pktinfo();
                     return Err(std::io::Error::other("recvmmsg did not return IP_PKTINFO"));
                 };
@@ -511,8 +505,95 @@ fn read_multiple_from_socket(
             BindMode::SpecificAddress { local_addr } => local_addr,
         };
 
-        metadata.push((peer_addr, local_addr));
+        metas.push(RecvMeta {
+            peer: peer_addr,
+            local: local_addr,
+        });
     }
 
-    Ok(metadata)
+    Ok(())
+}
+
+#[cfg(linux)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytesize::ByteSize;
+    use lightway_core::MAX_OUTSIDE_MTU;
+    use std::time::Duration;
+
+    /// A socket bound to the unspecified address must echo the local
+    /// address back as `IP_PKTINFO` on replies, so a multi-homed server
+    /// answers from the address the client reached it on.
+    ///
+    /// The reply pktinfo is rebuilt from the received local address rather
+    /// than carried through the receive path, so this checks the round
+    /// trip: receive on 0.0.0.0, reply, and confirm the client sees the
+    /// reply arriving from the address it sent to.
+    ///
+    /// The client sits on `127.0.0.1` and addresses the server as
+    /// `127.0.0.2`, so the two outcomes differ: without the control message
+    /// the kernel sources the reply from `127.0.0.1`, and only an applied
+    /// `ipi_spec_dst` makes it `127.0.0.2`. Linux only, because macOS does
+    /// not configure the rest of `127/8`.
+    #[cfg(linux)]
+    #[tokio::test]
+    #[serial_test::serial]
+    #[cfg_attr(
+        miri,
+        ignore = "binds a real UDP socket, unsupported under miri isolation"
+    )]
+    async fn reply_to_unconnected_peer_comes_from_the_address_it_arrived_on() {
+        let sock = tokio::net::UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        let port = sock.local_addr().unwrap().port();
+
+        let mut io = UdpIo::new(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port),
+            ByteSize::kib(64),
+            false,
+            false,
+            Some(sock),
+        )
+        .await
+        .unwrap();
+
+        // A second loopback address, so the reply source distinguishes
+        // "pktinfo applied" from "kernel picked the default".
+        let server_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), port);
+        let client = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        client.send_to(b"hello", server_addr).await.unwrap();
+
+        let mut buf = BytesMut::with_capacity(MAX_OUTSIDE_MTU);
+        let meta = match io.recv(&mut buf).await {
+            IOCallbackResult::Ok(meta) => meta,
+            other => panic!("recv failed: {other:?}"),
+        };
+
+        assert_eq!(&buf[..], b"hello");
+        assert_eq!(
+            meta.local, server_addr,
+            "IP_PKTINFO must resolve the address the client sent to"
+        );
+        assert_eq!(meta.peer, client.local_addr().unwrap());
+
+        // A missing control message is caught by the source-address
+        // assertion below, because the kernel then sources the reply from
+        // 127.0.0.1. A non-local `ipi_spec_dst` instead makes the send
+        // fail, which `send_unconnected` swallows, and the timeout catches
+        // that.
+        io.send_unconnected(&meta, b"rejected");
+
+        let mut reply = [0u8; 32];
+        let (len, from) =
+            tokio::time::timeout(Duration::from_secs(2), client.recv_from(&mut reply))
+                .await
+                .expect("reply must arrive")
+                .unwrap();
+
+        assert_eq!(&reply[..len], b"rejected");
+        assert_eq!(
+            from, server_addr,
+            "reply must come from 127.0.0.2, which only an applied IP_PKTINFO achieves"
+        );
+    }
 }

--- a/lightway-server/src/io/outside/udp.rs
+++ b/lightway-server/src/io/outside/udp.rs
@@ -9,10 +9,7 @@ use lightway_app_utils::cmsg;
 #[cfg(target_os = "linux")]
 use lightway_app_utils::sockopt;
 use lightway_app_utils::sockopt::socket_enable_pktinfo;
-use lightway_core::{
-    ConnectionType, Header, IOCallbackResult, MAX_IO_BATCH_SIZE, MAX_OUTSIDE_MTU,
-    OutsideIOSendCallback, OutsidePacket, SessionId, Version,
-};
+use lightway_core::{IOCallbackResult, MAX_IO_BATCH_SIZE, MAX_OUTSIDE_MTU, OutsideIOSendCallback};
 use socket2::{MaybeUninitSlice, MsgHdr, MsgHdrMut, SockAddr, SockRef};
 use std::os::fd::AsRawFd;
 use std::{
@@ -21,9 +18,10 @@ use std::{
     sync::{Arc, RwLock},
 };
 use tokio::io::Interest;
-use tracing::{info, warn};
+use tracing::info;
 
 use super::Server;
+use crate::io::outside::datagram;
 use crate::io::outside::udp::batch_receive::{BatchRecvSlot, recv_multiple_with_metadata};
 use crate::io::outside::udp::send_queue::SendQueue;
 use crate::{connection_manager::ConnectionManager, metrics};
@@ -215,7 +213,7 @@ impl UdpServer {
             if lightway_app_utils::recvmsg_x::is_batch_receive_available() {
                 true
             } else {
-                warn!(
+                tracing::warn!(
                     "batch receive (recvmsg_x) not available on this system, batch receive disabled"
                 );
                 false
@@ -240,116 +238,35 @@ impl UdpServer {
     }
 
     fn data_received(
-        &mut self,
+        &self,
         peer_addr: SocketAddr,
         local_addr: SocketAddr,
         reply_pktinfo: Option<libc::in_pktinfo>,
         buf: &mut BytesMut,
     ) {
-        let pkt = OutsidePacket::Wire(buf, ConnectionType::Datagram);
-        let pkt = match self.conn_manager.parse_raw_outside_packet(pkt) {
-            Ok(hdr) => hdr,
-            Err(e) => {
-                metrics::udp_parse_wire_failed();
-                warn!("Extracting header from packet failed: {e}");
-                return;
-            }
-        };
-
-        let Some(hdr) = pkt.header() else {
-            metrics::udp_no_header();
-            warn!("Packet parsing error: Not a UDP frame");
-            return;
-        };
-        if !self.conn_manager.is_supported_version(hdr.version) {
-            // If the protocol version is not supported then drop
-            // the packet.
-            metrics::udp_bad_packet_version(hdr.version);
-            return;
-        }
-
-        let may_be_conn = self.conn_manager.find_datagram_connection_with(peer_addr);
-        let (conn, update_peer_address) = match may_be_conn {
-            Some(conn) => (conn, false),
-            None => {
-                let conn_result = self.conn_manager.find_or_create_datagram_connection_with(
-                    peer_addr,
-                    hdr.version,
-                    hdr.session,
-                    local_addr,
-                    || {
-                        Arc::new(UdpSocket {
-                            sock: self.sock.clone(),
-                            peer_addr: RwLock::new((peer_addr, peer_addr.into())),
-                            reply_pktinfo,
-                            send_queue: self.send_queue.clone(),
-                        })
-                    },
+        datagram::data_received(
+            &self.conn_manager,
+            buf,
+            peer_addr,
+            local_addr,
+            || {
+                Arc::new(UdpSocket {
+                    sock: self.sock.clone(),
+                    peer_addr: RwLock::new((peer_addr, peer_addr.into())),
+                    reply_pktinfo,
+                    send_queue: self.send_queue.clone(),
+                })
+            },
+            |frame| {
+                // Ignore failure to send.
+                let _ = send_to_socket(
+                    &self.sock,
+                    &[IoSlice::new(frame)],
+                    &peer_addr.into(),
+                    reply_pktinfo,
+                    None,
                 );
-
-                match conn_result {
-                    Ok(conn) => conn,
-                    Err(_e) => {
-                        self.send_reject(peer_addr.into(), reply_pktinfo);
-                        return;
-                    }
-                }
-            }
-        };
-
-        let session = hdr.session;
-
-        match conn.outside_data_received(pkt) {
-            Ok(0) => {
-                // We will hit this case when there is UDP packet duplication.
-                // TLS library skips duplicate packets and thus no frames read.
-                // It is also possible that adversary can capture the packet
-                // and replay it. In any case, skip processing further
-                if update_peer_address {
-                    metrics::udp_session_rotation_attempted_via_replay();
-                }
-            }
-            Ok(_) => {
-                // NOTE: We wait until the first successful TLS
-                // decrypt to protect against the case where a crafted
-                // packet with a session ID causes us to change the
-                // connection IP without verifying the SSL connection
-                // first
-                if update_peer_address {
-                    metrics::udp_conn_recovered_via_session(session);
-                    // Address first: the rotation announce must go to the
-                    // address the client roamed to.
-                    self.conn_manager.set_peer_addr(&conn, peer_addr);
-                    conn.begin_session_id_rotation();
-                }
-            }
-            Err(err) => {
-                warn!("Failed to process outside data: {err}");
-                let _ = conn.handle_outside_data_error(&err);
-                // Fatal or not, we are done with this packet.
-            }
-        }
-    }
-
-    fn send_reject(&self, peer_addr: SockAddr, reply_pktinfo: Option<libc::in_pktinfo>) {
-        metrics::udp_rejected_session();
-        let msg = Header {
-            version: Version::MINIMUM,
-            aggressive_mode: false,
-            session: SessionId::REJECTED,
-            expresslane_data: false,
-        };
-
-        let mut buf = BytesMut::with_capacity(Header::WIRE_SIZE);
-        msg.append_to_wire(&mut buf);
-
-        // Ignore failure to send.
-        let _ = send_to_socket(
-            &self.sock,
-            &[IoSlice::new(&buf)],
-            &peer_addr,
-            reply_pktinfo,
-            None,
+            },
         );
     }
 }

--- a/lightway-server/src/io/outside/udp.rs
+++ b/lightway-server/src/io/outside/udp.rs
@@ -377,27 +377,26 @@ impl UdpServer {
     /// Receive and process packets in batches using the platform batch-receive
     /// syscall (`recvmmsg` on Linux, `recvmsg_x` on macOS).
     async fn run_batch(&mut self) -> Result<()> {
-        const SIZE: usize = cmsg::Message::space::<libc::in_pktinfo>();
-        let mut buf_slots: [BatchRecvSlot<SIZE>; MAX_IO_BATCH_SIZE] =
+        let mut buf_slots: [BatchRecvSlot; MAX_IO_BATCH_SIZE] =
             std::array::from_fn(|_| BatchRecvSlot::new());
+        let mut bufs: [BytesMut; MAX_IO_BATCH_SIZE] =
+            std::array::from_fn(|_| BytesMut::with_capacity(MAX_OUTSIDE_MTU));
         loop {
             let pkt_metadata = self
                 .sock
                 .async_io(Interest::READABLE, || {
                     read_multiple_from_socket(
                         &self.sock,
+                        &mut bufs,
                         &mut buf_slots,
-                        MAX_IO_BATCH_SIZE,
                         &self.bind_mode,
                     )
                 })
                 .await?;
             // `zip` stops at the shorter iterator, so this processes exactly the
             // slots that batch receive filled (one metadata entry per slot).
-            for (slot, meta) in buf_slots.iter_mut().zip(pkt_metadata) {
-                self.data_received(meta.peer, meta.local, meta.reply_pktinfo, &mut slot.buf);
-                // Recover full capacity
-                slot.reset();
+            for (buf, meta) in bufs.iter_mut().zip(pkt_metadata) {
+                self.data_received(meta.peer, meta.local, meta.reply_pktinfo, buf);
             }
         }
     }
@@ -534,24 +533,22 @@ fn read_single_from_socket(
 
 /// Per-packet metadata produced by batched receive.
 struct BatchRecvMetadata {
-    /// The peer (remote) address the packet was received from.
     peer: SocketAddr,
-    /// The resolved local address the packet was received on.
     local: SocketAddr,
     /// The `in_pktinfo` to echo back on replies, when the bind mode needs it.
     reply_pktinfo: Option<libc::in_pktinfo>,
 }
 
-fn read_multiple_from_socket<const N: usize>(
+fn read_multiple_from_socket(
     sock: &Arc<tokio::net::UdpSocket>,
-    buf_slots: &mut [BatchRecvSlot<N>; MAX_IO_BATCH_SIZE],
-    max_batch_size: usize,
+    bufs: &mut [BytesMut; MAX_IO_BATCH_SIZE],
+    buf_slots: &mut [BatchRecvSlot; MAX_IO_BATCH_SIZE],
     bind_mode: &BindMode,
 ) -> std::io::Result<Vec<BatchRecvMetadata>> {
     let sock = SockRef::from(sock.as_ref());
 
     let fd = sock.as_raw_fd();
-    let n = recv_multiple_with_metadata(fd, buf_slots, max_batch_size)?;
+    let n = recv_multiple_with_metadata(fd, bufs, buf_slots)?;
 
     let mut metadata = Vec::with_capacity(n);
 
@@ -571,28 +568,16 @@ fn read_multiple_from_socket<const N: usize>(
 
         let (local_addr, reply_pktinfo) = match *bind_mode {
             BindMode::UnspecifiedAddress { local_port } => {
-                if let Some(ref mut control) = slot.control
-                    && let Some(control_len) = slot.control_length
-                {
-                    #[allow(unsafe_code)]
-                    let Some((local_addr, reply_pktinfo)) =
-                        // SAFETY: The call to `recvmmsg` above updated
-                        // the control buffer length field.
-                        find_pktinfo_from_iter(unsafe { control.iter(control_len) }, local_port) else {
-                        // Since we have a bound socket
-                        // and we have set IP_PKTINFO
-                        // sockopt this shouldn't happen.
-                        metrics::udp_recv_missing_pktinfo();
-                        return Err(std::io::Error::other("recvmmsg did not return IP_PKTINFO"));
-                    };
-                    (local_addr, Some(reply_pktinfo))
-                } else {
-                    // No cmsg found, returning error
+                let Some((local_addr, reply_pktinfo)) = slot
+                    .control_messages()
+                    .and_then(|iter| find_pktinfo_from_iter(iter, local_port))
+                else {
+                    // We bind the socket and set the IP_PKTINFO sockopt, so
+                    // this should not happen.
                     metrics::udp_recv_missing_pktinfo();
-                    return Err(std::io::Error::other(
-                        "recvmmsg did not return cmsg and IP_PKTINFO",
-                    ));
-                }
+                    return Err(std::io::Error::other("recvmmsg did not return IP_PKTINFO"));
+                };
+                (local_addr, Some(reply_pktinfo))
             }
             BindMode::SpecificAddress { local_addr } => (local_addr, None),
         };

--- a/lightway-server/src/io/outside/udp.rs
+++ b/lightway-server/src/io/outside/udp.rs
@@ -237,13 +237,36 @@ impl UdpServer {
         self.send_queue.clone()
     }
 
-    fn data_received(
-        &self,
-        peer_addr: SocketAddr,
-        local_addr: SocketAddr,
-        reply_pktinfo: Option<libc::in_pktinfo>,
-        buf: &mut BytesMut,
-    ) {
+    /// The `IP_PKTINFO` to echo on replies to a packet that arrived on
+    /// `local_addr`.
+    ///
+    /// Derived rather than carried: the kernel's `ipi_spec_dst` is the
+    /// local address, which is what `local_addr` already holds, so there
+    /// is nothing extra to thread through the receive path.
+    ///
+    /// `None` when the socket is bound to a specific address, because the
+    /// kernel then picks the right source itself.
+    fn reply_pktinfo(&self, local_addr: SocketAddr) -> Option<libc::in_pktinfo> {
+        if !self.bind_mode.needs_pktinfo() {
+            return None;
+        }
+        let IpAddr::V4(v4) = local_addr.ip() else {
+            // `IP_PKTINFO` is IPv4 only, and the receive path only
+            // resolves a local address for IPv4.
+            return None;
+        };
+        Some(libc::in_pktinfo {
+            ipi_ifindex: 0,
+            ipi_spec_dst: libc::in_addr {
+                s_addr: v4.to_bits().to_be(),
+            },
+            ipi_addr: libc::in_addr { s_addr: 0 },
+        })
+    }
+
+    fn data_received(&self, peer_addr: SocketAddr, local_addr: SocketAddr, buf: &mut BytesMut) {
+        let reply_pktinfo = self.reply_pktinfo(local_addr);
+
         datagram::data_received(
             &self.conn_manager,
             buf,
@@ -280,14 +303,14 @@ impl UdpServer {
             buf.clear();
             buf.reserve(MAX_OUTSIDE_MTU);
 
-            let (peer_addr, local_addr, reply_pktinfo) = self
+            let (peer_addr, local_addr) = self
                 .sock
                 .async_io(Interest::READABLE, || {
                     read_single_from_socket(&self.sock, &mut buf, &self.bind_mode)
                 })
                 .await?;
 
-            self.data_received(peer_addr, local_addr, reply_pktinfo, &mut buf);
+            self.data_received(peer_addr, local_addr, &mut buf);
         }
     }
 
@@ -313,7 +336,7 @@ impl UdpServer {
             // `zip` stops at the shorter iterator, so this processes exactly the
             // slots that batch receive filled (one metadata entry per slot).
             for (buf, meta) in bufs.iter_mut().zip(pkt_metadata) {
-                self.data_received(meta.peer, meta.local, meta.reply_pktinfo, buf);
+                self.data_received(meta.0, meta.1, buf);
             }
         }
     }
@@ -333,10 +356,13 @@ impl Server for UdpServer {
     }
 }
 
-fn find_pktinfo_from_iter(
-    mut iter: cmsg::Iter<'_>,
-    local_port: u16,
-) -> Option<(SocketAddr, libc::in_pktinfo)> {
+/// Resolve the local address a packet arrived on from its `IP_PKTINFO`
+/// control message.
+///
+/// The reply `IP_PKTINFO` is not returned: it is a function of this
+/// address, rebuilt by [`UdpServer::reply_pktinfo`] when a reply is
+/// needed.
+fn find_local_addr_from_iter(mut iter: cmsg::Iter<'_>, local_port: u16) -> Option<SocketAddr> {
     iter.find_map(|cmsg| {
         match cmsg {
             cmsg::Message::IpPktinfo(pi) => {
@@ -348,13 +374,7 @@ fn find_pktinfo_from_iter(
                 let ipv4 = Ipv4Addr::from_bits(ipv4);
                 let ip = IpAddr::V4(ipv4);
 
-                let reply_pktinfo = libc::in_pktinfo {
-                    ipi_ifindex: 0,
-                    ipi_spec_dst: pi.ipi_spec_dst,
-                    ipi_addr: libc::in_addr { s_addr: 0 },
-                };
-
-                Some((SocketAddr::new(ip, local_port), reply_pktinfo))
+                Some(SocketAddr::new(ip, local_port))
             }
             _ => None,
         }
@@ -365,7 +385,7 @@ fn read_single_from_socket(
     sock: &Arc<tokio::net::UdpSocket>,
     buf: &mut BytesMut,
     bind_mode: &BindMode,
-) -> std::io::Result<(SocketAddr, SocketAddr, Option<libc::in_pktinfo>)> {
+) -> std::io::Result<(SocketAddr, SocketAddr)> {
     let sock = SockRef::from(sock.as_ref());
     let mut raw_buf = [MaybeUninitSlice::new(buf.spare_capacity_mut())];
 
@@ -428,32 +448,24 @@ fn read_single_from_socket(
     };
 
     #[allow(unsafe_code)]
-    let (local_addr, reply_pktinfo) = match *bind_mode {
+    let local_addr = match *bind_mode {
         BindMode::UnspecifiedAddress { local_port } => {
-            let Some((local_addr, reply_pktinfo)) =
+            let Some(local_addr) =
             // SAFETY: The call to `recvmsg` above updated
             // the control buffer length field.
-                find_pktinfo_from_iter(unsafe { control.iter(control_len) }, local_port) else {
+                find_local_addr_from_iter(unsafe { control.iter(control_len) }, local_port) else {
                 // Since we have a bound socket
                 // and we have set IP_PKTINFO
                 // sockopt this shouldn't happen.
                 metrics::udp_recv_missing_pktinfo();
                 return Err(std::io::Error::other( "recvmsg did not return IP_PKTINFO",));
             };
-            (local_addr, Some(reply_pktinfo))
+            local_addr
         }
-        BindMode::SpecificAddress { local_addr } => (local_addr, None),
+        BindMode::SpecificAddress { local_addr } => local_addr,
     };
 
-    Ok((peer_addr, local_addr, reply_pktinfo))
-}
-
-/// Per-packet metadata produced by batched receive.
-struct BatchRecvMetadata {
-    peer: SocketAddr,
-    local: SocketAddr,
-    /// The `in_pktinfo` to echo back on replies, when the bind mode needs it.
-    reply_pktinfo: Option<libc::in_pktinfo>,
+    Ok((peer_addr, local_addr))
 }
 
 fn read_multiple_from_socket(
@@ -461,7 +473,7 @@ fn read_multiple_from_socket(
     bufs: &mut [BytesMut; MAX_IO_BATCH_SIZE],
     buf_slots: &mut [BatchRecvSlot; MAX_IO_BATCH_SIZE],
     bind_mode: &BindMode,
-) -> std::io::Result<Vec<BatchRecvMetadata>> {
+) -> std::io::Result<Vec<(SocketAddr, SocketAddr)>> {
     let sock = SockRef::from(sock.as_ref());
 
     let fd = sock.as_raw_fd();
@@ -483,27 +495,23 @@ fn read_multiple_from_socket(
             ));
         };
 
-        let (local_addr, reply_pktinfo) = match *bind_mode {
+        let local_addr = match *bind_mode {
             BindMode::UnspecifiedAddress { local_port } => {
-                let Some((local_addr, reply_pktinfo)) = slot
+                let Some(local_addr) = slot
                     .control_messages()
-                    .and_then(|iter| find_pktinfo_from_iter(iter, local_port))
+                    .and_then(|iter| find_local_addr_from_iter(iter, local_port))
                 else {
                     // We bind the socket and set the IP_PKTINFO sockopt, so
                     // this should not happen.
                     metrics::udp_recv_missing_pktinfo();
                     return Err(std::io::Error::other("recvmmsg did not return IP_PKTINFO"));
                 };
-                (local_addr, Some(reply_pktinfo))
+                local_addr
             }
-            BindMode::SpecificAddress { local_addr } => (local_addr, None),
+            BindMode::SpecificAddress { local_addr } => local_addr,
         };
 
-        metadata.push(BatchRecvMetadata {
-            peer: peer_addr,
-            local: local_addr,
-            reply_pktinfo,
-        });
+        metadata.push((peer_addr, local_addr));
     }
 
     Ok(metadata)

--- a/lightway-server/src/io/outside/udp/batch_receive.rs
+++ b/lightway-server/src/io/outside/udp/batch_receive.rs
@@ -9,54 +9,38 @@
 use bytes::BytesMut;
 use lightway_app_utils::cmsg;
 use lightway_app_utils::cmsg::LibcControlLen;
-use lightway_core::MAX_IO_BATCH_SIZE;
+use lightway_core::{MAX_IO_BATCH_SIZE, MAX_OUTSIDE_MTU};
 use std::io;
 use std::net::SocketAddr;
 
-/// Platform-specific batch receive syscall.
-trait ServerBatchRecvSyscall {
-    /// Receive up to `msg_count` packets from `fd` into `slots`, filling
-    /// per-packet peer address and control (cmsg) data alongside the payload.
-    /// Returns the number of packets actually received.
-    fn recv_multiple_with_metadata<const CONTROL_SIZE: usize>(
-        fd: libc::c_int,
-        slots: &mut [BatchRecvSlot<CONTROL_SIZE>; MAX_IO_BATCH_SIZE],
-        msg_count: usize,
-    ) -> io::Result<usize>;
-}
+/// Control-buffer size for one `IP_PKTINFO` control message, which is the
+/// only cmsg this server reads.
+pub(crate) const CONTROL_SIZE: usize = cmsg::Message::space::<libc::in_pktinfo>();
 
-/// Per-slot state for a batched UDP receive that also captures the source
-/// address and any control messages (cmsg) the kernel returns.
+/// Per-packet metadata for a batched UDP receive: the source address and
+/// any control messages (cmsg) the kernel returns.
 ///
-/// Construct once with [`BatchRecvSlot::new`] and reuse across calls by
-/// invoking [`BatchRecvSlot::reset`] between batches.
-pub struct BatchRecvSlot<const CONTROL_SIZE: usize> {
-    /// Data buffer for the packet payload.
-    ///
-    /// Spare capacity should be at least [`lightway_core::MAX_OUTSIDE_MTU`]
-    /// before each batch call. The syscall advertises at most the spare capacity
-    /// to the kernel, so an undersized buffer results in truncated datagrams
-    /// rather than an out-of-bounds write. The syscall sets the length to the
-    /// number of bytes actually received.
-    pub buf: BytesMut,
-    /// Control message buffer.
-    ///
-    /// Caller supplies the capacity needed for the cmsg types they care about
-    /// (e.g. `CMSG_SPACE(sizeof(in_pktinfo))`). The syscall sets the length to
-    /// the number of bytes of cmsg data the kernel wrote.
-    pub control: Option<cmsg::Buffer<CONTROL_SIZE>>,
+/// The payload buffers are supplied by the caller, one per slot, so a
+/// receive can read straight into buffers the caller already owns.
+///
+/// Construct once with [`BatchRecvSlot::new`] and reuse across calls: the
+/// receive call re-advertises the control buffer and the address length on
+/// every packet it fills.
+pub(crate) struct BatchRecvSlot {
+    /// Control message buffer. The receive call sets `control_length` to the
+    /// number of cmsg bytes the kernel wrote.
+    control: cmsg::Buffer<CONTROL_SIZE>,
     /// Out: Control message buffer length
-    pub control_length: Option<LibcControlLen>,
+    control_length: Option<LibcControlLen>,
     /// Out: source-address storage written by the kernel. `SockAddrStorage`
     /// is `#[repr(transparent)]` over `libc::sockaddr_storage`, so it can be
     /// handed to a raw recvmsg-style syscall and afterwards decoded via
     /// [`BatchRecvSlot::take_peer_addr`].
     peer_addr_storage: socket2::SockAddrStorage,
-    /// Buffer length for the source address. Pre-filled with
-    /// [`socket2::SockAddrStorage::size_of`] when we call reset() so the kernel
-    /// knows how much room it has; the syscall replaces it with the actual
-    /// number of bytes it wrote (typically `sizeof(sockaddr_in)` for IPv4 or
-    /// `sizeof(sockaddr_in6)` for IPv6).
+    /// Buffer length for the source address. The receive call pre-fills it
+    /// from [`socket2::SockAddrStorage::size_of`] so the kernel knows how
+    /// much room it has, then the syscall replaces it with the number of
+    /// bytes it wrote.
     peer_addr_len: libc::socklen_t,
     /// Out: `true` if the kernel set `MSG_TRUNC` in `msg_flags` for this
     /// packet, meaning the datagram was larger than the buffer we supplied and
@@ -68,19 +52,13 @@ pub struct BatchRecvSlot<const CONTROL_SIZE: usize> {
     pub truncated: bool,
 }
 
-impl<const CONTROL_SIZE: usize> BatchRecvSlot<CONTROL_SIZE> {
-    /// Create a slot with data spare-capacity of [`lightway_core::MAX_OUTSIDE_MTU`]
-    /// and a control buffer of `control_capacity` bytes.
-    pub fn new() -> Self {
+impl BatchRecvSlot {
+    /// Create a slot with a control buffer of [`CONTROL_SIZE`] bytes.
+    pub(crate) fn new() -> Self {
         let peer_addr_storage = socket2::SockAddrStorage::zeroed();
         let peer_addr_len = peer_addr_storage.size_of();
         Self {
-            buf: BytesMut::with_capacity(lightway_core::MAX_OUTSIDE_MTU),
-            control: if CONTROL_SIZE > 0 {
-                Some(cmsg::Buffer::<CONTROL_SIZE>::new())
-            } else {
-                None
-            },
+            control: cmsg::Buffer::new(),
             control_length: None,
             peer_addr_storage,
             peer_addr_len,
@@ -88,21 +66,15 @@ impl<const CONTROL_SIZE: usize> BatchRecvSlot<CONTROL_SIZE> {
         }
     }
 
-    /// Reset the slot for a new batch receive without releasing any
-    /// allocations: clears the buffer length (preserving capacity) and restores
-    /// the source-address length bound so the kernel knows how much room the
-    /// storage has. The address storage itself is not touched here — it is left
-    /// zeroed by [`take_peer_addr`](Self::take_peer_addr) and overwritten by the
-    /// kernel on the next receive.
-    pub fn reset(&mut self) {
-        self.buf.clear();
-        self.buf.reserve(lightway_core::MAX_OUTSIDE_MTU);
-        if let Some(control) = &mut self.control {
-            control.reset();
-        }
-        self.control_length = None;
-        self.peer_addr_len = self.peer_addr_storage.size_of();
-        self.truncated = false;
+    /// Iterate the control messages the kernel wrote for this packet.
+    ///
+    /// `None` until a receive has filled the slot.
+    pub(crate) fn control_messages(&mut self) -> Option<cmsg::Iter<'_>> {
+        let len = self.control_length?;
+        // SAFETY: the receive call set `control_length` to the number of
+        // bytes the kernel wrote into `control`.
+        #[allow(unsafe_code)]
+        Some(unsafe { self.control.iter(len) })
     }
 
     /// Convert the slot's source-address storage into a [`SocketAddr`], taking
@@ -110,7 +82,7 @@ impl<const CONTROL_SIZE: usize> BatchRecvSlot<CONTROL_SIZE> {
     ///
     /// Returns `None` if the address family is not `AF_INET` or `AF_INET6`,
     /// which should not happen for a UDP/IP socket.
-    pub fn take_peer_addr(&mut self) -> Option<SocketAddr> {
+    pub(crate) fn take_peer_addr(&mut self) -> Option<SocketAddr> {
         // `SockAddr::new` consumes the storage by value, so move the
         // kernel-populated bytes out of the slot (leaving a zeroed storage in
         // their place) rather than copying them. The length is what the
@@ -130,30 +102,37 @@ impl<const CONTROL_SIZE: usize> BatchRecvSlot<CONTROL_SIZE> {
 }
 
 #[cfg(macos)]
-type PlatformBatchRecv = apple::RecvmsgX;
-
+use apple::recv_multiple as platform_recv;
 #[cfg(linux)]
-type PlatformBatchRecv = linux::Recvmmsg;
+use linux::recv_multiple as platform_recv;
 
-/// Receive up to `max_batch_size` packets from `fd` into `slots`, filling each
-/// slot's peer address and control buffer in addition to the data buffer.
+/// Receive up to [`MAX_IO_BATCH_SIZE`] packets from `fd` into `bufs`, filling
+/// the matching slot's peer address and control buffer for each.
 ///
 /// Returns the number of packets received. On `Ok(n)`, for every `i < n`:
-/// - `slots[i].buf.len()` is set to the bytes received,
-/// - `slots[i].control.len()` is set to the cmsg bytes received,
+/// - `bufs[i].len()` is set to the bytes received,
+/// - `slots[i].control_length` is set to the cmsg bytes received,
 /// - `slots[i].peer_addr_storage` holds the source address (use
 ///   [`BatchRecvSlot::take_peer_addr`] to decode).
 ///
-/// Callers must call [`BatchRecvSlot::reset`] on each slot before invoking this
-/// again, otherwise the data and control lengths from the previous call leak
-/// into the new one.
-pub(crate) fn recv_multiple_with_metadata<const CONTROL_SIZE: usize>(
+/// Every buffer and slot is prepared here, so a caller can hand the same
+/// arrays back on the next call without touching them.
+pub(crate) fn recv_multiple_with_metadata(
     fd: libc::c_int,
-    slots: &mut [BatchRecvSlot<CONTROL_SIZE>; MAX_IO_BATCH_SIZE],
-    max_batch_size: usize,
+    bufs: &mut [BytesMut; MAX_IO_BATCH_SIZE],
+    slots: &mut [BatchRecvSlot; MAX_IO_BATCH_SIZE],
 ) -> io::Result<usize> {
-    let max_batch_size = max_batch_size.min(MAX_IO_BATCH_SIZE);
-    PlatformBatchRecv::recv_multiple_with_metadata(fd, slots, max_batch_size)
+    for (buf, slot) in bufs.iter_mut().zip(slots.iter_mut()) {
+        // Prepare here rather than trusting the caller. `clear` alone is not
+        // enough: parsing advances the offset, so `reserve` is what returns
+        // the full spare capacity the iovec advertises.
+        buf.clear();
+        buf.reserve(MAX_OUTSIDE_MTU);
+        slot.control_length = None;
+        slot.peer_addr_len = slot.peer_addr_storage.size_of();
+        slot.truncated = false;
+    }
+    platform_recv(fd, bufs, slots)
 }
 
 #[cfg(macos)]
@@ -163,88 +142,72 @@ mod apple {
     use lightway_core::{MAX_IO_BATCH_SIZE, MAX_OUTSIDE_MTU};
     use std::{io, mem};
 
-    pub(crate) struct RecvmsgX;
+    /// Receive packets with peer-address and control (cmsg) metadata using
+    /// the batch syscall. Buffers and slots arrive prepared by the caller.
+    #[allow(unsafe_code)]
+    pub(crate) fn recv_multiple(
+        fd: libc::c_int,
+        bufs: &mut [bytes::BytesMut; MAX_IO_BATCH_SIZE],
+        slots: &mut [super::BatchRecvSlot; MAX_IO_BATCH_SIZE],
+    ) -> io::Result<usize> {
+        // SAFETY: zeroed iovec are valid (null pointers + zero lengths).
+        let mut iovecs = unsafe { mem::zeroed::<[libc::iovec; MAX_IO_BATCH_SIZE]>() };
+        // SAFETY: zeroed msghdr_x is valid (null pointers + zero lengths).
+        let mut hdrs = unsafe { mem::zeroed::<[msghdr_x; MAX_IO_BATCH_SIZE]>() };
+        for (i, (slot, buf)) in slots.iter_mut().zip(bufs.iter_mut()).enumerate() {
+            let spare = buf.spare_capacity_mut();
 
-    impl super::ServerBatchRecvSyscall for RecvmsgX {
-        /// Receive packets with peer-address and control (cmsg) metadata using
-        /// the `recvmsg_x` batch syscall.
-        #[allow(unsafe_code)]
-        fn recv_multiple_with_metadata<const CONTROL_SIZE: usize>(
-            fd: libc::c_int,
-            slots: &mut [super::BatchRecvSlot<CONTROL_SIZE>; MAX_IO_BATCH_SIZE],
-            msg_count: usize,
-        ) -> io::Result<usize> {
-            // SAFETY: zeroed iovec are valid (null pointers + zero lengths).
-            let mut iovecs = unsafe { mem::zeroed::<[libc::iovec; MAX_IO_BATCH_SIZE]>() };
-            // SAFETY: zeroed msghdr_x is valid (null pointers + zero lengths).
-            let mut hdrs = unsafe { mem::zeroed::<[msghdr_x; MAX_IO_BATCH_SIZE]>() };
-            for (i, slot) in slots.iter_mut().take(msg_count).enumerate() {
-                let spare = slot.buf.spare_capacity_mut();
-                debug_assert!(
-                    spare.len() >= MAX_OUTSIDE_MTU,
-                    "slot {i}: buf spare capacity ({}) < MAX_OUTSIDE_MTU ({MAX_OUTSIDE_MTU})",
-                    spare.len(),
-                );
+            let iovec = &mut iovecs[i];
+            let hdr = &mut hdrs[i];
+            iovec.iov_base = spare.as_mut_ptr() as *mut libc::c_void;
+            // Bound by the spare capacity actually behind the pointer, so the
+            // kernel cannot write past the allocation whatever was reserved.
+            iovec.iov_len = spare.len().min(MAX_OUTSIDE_MTU);
+            hdr.msg_iov = iovec;
+            hdr.msg_iovlen = 1;
 
-                let iovec = &mut iovecs[i];
-                let hdr = &mut hdrs[i];
-                // Bound the iovec by the spare capacity actually available so
-                // the kernel can never write past the allocation, even if a
-                // caller violates the spare-capacity contract above.
-                iovec.iov_base = spare.as_mut_ptr() as *mut libc::c_void;
-                iovec.iov_len = spare.len().min(MAX_OUTSIDE_MTU);
-                hdr.msg_iov = iovec;
-                hdr.msg_iovlen = 1;
+            hdr.msg_name =
+                &mut slot.peer_addr_storage as *mut socket2::SockAddrStorage as *mut libc::c_void;
+            hdr.msg_namelen = slot.peer_addr_len;
 
-                hdr.msg_name = &mut slot.peer_addr_storage as *mut socket2::SockAddrStorage
-                    as *mut libc::c_void;
-                hdr.msg_namelen = slot.peer_addr_len;
-
-                if let Some(control) = &mut slot.control {
-                    hdr.msg_control =
-                        control.spare_capacity_mut().as_mut_ptr() as *mut libc::c_void;
-                    hdr.msg_controllen = control.capacity() as LibcControlLen;
-                }
-            }
-
-            // SAFETY: hdrs/iovecs and the per-slot storage referenced by their
-            // pointers remain valid for the duration of the syscall; `slots`
-            // is borrowed mutably for the whole call.
-            let n = unsafe { recvmsg_x(fd, hdrs.as_mut_ptr(), msg_count as _, 0) };
-
-            if n < 0 {
-                return Err(io::Error::last_os_error());
-            }
-
-            let count = n as usize;
-            if count > msg_count {
-                return Err(io::Error::other(
-                    "recvmsg_x returned more packets than requested",
-                ));
-            }
-            for (slot, hdr) in slots.iter_mut().take(count).zip(hdrs) {
-                // For recvmsg_x(), the size of the data received is given by the field msg_datalen.
-                let len = hdr.msg_datalen;
-                let new_len = slot.buf.len() + len;
-                // SAFETY: the kernel wrote `len` bytes into the spare capacity
-                // advertised via the iovec, which was bounded by that spare
-                // capacity, so `new_len <= capacity()`.
-                unsafe {
-                    slot.buf.set_len(new_len);
-                }
-                slot.peer_addr_len = hdr.msg_namelen;
-                if slot.control.is_some() {
-                    slot.control_length = Some(hdr.msg_controllen);
-                }
-                // Note: current XNU does not set MSG_TRUNC in the per-message
-                // msg_flags of recvmsg_x (only MSG_CTRUNC is reported there),
-                // so this stays false today. The check is kept in case the
-                // kernel gains support.
-                slot.truncated = hdr.msg_flags & libc::MSG_TRUNC != 0;
-            }
-
-            Ok(count)
+            hdr.msg_control = slot.control.spare_capacity_mut().as_mut_ptr() as *mut libc::c_void;
+            hdr.msg_controllen = super::CONTROL_SIZE as LibcControlLen;
         }
+
+        // SAFETY: hdrs/iovecs and the per-slot storage referenced by their
+        // pointers remain valid for the duration of the syscall; `slots`
+        // is borrowed mutably for the whole call.
+        let n = unsafe { recvmsg_x(fd, hdrs.as_mut_ptr(), MAX_IO_BATCH_SIZE as _, 0) };
+
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let count = n as usize;
+        if count > MAX_IO_BATCH_SIZE {
+            return Err(io::Error::other(
+                "recvmsg_x returned more packets than requested",
+            ));
+        }
+        for ((slot, buf), hdr) in slots.iter_mut().zip(bufs.iter_mut()).take(count).zip(hdrs) {
+            // For recvmsg_x(), the size of the data received is given by the field msg_datalen.
+            let len = hdr.msg_datalen;
+            // SAFETY: the caller cleared the buffer and the kernel wrote
+            // `len` bytes into the spare capacity advertised via the
+            // iovec, which was bounded by that spare capacity, so
+            // `len <= capacity()`.
+            unsafe {
+                buf.set_len(len);
+            }
+            slot.peer_addr_len = hdr.msg_namelen;
+            slot.control_length = Some(hdr.msg_controllen);
+            // Current XNU does not set MSG_TRUNC in the per-message msg_flags
+            // of recvmsg_x (only MSG_CTRUNC is reported there), so this stays
+            // false today. Read it anyway, in case the kernel gains support.
+            slot.truncated = hdr.msg_flags & libc::MSG_TRUNC != 0;
+        }
+
+        Ok(count)
     }
 }
 
@@ -254,92 +217,78 @@ mod linux {
     use lightway_core::{MAX_IO_BATCH_SIZE, MAX_OUTSIDE_MTU};
     use std::{io, mem};
 
-    pub(crate) struct Recvmmsg;
+    /// Receive packets with peer-address and control (cmsg) metadata using
+    /// the batch syscall. Buffers and slots arrive prepared by the caller.
+    #[allow(unsafe_code)]
+    pub(crate) fn recv_multiple(
+        fd: libc::c_int,
+        bufs: &mut [bytes::BytesMut; MAX_IO_BATCH_SIZE],
+        slots: &mut [super::BatchRecvSlot; MAX_IO_BATCH_SIZE],
+    ) -> io::Result<usize> {
+        // SAFETY: zeroed iovec are valid (null pointers + zero lengths).
+        let mut iovecs = unsafe { mem::zeroed::<[libc::iovec; MAX_IO_BATCH_SIZE]>() };
+        // SAFETY: zeroed hdrs are valid (null pointers + zero lengths).
+        let mut hdrs = unsafe { mem::zeroed::<[libc::mmsghdr; MAX_IO_BATCH_SIZE]>() };
+        for (i, (slot, buf)) in slots.iter_mut().zip(bufs.iter_mut()).enumerate() {
+            let spare = buf.spare_capacity_mut();
 
-    impl super::ServerBatchRecvSyscall for Recvmmsg {
-        /// Receive packets with peer-address and control (cmsg) metadata using
-        /// the `recvmmsg` batch syscall.
-        #[allow(unsafe_code)]
-        fn recv_multiple_with_metadata<const CONTROL_SIZE: usize>(
-            fd: libc::c_int,
-            slots: &mut [super::BatchRecvSlot<CONTROL_SIZE>; MAX_IO_BATCH_SIZE],
-            msg_count: usize,
-        ) -> io::Result<usize> {
-            // SAFETY: zeroed iovec are valid (null pointers + zero lengths).
-            let mut iovecs = unsafe { mem::zeroed::<[libc::iovec; MAX_IO_BATCH_SIZE]>() };
-            // SAFETY: zeroed hdrs are valid (null pointers + zero lengths).
-            let mut hdrs = unsafe { mem::zeroed::<[libc::mmsghdr; MAX_IO_BATCH_SIZE]>() };
-            for (i, slot) in slots.iter_mut().take(msg_count).enumerate() {
-                let spare = slot.buf.spare_capacity_mut();
-                debug_assert!(
-                    spare.len() >= MAX_OUTSIDE_MTU,
-                    "slot {i}: buf spare capacity ({}) < MAX_OUTSIDE_MTU ({MAX_OUTSIDE_MTU})",
-                    spare.len(),
-                );
+            let iovec = &mut iovecs[i];
+            let hdr = &mut hdrs[i];
+            iovec.iov_base = spare.as_mut_ptr() as *mut libc::c_void;
+            // Bound by the spare capacity actually behind the pointer, so the
+            // kernel cannot write past the allocation whatever was reserved.
+            iovec.iov_len = spare.len().min(MAX_OUTSIDE_MTU);
+            hdr.msg_hdr.msg_iov = iovec;
+            hdr.msg_hdr.msg_iovlen = 1;
 
-                let iovec = &mut iovecs[i];
-                let hdr = &mut hdrs[i];
-                // Bound the iovec by the spare capacity actually available so
-                // the kernel can never write past the allocation, even if a
-                // caller violates the spare-capacity contract above.
-                iovec.iov_base = spare.as_mut_ptr() as *mut libc::c_void;
-                iovec.iov_len = spare.len().min(MAX_OUTSIDE_MTU);
-                hdr.msg_hdr.msg_iov = iovec;
-                hdr.msg_hdr.msg_iovlen = 1;
+            hdr.msg_hdr.msg_name =
+                &mut slot.peer_addr_storage as *mut socket2::SockAddrStorage as *mut libc::c_void;
+            hdr.msg_hdr.msg_namelen = slot.peer_addr_len;
 
-                hdr.msg_hdr.msg_name = &mut slot.peer_addr_storage as *mut socket2::SockAddrStorage
-                    as *mut libc::c_void;
-                hdr.msg_hdr.msg_namelen = slot.peer_addr_len;
-
-                if let Some(control) = &mut slot.control {
-                    hdr.msg_hdr.msg_control =
-                        control.spare_capacity_mut().as_mut_ptr() as *mut libc::c_void;
-                    hdr.msg_hdr.msg_controllen = control.capacity() as LibcControlLen;
-                }
-            }
-
-            // SAFETY: hdrs/iovecs and the per-slot storage referenced by their
-            // pointers remain valid for the duration of the syscall; `slots`
-            // is borrowed mutably for the whole call.
-            let n = unsafe {
-                libc::recvmmsg(
-                    fd,
-                    hdrs.as_mut_ptr(),
-                    msg_count as _,
-                    0,
-                    std::ptr::null_mut(),
-                )
-            };
-
-            if n < 0 {
-                return Err(io::Error::last_os_error());
-            }
-
-            let count = n as usize;
-            if count > msg_count {
-                return Err(io::Error::other(
-                    "recvmmsg returned more packets than requested",
-                ));
-            }
-            for (slot, hdr) in slots.iter_mut().take(count).zip(hdrs) {
-                // recvmmsg sets msg_len to the number of bytes received per message.
-                let len = hdr.msg_len as usize;
-                let new_len = slot.buf.len() + len;
-                // SAFETY: the kernel wrote `len` bytes into the spare capacity
-                // advertised via the iovec, which was bounded by that spare
-                // capacity, so `new_len <= capacity()`.
-                unsafe {
-                    slot.buf.set_len(new_len);
-                }
-                slot.peer_addr_len = hdr.msg_hdr.msg_namelen;
-                if slot.control.is_some() {
-                    slot.control_length = Some(hdr.msg_hdr.msg_controllen);
-                }
-                slot.truncated = hdr.msg_hdr.msg_flags & libc::MSG_TRUNC != 0;
-            }
-
-            Ok(count)
+            hdr.msg_hdr.msg_control =
+                slot.control.spare_capacity_mut().as_mut_ptr() as *mut libc::c_void;
+            hdr.msg_hdr.msg_controllen = super::CONTROL_SIZE as LibcControlLen;
         }
+
+        // SAFETY: hdrs/iovecs and the per-slot storage referenced by their
+        // pointers remain valid for the duration of the syscall; `slots`
+        // is borrowed mutably for the whole call.
+        let n = unsafe {
+            libc::recvmmsg(
+                fd,
+                hdrs.as_mut_ptr(),
+                MAX_IO_BATCH_SIZE as _,
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let count = n as usize;
+        if count > MAX_IO_BATCH_SIZE {
+            return Err(io::Error::other(
+                "recvmmsg returned more packets than requested",
+            ));
+        }
+        for ((slot, buf), hdr) in slots.iter_mut().zip(bufs.iter_mut()).take(count).zip(hdrs) {
+            // recvmmsg sets msg_len to the number of bytes received per message.
+            let len = hdr.msg_len as usize;
+            // SAFETY: the caller cleared the buffer and the kernel wrote
+            // `len` bytes into the spare capacity advertised via the
+            // iovec, which was bounded by that spare capacity, so
+            // `len <= capacity()`.
+            unsafe {
+                buf.set_len(len);
+            }
+            slot.peer_addr_len = hdr.msg_hdr.msg_namelen;
+            slot.control_length = Some(hdr.msg_hdr.msg_controllen);
+            slot.truncated = hdr.msg_hdr.msg_flags & libc::MSG_TRUNC != 0;
+        }
+
+        Ok(count)
     }
 }
 
@@ -349,56 +298,15 @@ mod tests {
     use std::time::Duration;
     use tokio::net::UdpSocket;
 
-    #[test]
-    fn reset_returns_slot_to_fresh_state() {
-        const CONTROL_CAP: usize = 64;
-        let mut slot: BatchRecvSlot<CONTROL_CAP> = BatchRecvSlot::new();
-
-        let initial_buf_cap = slot.buf.capacity();
-        let initial_peer_addr_len = slot.peer_addr_len;
-        let initial_control_cap = slot
-            .control
-            .as_ref()
-            .expect("CONTROL_CAP > 0 should allocate a control buffer")
-            .capacity();
-
-        // Dirty every output field as a kernel write would. The address
-        // storage itself is owned by `take_peer_addr` (see its own test), so
-        // `reset` only has to restore the length bound here.
-        slot.buf.extend_from_slice(b"junk payload");
-        slot.control_length = Some(32);
-        slot.truncated = true;
-        slot.peer_addr_len = std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t;
-
-        slot.reset();
-
-        assert_eq!(slot.buf.len(), 0, "reset must clear buf len");
-        assert_eq!(
-            slot.buf.capacity(),
-            initial_buf_cap,
-            "reset must preserve buf capacity",
-        );
-        let control = slot.control.as_ref().expect("control buffer still present");
-        assert_eq!(
-            control.capacity(),
-            initial_control_cap,
-            "reset must preserve control capacity",
-        );
-        assert!(
-            slot.control_length.is_none(),
-            "reset must clear control_length",
-        );
-        assert_eq!(
-            slot.peer_addr_len, initial_peer_addr_len,
-            "reset must restore peer_addr_len to the storage bound",
-        );
-        assert!(!slot.truncated, "reset must clear the truncated flag");
+    /// The receive call clears and reserves each buffer itself, so these
+    /// start empty.
+    fn fresh_bufs() -> [BytesMut; MAX_IO_BATCH_SIZE] {
+        std::array::from_fn(|_| BytesMut::new())
     }
 
     #[test]
     fn take_peer_addr_consumes_the_stored_address() {
-        const CONTROL_CAP: usize = 64;
-        let mut slot: BatchRecvSlot<CONTROL_CAP> = BatchRecvSlot::new();
+        let mut slot: BatchRecvSlot = BatchRecvSlot::new();
 
         // Simulate a kernel write of an IPv4 source address.
         slot.peer_addr_len = std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t;
@@ -420,26 +328,6 @@ mod tests {
             slot.take_peer_addr().is_none(),
             "take_peer_addr must leave the storage zeroed (AF_UNSPEC -> None)",
         );
-    }
-
-    #[test]
-    fn reset_with_zero_control_capacity_keeps_control_none() {
-        let mut slot: BatchRecvSlot<0> = BatchRecvSlot::new();
-        assert!(
-            slot.control.is_none(),
-            "CONTROL_SIZE == 0 must not allocate a control buffer",
-        );
-
-        slot.buf.extend_from_slice(b"junk");
-        slot.control_length = Some(8);
-        slot.reset();
-
-        assert_eq!(slot.buf.len(), 0);
-        assert!(
-            slot.control.is_none(),
-            "reset must not allocate a control buffer when CONTROL_SIZE == 0",
-        );
-        assert!(slot.control_length.is_none());
     }
 
     async fn make_socket_pair() -> (UdpSocket, UdpSocket) {
@@ -464,8 +352,9 @@ mod tests {
         sender.send(b"hello").await.unwrap();
 
         // No cmsg sockopt enabled on this connected socket, so zero control capacity.
-        let mut slots: [BatchRecvSlot<0>; MAX_IO_BATCH_SIZE] =
+        let mut slots: [BatchRecvSlot; MAX_IO_BATCH_SIZE] =
             std::array::from_fn(|_| BatchRecvSlot::new());
+        let mut bufs = fresh_bufs();
 
         tokio::time::timeout(Duration::from_secs(2), receiver.readable())
             .await
@@ -473,11 +362,9 @@ mod tests {
             .unwrap();
 
         let fd = std::os::fd::AsRawFd::as_raw_fd(&receiver);
-        let count =
-            PlatformBatchRecv::recv_multiple_with_metadata(fd, &mut slots, MAX_IO_BATCH_SIZE)
-                .unwrap();
+        let count = recv_multiple_with_metadata(fd, &mut bufs, &mut slots).unwrap();
         assert!(count >= 1);
-        assert_eq!(&slots[0].buf[..], b"hello");
+        assert_eq!(&bufs[0][..], b"hello");
     }
 
     #[tokio::test]
@@ -495,8 +382,9 @@ mod tests {
         let payload = vec![0xa5u8; lightway_core::MAX_OUTSIDE_MTU + 500];
         sender.send(&payload).await.unwrap();
 
-        let mut slots: [BatchRecvSlot<0>; MAX_IO_BATCH_SIZE] =
+        let mut slots: [BatchRecvSlot; MAX_IO_BATCH_SIZE] =
             std::array::from_fn(|_| BatchRecvSlot::new());
+        let mut bufs = fresh_bufs();
 
         tokio::time::timeout(Duration::from_secs(2), receiver.readable())
             .await
@@ -504,20 +392,17 @@ mod tests {
             .unwrap();
 
         let fd = std::os::fd::AsRawFd::as_raw_fd(&receiver);
-        let count =
-            PlatformBatchRecv::recv_multiple_with_metadata(fd, &mut slots, MAX_IO_BATCH_SIZE)
-                .unwrap();
+        let count = recv_multiple_with_metadata(fd, &mut bufs, &mut slots).unwrap();
         assert_eq!(count, 1);
 
-        let slot = &slots[0];
-        assert_eq!(slot.buf.len(), lightway_core::MAX_OUTSIDE_MTU);
-        assert_eq!(&slot.buf[..], &payload[..lightway_core::MAX_OUTSIDE_MTU]);
+        assert_eq!(bufs[0].len(), lightway_core::MAX_OUTSIDE_MTU);
+        assert_eq!(&bufs[0][..], &payload[..lightway_core::MAX_OUTSIDE_MTU]);
         // recvmsg_x on Apple platforms does not report MSG_TRUNC in the
         // per-message msg_flags, so the truncated flag can only be asserted
         // where recvmmsg provides it.
         #[cfg(linux)]
         assert!(
-            slot.truncated,
+            slots[0].truncated,
             "MSG_TRUNC must be reported for oversized datagrams",
         );
     }
@@ -538,23 +423,9 @@ mod tests {
         let addr_a = sender_a.local_addr().unwrap();
         let addr_b = sender_b.local_addr().unwrap();
 
-        // Use a non-zero control capacity so we can verify reset() preserves
-        // control-buffer capacity even though this test doesn't enable any
-        // cmsg sockopt on the server.
-        const CONTROL_CAP: usize = 64;
-        let mut slots: [BatchRecvSlot<CONTROL_CAP>; MAX_IO_BATCH_SIZE] =
+        let mut slots: [BatchRecvSlot; MAX_IO_BATCH_SIZE] =
             std::array::from_fn(|_| BatchRecvSlot::new());
-
-        let storage_size_of = slots[0].peer_addr_storage.size_of();
-        for (i, slot) in slots.iter().enumerate() {
-            assert_eq!(slot.buf.len(), 0, "slot {i}: fresh buf must be empty");
-            assert!(
-                slot.buf.capacity() >= lightway_core::MAX_OUTSIDE_MTU,
-                "slot {i}: buf cap {} < MAX_OUTSIDE_MTU",
-                slot.buf.capacity(),
-            );
-            assert_eq!(slot.peer_addr_len, storage_size_of);
-        }
+        let mut bufs = fresh_bufs();
 
         sender_a.send_to(b"alpha", server_addr).await.unwrap();
         sender_b.send_to(b"bravo", server_addr).await.unwrap();
@@ -567,16 +438,15 @@ mod tests {
             .unwrap();
 
         let fd = std::os::fd::AsRawFd::as_raw_fd(&server);
-        let count =
-            PlatformBatchRecv::recv_multiple_with_metadata(fd, &mut slots, MAX_IO_BATCH_SIZE)
-                .unwrap();
+        let count = recv_multiple_with_metadata(fd, &mut bufs, &mut slots).unwrap();
         assert!(count >= 1);
 
         // recvmmsg/recvmsg_x ordering across distinct peers isn't guaranteed,
         // so check that both senders appear among the received slots.
         let received: Vec<(std::net::SocketAddr, Vec<u8>)> = slots[..count]
             .iter_mut()
-            .map(|s| (s.take_peer_addr().expect("AF_INET peer"), s.buf.to_vec()))
+            .zip(bufs[..count].iter())
+            .map(|(s, b)| (s.take_peer_addr().expect("AF_INET peer"), b.to_vec()))
             .collect();
         assert!(
             received.contains(&(addr_a, b"alpha".to_vec())),
@@ -589,29 +459,10 @@ mod tests {
 
         let expected_v4_addrlen = std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t;
         for (i, slot) in slots[..count].iter().enumerate() {
-            assert_eq!(slot.buf.len(), 5, "slot {i}: payload was 5 bytes");
+            assert_eq!(bufs[i].len(), 5, "slot {i}: payload was 5 bytes");
             assert_eq!(
                 slot.peer_addr_len, expected_v4_addrlen,
                 "slot {i}: AF_INET peer_addr_len should be sizeof(sockaddr_in)",
-            );
-        }
-
-        // Reset all slots and verify they're back to a clean "ready for next
-        // batch" state without releasing the underlying allocations.
-        let buf_caps_before: Vec<usize> = slots.iter().map(|s| s.buf.capacity()).collect();
-        for slot in &mut slots {
-            slot.reset();
-        }
-        for (i, slot) in slots.iter_mut().enumerate() {
-            assert_eq!(slot.buf.len(), 0, "slot {i}: reset must clear buf len");
-            assert_eq!(
-                slot.buf.capacity(),
-                buf_caps_before[i],
-                "slot {i}: reset must preserve buf capacity",
-            );
-            assert_eq!(
-                slot.peer_addr_len, storage_size_of,
-                "slot {i}: reset must restore peer_addr_len to the buffer bound",
             );
         }
     }
@@ -632,9 +483,9 @@ mod tests {
         let sender = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         sender.send_to(b"pktinfo", server_addr).await.unwrap();
 
-        const CONTROL_CAP: usize = cmsg::Message::space::<libc::in_pktinfo>();
-        let mut slots: [BatchRecvSlot<CONTROL_CAP>; MAX_IO_BATCH_SIZE] =
+        let mut slots: [BatchRecvSlot; MAX_IO_BATCH_SIZE] =
             std::array::from_fn(|_| BatchRecvSlot::new());
+        let mut bufs = fresh_bufs();
 
         // Sanity: a fresh slot has no control_length until the syscall writes one.
         assert!(slots[0].control_length.is_none());
@@ -645,13 +496,11 @@ mod tests {
             .unwrap();
 
         let fd = std::os::fd::AsRawFd::as_raw_fd(&server);
-        let count =
-            PlatformBatchRecv::recv_multiple_with_metadata(fd, &mut slots, MAX_IO_BATCH_SIZE)
-                .unwrap();
+        let count = recv_multiple_with_metadata(fd, &mut bufs, &mut slots).unwrap();
         assert!(count >= 1);
 
         let slot = &slots[0];
-        assert_eq!(&slot.buf[..], b"pktinfo");
+        assert_eq!(&bufs[0][..], b"pktinfo");
 
         let control_len = slot
             .control_length
@@ -661,8 +510,8 @@ mod tests {
             "control_length ({control_len}) too small to hold a cmsghdr",
         );
         assert!(
-            (control_len as usize) <= CONTROL_CAP,
-            "control_length ({control_len}) exceeded control capacity ({CONTROL_CAP})",
+            (control_len as usize) <= CONTROL_SIZE,
+            "control_length ({control_len}) exceeded the control buffer",
         );
     }
 }

--- a/lightway-server/src/io/outside/udp/batch_receive.rs
+++ b/lightway-server/src/io/outside/udp/batch_receive.rs
@@ -13,9 +13,7 @@ use lightway_core::{MAX_IO_BATCH_SIZE, MAX_OUTSIDE_MTU};
 use std::io;
 use std::net::SocketAddr;
 
-/// Control-buffer size for one `IP_PKTINFO` control message, which is the
-/// only cmsg this server reads.
-pub(crate) const CONTROL_SIZE: usize = cmsg::Message::space::<libc::in_pktinfo>();
+const CONTROL_SIZE: usize = super::PKTINFO_CONTROL_SIZE;
 
 /// Per-packet metadata for a batched UDP receive: the source address and
 /// any control messages (cmsg) the kernel returns.

--- a/lightway-server/src/ip_manager.rs
+++ b/lightway-server/src/ip_manager.rs
@@ -167,7 +167,6 @@ impl<T> IpManagerInner<T> {
     }
 }
 
-// Tests START -> panic, unwrap, expect allowed
 #[cfg(test)]
 mod tests {
     use ipnet::Ipv4Net;
@@ -417,5 +416,3 @@ mod tests {
         assert_eq!(count, total_hosts - 4); // 4 == local + dns + 2x reserved
     }
 }
-
-// Tests END -> panic, unwrap, expect allowed

--- a/lightway-server/src/ip_manager/ip_pool.rs
+++ b/lightway-server/src/ip_manager/ip_pool.rs
@@ -86,7 +86,6 @@ impl IpPool {
     }
 }
 
-// Tests START -> panic, unwrap, expect allowed
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -399,5 +398,3 @@ mod tests {
         assert_gt!(total_differences / count as f64, 512.0);
     }
 }
-
-// Tests END -> panic, unwrap, expect allowed

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -50,6 +50,7 @@ pub use crate::connection::ConnectionState;
 #[cfg(linux)]
 pub use crate::io::inside::InsideIORecvGso;
 pub use crate::io::inside::{InsideIO, InsideIORecv, InsideIORecvBatch};
+pub use crate::io::outside::{OutsideIO, RecvMeta};
 
 use crate::io::outside::udp::send_queue::SendQueue;
 use crate::ip_manager::IpManager;
@@ -118,6 +119,12 @@ impl<SA: for<'a> ServerAuth<AuthState<'a>>> ServerAuth<connection::ConnectionSta
 pub enum ServerConnectionMode {
     Stream(Option<TcpListener>),
     Datagram(Option<UdpSocket>),
+    /// A datagram transport supplied by the application, in place of the
+    /// socket the server otherwise creates. Every socket option on
+    /// `ServerConfig` goes unused, `enable_batch_send` included: the
+    /// batched inside loop needs the UDP send queue that only the built-in
+    /// socket provides.
+    DatagramIo(Box<dyn OutsideIO>),
 }
 
 impl std::fmt::Debug for ServerConnectionMode {
@@ -125,6 +132,7 @@ impl std::fmt::Debug for ServerConnectionMode {
         match self {
             Self::Stream(_) => f.debug_tuple("Stream").finish(),
             Self::Datagram(_) => f.debug_tuple("Datagram").finish(),
+            Self::DatagramIo(_) => f.debug_tuple("DatagramIo").finish(),
         }
     }
 }
@@ -133,7 +141,9 @@ impl From<&ServerConnectionMode> for ConnectionType {
     fn from(value: &ServerConnectionMode) -> Self {
         match value {
             ServerConnectionMode::Stream(_) => ConnectionType::Stream,
-            ServerConnectionMode::Datagram(_) => ConnectionType::Datagram,
+            ServerConnectionMode::Datagram(_) | ServerConnectionMode::DatagramIo(_) => {
+                ConnectionType::Datagram
+            }
         }
     }
 }
@@ -663,6 +673,10 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
                 conn_manager.clone(),
             ))
         }
+        ServerConnectionMode::DatagramIo(outside_io) => Box::new(io::outside::DatagramServer::new(
+            outside_io,
+            conn_manager.clone(),
+        )),
         ServerConnectionMode::Stream(may_be_sock) => Box::new(
             io::outside::TcpServer::new(
                 conn_manager.clone(),

--- a/lightway-server/src/lib.rs
+++ b/lightway-server/src/lib.rs
@@ -555,6 +555,7 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
     let ip_manager = Arc::new(ip_manager);
 
     let connection_type = config.mode;
+
     let auth = Arc::new(AuthAdapter(config.auth));
 
     let inside_io: Arc<dyn InsideIO> = match config.inside_io.take() {
@@ -648,8 +649,7 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
 
     let mut server: Box<dyn Server> = match connection_type {
         ServerConnectionMode::Datagram(may_be_sock) => {
-            let udp_server = io::outside::UdpServer::new(
-                conn_manager.clone(),
+            let udp_io = io::outside::UdpIo::new(
                 config.bind_address,
                 config.udp_buffer_size,
                 config.enable_batch_receive,
@@ -657,8 +657,11 @@ pub async fn server<SA: for<'a> ServerAuth<AuthState<'a>> + Sync + Send + 'stati
                 may_be_sock,
             )
             .await?;
-            send_queue = udp_server.send_queue();
-            Box::new(udp_server)
+            send_queue = udp_io.send_queue();
+            Box::new(io::outside::DatagramServer::new(
+                Box::new(udp_io),
+                conn_manager.clone(),
+            ))
         }
         ServerConnectionMode::Stream(may_be_sock) => Box::new(
             io::outside::TcpServer::new(

--- a/lightway-server/src/metrics.rs
+++ b/lightway-server/src/metrics.rs
@@ -44,7 +44,6 @@ static METRIC_UDP_REJECTED_SESSION: LazyLock<Counter> =
     LazyLock::new(|| counter!("udp_rejected_session"));
 static METRIC_UDP_PARSE_WIRE_FAILED: LazyLock<Counter> =
     LazyLock::new(|| counter!("udp_parse_wire_failed"));
-static METRIC_UDP_NO_HEADER: LazyLock<Counter> = LazyLock::new(|| counter!("udp_no_header"));
 static METRIC_UDP_SESSION_ROTATION_BEGIN: LazyLock<Counter> =
     LazyLock::new(|| counter!("udp_session_rotation_begin"));
 static METRIC_UDP_SESSION_ROTATION_FINALIZED: LazyLock<Counter> =
@@ -287,10 +286,6 @@ pub(crate) fn udp_rejected_session() {
 
 pub(crate) fn udp_parse_wire_failed() {
     METRIC_UDP_PARSE_WIRE_FAILED.increment(1);
-}
-
-pub(crate) fn udp_no_header() {
-    METRIC_UDP_NO_HEADER.increment(1);
 }
 
 pub(crate) fn udp_recv_truncated() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Makes outside IO injectable on both the server and the client, the way inside IO already is. An application supplies a datagram transport; lightway keeps the receive loop and all of the dispatch, so a transport never touches ConnectionManager.

ServerConfig::outside_io and ClientConnectionConfig::outside_io take an OutsideIO: recv, recv_many (defaults to one packet, so a transport without a batch syscall implements recv alone), send_callback, send_unconnected, plus a RecvMeta { peer, local }. On the server UdpServer splits into UdpIo (the socket, still private) and DatagramServer (the loop).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Inside IO has been injectable for a while, so a tun replacement can live outside this repository. Outside IO could not: UdpServer owned both the socket and the receive loop, and the packet handling was inlined into it, so a new transport meant either adding it here or duplicating the loop, the dispatch and the roaming rules.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and with CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] The correct base branch is being used, if not `main`
