### PR TITLE
core: allow explicit outside MTU for datagram carriers

### DIFF
--- a/docs/pmtu_discovery.md
+++ b/docs/pmtu_discovery.md
@@ -35,3 +35,24 @@ does for the packets it sends itself.
 At present, PMTU discovery is only enabled on client side. In future, we may enable
 it in Server.
 
+## Outside MTU and the advertised inside MTU
+
+A datagram connection carries each inside packet in one outside datagram. The outside MTU
+therefore bounds the inside MTU. `ServerConnectionBuilder::with_outside_mtu` sets the outside
+MTU for a carrier whose per-frame budget is below the wire MTU, because it frames Lightway
+inside its own datagrams. The DTLS record size follows that MTU.
+
+The server reduces the inside MTU it advertises to what its own outside path can carry. The
+reduction is a ceiling only. A carrier that already sizes its inside MTU under the budget
+passes through unchanged. A stream carrier is never reduced.
+
+`MIN_INSIDE_MTU` is advisory. It is not a floor on what a connection advertises. A datagram
+carrier whose per-frame budget is smaller than a UDP datagram can advertise below it. That
+budget can also depend on what the peer announces, so the connection builder cannot know it.
+
+A client rejects an advertised inside MTU that its own outside MTU cannot carry. It returns
+`ConnectionError::OutsideMtuTooSmallForInsideMtu`. The client applies this check only in two
+cases: PMTUD runs, or `ClientConnectionBuilder::with_strict_mtu` marks the carrier as unable to
+fall back on IP fragmentation. A carrier with neither relies on fragmentation and stays
+connected.
+

--- a/lightway-core/src/connection.rs
+++ b/lightway-core/src/connection.rs
@@ -208,15 +208,20 @@ pub enum ConnectionError {
     #[error("Invalid inside packet: {0}")]
     InvalidInsidePacket(InvalidPacketError),
 
-    /// Invalid Outside MTU
+    /// The outside MTU cannot carry the inside MTU the peer advertised, and
+    /// this connection has no way to shrink the gap: either PMTUD is running
+    /// (so the advertised MTU was never achievable) or the carrier is
+    /// strict-MTU and cannot fall back on IP fragmentation.
     #[error(
-        "PMTUD required: inside MTU {inside_mtu} needs at least {required_outside_mtu} outside MTU"
+        "inside MTU {inside_mtu} requires at least {required_outside_mtu} outside MTU, but outside MTU is {outside_mtu}"
     )]
-    PathMtuDiscoveryRequired {
+    OutsideMtuTooSmallForInsideMtu {
         /// The inside MTU
         inside_mtu: usize,
         /// The required outside MTU to support the inside MTU without PMTUD
         required_outside_mtu: usize,
+        /// The actual outside MTU the connection was built with
+        outside_mtu: usize,
     },
 
     /// Plugin returns a reply packet
@@ -287,7 +292,7 @@ impl ConnectionError {
                     PacketCodecDoesNotExist => true,
                     PacketCodecError(_) => true,
                     Disconnected => true,
-                    PathMtuDiscoveryRequired { .. } => true,
+                    OutsideMtuTooSmallForInsideMtu { .. } => true,
                     Tls(crate::tls::Error::Fatal(ErrorKind::DomainNameMismatch)) => true,
                     Tls(crate::tls::Error::Fatal(ErrorKind::DuplicateMessage)) => true,
                     Tls(crate::tls::Error::Fatal(ErrorKind::PeerClosed)) => true,
@@ -579,6 +584,14 @@ pub struct Connection<AppState: Send = ()> {
     /// PMTU discovery state ([`ConnectionType::Datagram`] only)
     pmtud: Option<dplpmtud::Dplpmtud<AppState>>,
 
+    /// True if the outside carrier cannot fall back on IP
+    /// fragmentation for a datagram that exceeds `outside_mtu`, as a
+    /// carrier that frames Lightway inside its own datagrams cannot.
+    /// Such carriers must hard-fail an
+    /// unsatisfiable MTU immediately rather than rely on the
+    /// leniency classic PMTUD-off UDP gets from IP fragmentation.
+    strict_mtu: bool,
+
     /// Counter to use for `wire::DataFrag`
     fragment_counter: std::num::Wrapping<u16>,
 
@@ -620,6 +633,7 @@ struct NewConnectionArgs<AppState> {
     max_fragment_map_entries: NonZeroU16,
     pmtud_timer: Option<dplpmtud::TimerArg<AppState>>,
     pmtud_base_mtu: Option<u16>,
+    strict_mtu: bool,
     inside_pkt_codec: Option<(PacketEncoderType, PacketDecoderType)>,
     expresslane: bool,
     expresslane_cb: Option<expresslane::ExpresslaneCbType<AppState>>,
@@ -679,6 +693,7 @@ impl<AppState: Send> Connection<AppState> {
                     )
                 }),
             },
+            strict_mtu: args.strict_mtu,
             fragment_counter: Wrapping(0),
             is_first_packet_received: false,
             inside_pkt_encoder,
@@ -2464,6 +2479,41 @@ impl<AppState: Send> Connection<AppState> {
         }
     }
 
+    /// The inside MTU to advertise to the peer: the inside interface's MTU,
+    /// reduced to what this connection's outside path can actually carry.
+    ///
+    /// The budget is the `Data` payload that fits one outside datagram:
+    /// `max_dtls_mtu` gives the DTLS record payload, and the record still
+    /// carries a `Data` frame around the inside packet.
+    ///
+    /// Datagram connections only. A stream carrier does not bound a single
+    /// inside packet, and the IP/UDP/DTLS-record overheads `max_dtls_mtu`
+    /// subtracts do not apply to it, so its inside MTU is advertised as-is.
+    ///
+    /// A ceiling only, with no clamp up to [`MIN_INSIDE_MTU`]: a datagram
+    /// carrier can genuinely fall below it, and advertising more than the
+    /// carrier can carry breaks the connection instead of saving it.
+    ///
+    /// [`MIN_INSIDE_MTU`]: crate::MIN_INSIDE_MTU
+    fn advertised_inside_mtu(
+        connection_type: ConnectionType,
+        outside_mtu: usize,
+        inside_mtu: usize,
+    ) -> usize {
+        if !connection_type.is_datagram() {
+            return inside_mtu;
+        }
+
+        let advertised =
+            wire::Data::maximum_packet_size_for_plpmtu(max_dtls_mtu(outside_mtu)).min(inside_mtu);
+        if advertised < inside_mtu {
+            info!(
+                "Advertising inside MTU {advertised} instead of {inside_mtu}: outside MTU {outside_mtu} cannot carry the full inside MTU"
+            );
+        }
+        advertised
+    }
+
     fn handle_auth_request(&mut self, auth_request: wire::AuthRequest) -> ConnectionResult<()> {
         let ConnectionMode::Server {
             auth,
@@ -2511,7 +2561,14 @@ impl<AppState: Send> Connection<AppState> {
                     local_ip: ip_config.client_ip.to_string(),
                     peer_ip: ip_config.server_ip.to_string(),
                     dns_ip: ip_config.dns_ip.to_string(),
-                    mtu: format!("{}", inside_io.mtu()),
+                    mtu: format!(
+                        "{}",
+                        Self::advertised_inside_mtu(
+                            self.connection_type,
+                            self.outside_mtu,
+                            inside_io.mtu()
+                        )
+                    ),
                     session: self.session_id,
                 });
 
@@ -2549,11 +2606,12 @@ impl<AppState: Send> Connection<AppState> {
         if let Ok(inside_mtu) = cfg.mtu.parse()
             && self.connection_type.is_datagram()
             && self.outside_mtu < dtls_required_outside_mtu(inside_mtu)
-            && self.pmtud.is_some()
+            && (self.pmtud.is_some() || self.strict_mtu)
         {
-            return Err(ConnectionError::PathMtuDiscoveryRequired {
+            return Err(ConnectionError::OutsideMtuTooSmallForInsideMtu {
                 inside_mtu,
                 required_outside_mtu: dtls_required_outside_mtu(inside_mtu),
+                outside_mtu: self.outside_mtu,
             });
         }
 
@@ -2962,6 +3020,7 @@ impl<AppState: Send> Connection<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{MAX_INSIDE_MTU, MAX_OUTSIDE_MTU, MIN_INSIDE_MTU, MIN_OUTSIDE_MTU};
 
     #[cfg(target_os = "linux")]
     mod gso_batch_tests {
@@ -3066,5 +3125,70 @@ mod tests {
     fn tick_data_is_nameable_and_debuggable() {
         fn assert_traits<T: std::fmt::Debug + Clone>() {}
         assert_traits::<crate::ExpresslaneTickData>();
+    }
+
+    /// A stream carrier does not bound a single inside packet, so its inside
+    /// MTU must reach the peer untouched even when the datagram formula would
+    /// have reduced it.
+    #[test]
+    fn advertised_inside_mtu_is_unclamped_for_stream() {
+        assert_eq!(
+            Conn::advertised_inside_mtu(ConnectionType::Stream, MIN_OUTSIDE_MTU, MAX_INSIDE_MTU),
+            MAX_INSIDE_MTU
+        );
+    }
+
+    /// A datagram carrier only clamps an inside MTU that genuinely does not
+    /// fit; anything the Data frame budget can carry passes through. A
+    /// narrow-budget carrier sizes its inside MTU from its own budget before
+    /// it reaches this function, so a clamp that rewrote safe values would
+    /// shrink every tunnel.
+    #[test]
+    fn advertised_inside_mtu_is_unclamped_when_the_budget_fits() {
+        let budget = wire::Data::maximum_packet_size_for_plpmtu(max_dtls_mtu(MAX_OUTSIDE_MTU));
+        assert_eq!(
+            Conn::advertised_inside_mtu(ConnectionType::Datagram, MAX_OUTSIDE_MTU, budget),
+            budget
+        );
+        assert_eq!(
+            Conn::advertised_inside_mtu(ConnectionType::Datagram, MAX_OUTSIDE_MTU, MAX_INSIDE_MTU),
+            budget,
+            "an inside MTU above the Data frame budget is reduced to it"
+        );
+    }
+
+    /// `dtls_required_outside_mtu` must be the exact inverse of the clamp
+    /// here, which is `Data::maximum_packet_size_for_plpmtu(max_dtls_mtu(..))`.
+    /// The two helpers meet across the connection: this side advertises with
+    /// one, the peer's strict-MTU check compares with the other, so an
+    /// off-by-one in either rejects a carrier that does fit. Not a floor;
+    /// `accept` admits a datagram outside MTU as low as one inside byte.
+    #[test]
+    fn advertised_inside_mtu_at_the_accepted_minimum_is_min_inside_mtu() {
+        let outside_mtu = dtls_required_outside_mtu(MIN_INSIDE_MTU);
+        assert_eq!(
+            Conn::advertised_inside_mtu(ConnectionType::Datagram, outside_mtu, MAX_INSIDE_MTU),
+            MIN_INSIDE_MTU
+        );
+    }
+
+    /// The DTLS budget helpers subtract 81 bytes of overhead, so an outside MTU
+    /// anywhere in `MIN_OUTSIDE_MTU..81` underflows on plain subtraction: a
+    /// panic under overflow checks, or a near-`usize::MAX` budget in release
+    /// that reads as "the full inside MTU fits".
+    #[test]
+    fn max_dtls_mtu_saturates_instead_of_underflowing() {
+        assert_eq!(max_dtls_mtu(MIN_OUTSIDE_MTU), 0);
+        assert_eq!(max_dtls_mtu(0), 0);
+    }
+
+    /// `tests/connection.rs` cannot see `dtls_required_outside_mtu`, so it
+    /// spells the datagram floor out as a literal sum. Pin the value here, so
+    /// a change to any overhead constant fails here rather than there. The
+    /// last two terms are the `Data` frame around the inside packet: its u16
+    /// length field and its FrameKind byte.
+    #[test]
+    fn dtls_required_outside_mtu_for_one_inside_byte() {
+        assert_eq!(dtls_required_outside_mtu(1), 1 + 20 + 8 + 16 + 37 + 2 + 1);
     }
 }

--- a/lightway-core/src/connection/builders.rs
+++ b/lightway-core/src/connection/builders.rs
@@ -10,7 +10,7 @@ use crate::{
     PacketEncoderType, ServerContext, ServerIpPoolArg, Version,
     connection::{EventCallbackArg, dplpmtud, fragment_map::FragmentMap, key_update},
     context::ServerAuthArg,
-    max_dtls_outside_mtu,
+    dtls_required_outside_mtu, max_dtls_outside_mtu,
     plugin::PluginFactoryError,
     wire::SessionId,
 };
@@ -56,6 +56,7 @@ pub struct ClientConnectionBuilder<AppState> {
     pmtud_timer: Option<dplpmtud::TimerArg<AppState>>,
     outside_plugins: Arc<PluginList>,
     inside_pkt_codec: Option<(PacketEncoderType, PacketDecoderType)>,
+    strict_mtu: bool,
 }
 
 impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
@@ -112,6 +113,7 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
             pmtud_base_mtu: None,
             outside_plugins,
             inside_pkt_codec: None,
+            strict_mtu: false,
         })
     }
 
@@ -211,6 +213,19 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
         }
     }
 
+    /// Marks the outside carrier as unable to fall back on IP
+    /// fragmentation for oversized datagrams, as a carrier that frames
+    /// Lightway inside its own datagrams does. An `outside_mtu` too
+    /// small for the peer's inside MTU
+    /// then fails the connection immediately instead of relying on
+    /// fragmentation, which classic PMTUD-off UDP still gets.
+    pub fn with_strict_mtu(self) -> Self {
+        Self {
+            strict_mtu: true,
+            ..self
+        }
+    }
+
     /// Sets the Inside Packet Codec which should be used for Lightway connection.
     /// See [`PacketEncoderType`] and [`PacketDecoderType`].
     pub fn with_inside_pkt_codec(
@@ -263,6 +278,7 @@ impl<AppState: Send + 'static> ClientConnectionBuilder<AppState> {
             max_fragment_map_entries: self.max_fragment_map_entries,
             pmtud_timer: self.pmtud_timer,
             pmtud_base_mtu: self.pmtud_base_mtu,
+            strict_mtu: self.strict_mtu,
             inside_pkt_codec: self.inside_pkt_codec,
             expresslane: self.ctx.expresslane,
             expresslane_cb: self.ctx.expresslane_cb.clone(),
@@ -283,12 +299,13 @@ pub struct ServerConnectionBuilder<'a, AppState> {
     ctx: &'a ServerContext<AppState>,
     auth: ServerAuthArg<AppState>,
     ip_pool: ServerIpPoolArg<AppState>,
-    session_config: crate::tls::SessionConfig<super::TlsIOAdapter>,
+    outside_io: OutsideIOSendCallbackArg,
     session_id: SessionId,
     event_cb: Option<EventCallbackArg>,
     max_fragment_map_entries: NonZeroU16,
     outside_plugins: Arc<PluginList>,
     inside_pkt_codec: Option<(PacketEncoderType, PacketDecoderType)>,
+    outside_mtu: usize,
 }
 
 impl<'a, AppState: Send + 'static> ServerConnectionBuilder<'a, AppState> {
@@ -304,35 +321,14 @@ impl<'a, AppState: Send + 'static> ServerConnectionBuilder<'a, AppState> {
 
         let session_id = StandardUniform.sample(&mut *ctx.rng.lock().unwrap());
 
-        let outside_mtu = MAX_OUTSIDE_MTU;
         let outside_plugins = ctx.outside_plugins.build()?;
         let outside_plugins = Arc::new(outside_plugins);
-
-        let io = super::TlsIOAdapter {
-            connection_type,
-            protocol_version,
-            aggressive_send: false,
-            outside_mtu,
-            recv_buf: BytesMut::new(),
-            send_buf: super::io_adapter::SendBuffer::new(outside_mtu),
-            io: outside_io,
-            session_id,
-            outside_plugins: outside_plugins.clone(),
-            #[cfg(target_os = "linux")]
-            gso_buf: super::io_adapter::GsoBuffer::default(),
-        };
-        let session_config =
-            crate::tls::SessionConfig::new(io).when(connection_type.is_datagram(), |s| {
-                s.with_dtls_mtu(max_dtls_outside_mtu(outside_mtu) as u16)
-                    .with_dtls_nonblocking(true)
-                    .with_dtls13_allow_ch_frag(true)
-            });
 
         Ok(Self {
             connection_type,
             protocol_version,
             ctx,
-            session_config,
+            outside_io,
             session_id,
             auth,
             ip_pool,
@@ -340,7 +336,24 @@ impl<'a, AppState: Send + 'static> ServerConnectionBuilder<'a, AppState> {
             max_fragment_map_entries: FragmentMap::DEFAULT_MAX_ENTRIES,
             outside_plugins,
             inside_pkt_codec: None,
+            outside_mtu: MAX_OUTSIDE_MTU,
         })
+    }
+
+    /// Sets the outside path (wire) MTU, for a carrier whose per-frame budget
+    /// is smaller than the wire MTU because it frames Lightway inside its own
+    /// datagrams. The DTLS MTU is derived from it, so it bounds every record
+    /// the connection emits.
+    ///
+    /// Range-checked by [`Self::accept`], which for a datagram connection
+    /// requires enough outside MTU to carry one inside byte: below
+    /// that the carrier cannot carry the smallest inside MTU Lightway may
+    /// advertise, and the budget can be peer-derived.
+    pub fn with_outside_mtu(self, outside_mtu: usize) -> Self {
+        Self {
+            outside_mtu,
+            ..self
+        }
     }
 
     /// Sets the callback to notify events
@@ -379,7 +392,46 @@ impl<'a, AppState: Send + 'static> ServerConnectionBuilder<'a, AppState> {
             ));
         }
 
-        let session = self.ctx.tls_ctx.new_session(self.session_config)?;
+        // One byte of inside packet, deliberately not
+        // `dtls_required_outside_mtu(MIN_INSIDE_MTU)`. A datagram carrier's
+        // per-frame budget can depend on what the peer announces, so it is not
+        // knowable here and can fall under that bound. An inside MTU the
+        // carrier cannot satisfy is for the peer's strict-MTU check to
+        // reject, which is the check that knows the real budget.
+        let min_outside_mtu = if self.connection_type.is_datagram() {
+            MIN_OUTSIDE_MTU.max(dtls_required_outside_mtu(1))
+        } else {
+            MIN_OUTSIDE_MTU
+        };
+        if !(min_outside_mtu..=MAX_OUTSIDE_MTU).contains(&self.outside_mtu) {
+            return Err(ConnectionBuilderError::UnsupportedOutsideMtu(
+                self.outside_mtu,
+            ));
+        }
+
+        // Built here rather than in `new` so `with_outside_mtu` can still
+        // change the MTU the send buffer and the DTLS record size derive from.
+        let io = super::TlsIOAdapter {
+            connection_type: self.connection_type,
+            protocol_version: self.protocol_version,
+            aggressive_send: false,
+            outside_mtu: self.outside_mtu,
+            recv_buf: BytesMut::new(),
+            send_buf: super::io_adapter::SendBuffer::new(self.outside_mtu),
+            io: self.outside_io,
+            session_id: self.session_id,
+            outside_plugins: self.outside_plugins.clone(),
+            #[cfg(target_os = "linux")]
+            gso_buf: super::io_adapter::GsoBuffer::default(),
+        };
+        let session_config =
+            crate::tls::SessionConfig::new(io).when(self.connection_type.is_datagram(), |s| {
+                s.with_dtls_mtu(max_dtls_outside_mtu(self.outside_mtu) as u16)
+                    .with_dtls_nonblocking(true)
+                    .with_dtls13_allow_ch_frag(true)
+            });
+
+        let session = self.ctx.tls_ctx.new_session(session_config)?;
 
         Ok(Connection::new(NewConnectionArgs {
             app_state,
@@ -395,7 +447,7 @@ impl<'a, AppState: Send + 'static> ServerConnectionBuilder<'a, AppState> {
                 pending_session_id: None,
             },
             rng: self.ctx.rng.clone(),
-            outside_mtu: MAX_OUTSIDE_MTU,
+            outside_mtu: self.outside_mtu,
             inside_io: Some(self.ctx.inside_io.clone()),
             schedule_tick_cb: self.ctx.schedule_tick_cb,
             event_cb: self.event_cb,
@@ -404,6 +456,7 @@ impl<'a, AppState: Send + 'static> ServerConnectionBuilder<'a, AppState> {
             max_fragment_map_entries: self.max_fragment_map_entries,
             pmtud_timer: None,
             pmtud_base_mtu: None,
+            strict_mtu: false,
             inside_pkt_codec: self.inside_pkt_codec,
             expresslane: self.ctx.expresslane,
             expresslane_cb: self.ctx.expresslane_cb.clone(),

--- a/lightway-core/src/lib.rs
+++ b/lightway-core/src/lib.rs
@@ -78,9 +78,17 @@ pub const MAX_OUTSIDE_MTU: usize = 1500;
 pub const MIN_OUTSIDE_MTU: usize = 68;
 
 /// The minimum usable outside path (wire) MTU required for a given
-/// inside path MTU
+/// inside path MTU, carried in one datagram. Includes the `Data` frame
+/// the DTLS record carries around the inside packet, so it stays the
+/// exact inverse of the `advertised_inside_mtu` clamp.
 const fn dtls_required_outside_mtu(inside_mtu: usize) -> usize {
-    inside_mtu + IPV4_HEADER_SIZE + UDP_HEADER_SIZE + wire::Header::WIRE_SIZE + MAX_DTLS_HEADER_SIZE
+    inside_mtu
+        + IPV4_HEADER_SIZE
+        + UDP_HEADER_SIZE
+        + wire::Header::WIRE_SIZE
+        + MAX_DTLS_HEADER_SIZE
+        + wire::Data::WIRE_OVERHEAD
+        + std::mem::size_of::<wire::FrameKind>()
 }
 
 const IPV4_HEADER_SIZE: usize = 20;
@@ -91,16 +99,29 @@ const UDP_HEADER_SIZE: usize = 8;
 const MAX_DTLS_HEADER_SIZE: usize = 37;
 
 /// Default MTU size for DTLS on the outside path (max outside MTU less IP and UDP header size)
+///
+/// Saturating: `MIN_OUTSIDE_MTU` is below the overheads subtracted here, and a
+/// wrap would produce a near-`usize::MAX` MTU that reads as "everything fits".
 const fn max_dtls_outside_mtu(outside_mtu: usize) -> usize {
-    outside_mtu - IPV4_HEADER_SIZE - UDP_HEADER_SIZE - wire::Header::WIRE_SIZE
+    outside_mtu
+        .saturating_sub(IPV4_HEADER_SIZE)
+        .saturating_sub(UDP_HEADER_SIZE)
+        .saturating_sub(wire::Header::WIRE_SIZE)
 }
 
 /// Default MTU size for DTLS payload (max DTLS wire MTU less DTLS overheads)
+///
+/// Saturating for the same reason as [`max_dtls_outside_mtu`]: any
+/// `outside_mtu` below 81 would otherwise underflow.
 const fn max_dtls_mtu(outside_mtu: usize) -> usize {
-    max_dtls_outside_mtu(outside_mtu) - MAX_DTLS_HEADER_SIZE
+    max_dtls_outside_mtu(outside_mtu).saturating_sub(MAX_DTLS_HEADER_SIZE)
 }
 
 /// The smallest supported inside MTU.
+///
+/// Advisory, not a floor on what a connection advertises: a datagram carrier
+/// whose per-frame budget is smaller than a UDP datagram can advertise below
+/// it. An inside MTU the local carrier cannot satisfy is rejected by the peer.
 pub const MIN_INSIDE_MTU: usize = 1250;
 
 /// The largest supported inside MTU.

--- a/lightway-core/src/wire/data.rs
+++ b/lightway-core/src/wire/data.rs
@@ -30,7 +30,7 @@ pub(crate) struct Data<'data> {
 
 impl Data<'_> {
     /// Wire overhead in bytes
-    const WIRE_OVERHEAD: usize = 2;
+    pub(crate) const WIRE_OVERHEAD: usize = 2;
 
     /// The maximum payload size for a given Packetization Layer PMTU
     pub(crate) fn maximum_packet_size_for_plpmtu(plpmtu: usize) -> usize {

--- a/lightway-core/tests/certs.rs
+++ b/lightway-core/tests/certs.rs
@@ -19,6 +19,13 @@ use crate::common::get_test_timeout;
 use rcgen::RsaKeySize;
 
 async fn handshake(pki: &'static TestPki) -> Result<(), String> {
+    // Built before the timed window: the defaults touch the shared valid PKI,
+    // whose keygen only happens on first use.
+    let client_config = TestClientConfig {
+        root_ca: pki.root_ca(),
+        ..Default::default()
+    };
+
     let attempt = tokio::spawn(async move {
         let (client_sock, server_sock) = UnixStream::pair().expect("UnixStream");
         let client_sock = Arc::new(TestStreamSock(client_sock));
@@ -39,20 +46,10 @@ async fn handshake(pki: &'static TestPki) -> Result<(), String> {
                     metrics: None,
                     cert,
                     key,
+                    inside_mtu: None,
                 },
             ),
-            client(
-                client_sock,
-                TestClientConfig {
-                    cipher: None,
-                    pqc,
-                    server_dn: None,
-                    enable_codec: false,
-                    enable_expresslane: false,
-                    use_versioned_token: false,
-                    root_ca: pki.root_ca(),
-                },
-            )
+            client(client_sock, client_config)
         )
     });
 

--- a/lightway-core/tests/common/connection.rs
+++ b/lightway-core/tests/common/connection.rs
@@ -1,3 +1,4 @@
+use crate::common::certgen::TestPki;
 use crate::common::packet_codec::TestPacketCodecFactory;
 use async_trait::async_trait;
 use bytes::{BufMut, Bytes, BytesMut};
@@ -7,6 +8,7 @@ use lightway_app_utils::{
 };
 use lightway_core::*;
 use more_asserts::*;
+use rcgen::RsaKeySize;
 use std::{
     collections::HashSet,
     net::SocketAddr,
@@ -66,23 +68,35 @@ impl ServerAuthHandle for TestAuthHandle {
     }
 }
 
-pub struct ChannelTun(mpsc::UnboundedSender<Bytes>);
+/// The inside MTU a [`ChannelTun`] reports unless a test asks for another.
+pub const DEFAULT_TUN_MTU: usize = 1350;
+
+pub struct ChannelTun {
+    tx: mpsc::UnboundedSender<Bytes>,
+    mtu: usize,
+}
 
 impl ChannelTun {
     pub fn new() -> (Self, mpsc::UnboundedReceiver<Bytes>) {
+        Self::with_mtu(DEFAULT_TUN_MTU)
+    }
+
+    /// A tun that reports `mtu`, for a test that needs the inside interface to
+    /// be larger than the outside path can carry.
+    pub fn with_mtu(mtu: usize) -> (Self, mpsc::UnboundedReceiver<Bytes>) {
         let (tx, rx) = mpsc::unbounded_channel();
-        (Self(tx), rx)
+        (Self { tx, mtu }, rx)
     }
 }
 impl<T> InsideIOSendCallback<T> for ChannelTun {
     fn send(&self, buf: BytesMut, _state: &mut T) -> IOCallbackResult<usize> {
         let buf_len = buf.len();
-        self.0.send(buf.freeze()).expect("Send");
+        self.tx.send(buf.freeze()).expect("Send");
         IOCallbackResult::Ok(buf_len)
     }
 
     fn mtu(&self) -> usize {
-        1350
+        self.mtu
     }
 
     fn if_index(&self) -> std::io::Result<u32> {
@@ -169,12 +183,15 @@ impl OutsideIOSendCallback for TestDatagramSock {
         SocketAddr::from(([127, 0, 0, 1], 0))
     }
 
+    // A UnixDatagram has no IP layer to set DF on, so probing is a no-op
+    // rather than unimplemented: a test may enable PMTUD purely to reach the
+    // MTU checks that PMTUD gates, without ever completing a probe.
     fn enable_pmtud_probe(&self) -> std::io::Result<()> {
-        todo!()
+        Ok(())
     }
 
     fn disable_pmtud_probe(&self) -> std::io::Result<()> {
-        todo!()
+        Ok(())
     }
 }
 
@@ -231,6 +248,8 @@ pub struct TestServerConfig<'a> {
     pub metrics: Option<ExpresslaneMetricsType>,
     pub cert: Secret<'a>,
     pub key: Secret<'a>,
+    /// The MTU the server's tun reports; `None` is [`DEFAULT_TUN_MTU`].
+    pub inside_mtu: Option<usize>,
 }
 
 pub async fn server<S: TestSock>(sock: Arc<S>, config: TestServerConfig<'_>) {
@@ -242,11 +261,12 @@ pub async fn server<S: TestSock>(sock: Arc<S>, config: TestServerConfig<'_>) {
         metrics,
         cert: server_cert,
         key: server_key,
+        inside_mtu,
     } = config;
 
     let ip_pool = Arc::new(StaticIpPool);
 
-    let (tun, mut inside_rx) = ChannelTun::new();
+    let (tun, mut inside_rx) = ChannelTun::with_mtu(inside_mtu.unwrap_or(DEFAULT_TUN_MTU));
     let mut last_inside_rx = std::time::Instant::now();
 
     let packet_codec = TestPacketCodecFactory::default().build();
@@ -425,6 +445,16 @@ pub enum ClientTestState {
     MessageSent,
 }
 
+/// A PMTUD timer that never fires. The MTU checks PMTUD gates run at auth
+/// time, long before any probe would, so a test that only needs those checks
+/// does not need a real timer.
+struct NoopPmtudTimer;
+
+impl<AppState> DplpmtudTimer<AppState> for NoopPmtudTimer {
+    fn start(&self, _d: std::time::Duration, _state: &mut AppState) {}
+    fn stop(&self, _state: &mut AppState) {}
+}
+
 pub struct TestClientConfig<'a> {
     pub cipher: Option<Cipher>,
     pub pqc: PQCrypto,
@@ -433,6 +463,35 @@ pub struct TestClientConfig<'a> {
     pub enable_expresslane: bool,
     pub use_versioned_token: bool,
     pub root_ca: RootCertificate<'a>,
+    pub outside_mtu: usize,
+    pub enable_pmtud: bool,
+    pub strict_mtu: bool,
+    /// Where to report a fatal `outside_data_received` error instead of
+    /// panicking, so a test can assert on the typed [`ConnectionError`] rather
+    /// than on a substring of its `Display`.
+    pub fatal_error: Option<Arc<Mutex<Option<ConnectionError>>>>,
+}
+
+/// The common case: the shared valid PKI as trust anchor, the context's
+/// default cipher, [`PQCrypto::default`], no server domain-name validation, no
+/// codec, no expresslane, an unversioned auth token, no PMTUD, and a full-size
+/// non-strict outside MTU.
+impl Default for TestClientConfig<'static> {
+    fn default() -> Self {
+        Self {
+            cipher: None,
+            pqc: PQCrypto::default(),
+            server_dn: None,
+            enable_codec: false,
+            enable_expresslane: false,
+            use_versioned_token: false,
+            root_ca: TestPki::get_valid(2, RsaKeySize::_2048).root_ca(),
+            outside_mtu: MAX_OUTSIDE_MTU,
+            enable_pmtud: false,
+            strict_mtu: false,
+            fatal_error: None,
+        }
+    }
 }
 
 pub async fn client<S: TestSock>(sock: Arc<S>, config: TestClientConfig<'_>) {
@@ -444,6 +503,10 @@ pub async fn client<S: TestSock>(sock: Arc<S>, config: TestClientConfig<'_>) {
         enable_expresslane,
         use_versioned_token,
         root_ca: ca_cert,
+        outside_mtu,
+        enable_pmtud,
+        strict_mtu,
+        fatal_error,
     } = config;
 
     let (tun, mut inside_rx) = ChannelTun::new();
@@ -482,12 +545,16 @@ pub async fn client<S: TestSock>(sock: Arc<S>, config: TestClientConfig<'_>) {
 
     let client = client
         .build()
-        .start_connect(sock.clone().into_io_send_callback(), MAX_OUTSIDE_MTU)
+        .start_connect(sock.clone().into_io_send_callback(), outside_mtu)
         .unwrap()
         .when(use_versioned_token, |b| {
             b.with_auth_versioned_token("LET ME IN", Version::MAXIMUM)
         })
         .when(!use_versioned_token, |b| b.with_auth_token("LET ME IN"))
+        .when(enable_pmtud, |b| {
+            b.with_pmtud_timer(Arc::new(NoopPmtudTimer))
+        })
+        .when(strict_mtu, |b| b.with_strict_mtu())
         .with_event_cb(Box::new(event_cb))
         .with_inside_pkt_codec(packet_codec);
 
@@ -628,7 +695,13 @@ pub async fn client<S: TestSock>(sock: Arc<S>, config: TestClientConfig<'_>) {
                 let pkt = OutsidePacket::Wire(&mut buf, sock.connection_type());
                 if let Err(err) = client.outside_data_received(pkt) {
                     // TODO: fatal vs non-fatal;
-                    panic!("{err}")
+                    match &fatal_error {
+                        Some(sink) => {
+                            sink.lock().unwrap().replace(err);
+                            return;
+                        }
+                        None => panic!("{err}"),
+                    }
                 }
 
                 println!("Client: {:?}", client.state());

--- a/lightway-core/tests/connection.rs
+++ b/lightway-core/tests/connection.rs
@@ -26,23 +26,33 @@ async fn run_test_tcp<S: TestSock>(
     client_sock: Arc<S>,
 ) -> Arc<Mutex<Option<AuthMethod>>> {
     // Inside packet codec is only supported by Lightway UDP
-    run_test(cipher, pqc, server_sock, client_sock, false, false, false).await
+    run_test(
+        server_sock,
+        client_sock,
+        TestClientConfig {
+            cipher,
+            pqc,
+            ..Default::default()
+        },
+    )
+    .await
 }
 
 async fn run_test<S: TestSock>(
-    cipher: Option<Cipher>,
-    pqc: PQCrypto,
     server_sock: Arc<S>,
     client_sock: Arc<S>,
-    enable_codec: bool,
-    enable_expresslane: bool,
-    use_versioned_token: bool,
+    params: TestClientConfig<'_>,
 ) -> Arc<Mutex<Option<AuthMethod>>> {
     let (auth, last_method) = TestAuth::new();
 
     // Take the shared test PKI before the timeout window: RSA keygen is very
     // slow on QEMU (especially on RISCV) and only happens on first use.
     let pki = TestPki::get_valid(2, RsaKeySize::_2048);
+
+    let pqc = params.pqc;
+    let expresslane_rotation_interval = params
+        .enable_expresslane
+        .then_some(DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL);
 
     let test = async move {
         let (cert, key) = pki.server_secrets();
@@ -52,26 +62,15 @@ async fn run_test<S: TestSock>(
                 TestServerConfig {
                     auth,
                     pqc,
-                    expresslane: enable_expresslane
-                        .then_some(DEFAULT_EXPRESSLANE_KEYS_ROTATION_INTERVAL),
+                    expresslane: expresslane_rotation_interval,
                     conn_out: None,
                     metrics: None,
                     cert,
                     key,
+                    inside_mtu: None,
                 },
             ),
-            client(
-                client_sock,
-                TestClientConfig {
-                    cipher,
-                    pqc,
-                    server_dn: None,
-                    enable_codec,
-                    enable_expresslane,
-                    use_versioned_token,
-                    root_ca: pki.root_ca(),
-                },
-            )
+            client(client_sock, params)
         )
     };
 
@@ -106,23 +105,18 @@ async fn test_datagram_connection(
     enable_expresslane: bool,
 ) {
     // Communicate over a local datagram socket for simplicity
-    let (client_sock, server_sock) = UnixDatagram::pair().expect("UnixDatagram");
-    let socket = socket2::SockRef::from(&client_sock);
-    socket.set_recv_buffer_size(1024 * 256).unwrap();
-    let socket = socket2::SockRef::from(&server_sock);
-    socket.set_recv_buffer_size(1024 * 256).unwrap();
-
-    let server_sock = Arc::new(TestDatagramSock(server_sock));
-    let client_sock = Arc::new(TestDatagramSock(client_sock));
+    let (server_sock, client_sock) = datagram_sock_pair();
 
     run_test(
-        cipher,
-        pqc,
         server_sock,
         client_sock,
-        enable_codec,
-        enable_expresslane,
-        false,
+        TestClientConfig {
+            cipher,
+            pqc,
+            enable_codec,
+            enable_expresslane,
+            ..Default::default()
+        },
     )
     .await;
 }
@@ -160,6 +154,7 @@ async fn inside_pkt_codec_stall_triggers_codec_downgrade() {
             metrics: None,
             cert,
             key,
+            inside_mtu: None,
         },
     ));
 
@@ -317,27 +312,17 @@ async fn test_stream_connection(cipher: Option<Cipher>, pqc: PQCrypto) {
 /// client's [`Version::MAXIMUM`].
 #[tokio::test]
 async fn test_datagram_connection_versioned_token() {
-    let (client_sock, server_sock) = UnixDatagram::pair().expect("UnixDatagram");
-    let socket = socket2::SockRef::from(&client_sock);
-    socket.set_recv_buffer_size(1024 * 256).unwrap();
-    let socket = socket2::SockRef::from(&server_sock);
-    socket.set_recv_buffer_size(1024 * 256).unwrap();
+    let (server_sock, client_sock) = datagram_sock_pair();
 
-    let server_sock = Arc::new(TestDatagramSock(server_sock));
-    let client_sock = Arc::new(TestDatagramSock(client_sock));
-
-    let pqc = PQCrypto {
-        server_pqc: false,
-        keyshare: None,
-    };
+    let pqc = no_pqc();
     let last_method = run_test(
-        None,
-        pqc,
         server_sock,
         client_sock,
-        false,
-        false,
-        true, // use_versioned_token
+        TestClientConfig {
+            pqc,
+            use_versioned_token: true,
+            ..Default::default()
+        },
     )
     .await;
 
@@ -363,18 +348,15 @@ async fn test_stream_connection_versioned_token() {
 
     let _ = client_sock.writable().await;
 
-    let pqc = PQCrypto {
-        server_pqc: false,
-        keyshare: None,
-    };
+    let pqc = no_pqc();
     let last_method = run_test(
-        None,
-        pqc,
         server_sock,
         client_sock,
-        false,
-        false,
-        true, // use_versioned_token
+        TestClientConfig {
+            pqc,
+            use_versioned_token: true,
+            ..Default::default()
+        },
     )
     .await;
 
@@ -393,7 +375,7 @@ async fn test_stream_connection_versioned_token() {
 #[cfg_attr(boringssl, test_case(Some("invalid") => panics "TLS Error: Fatal error: DomainNameMismatch"; "Invalid server domain name"))]
 #[cfg_attr(wolfssl, test_case(Some("invalid") => panics "TLS Error: Fatal: Domain name mismatch"; "Invalid server domain name"))]
 #[tokio::test]
-async fn test_server_dn(server_dn: Option<&str>) {
+async fn test_server_dn(server_dn: Option<&'static str>) {
     // Communicate over a local stream socket for simplicity
     let (client_sock, server_sock) = UnixStream::pair().expect("UnixStream");
     let server_sock = Arc::new(TestStreamSock(server_sock));
@@ -422,20 +404,18 @@ async fn test_server_dn(server_dn: Option<&str>) {
                         metrics: None,
                         cert,
                         key,
+                        inside_mtu: None,
                     },
                 )
             },
             client(
                 client_sock,
                 TestClientConfig {
-                    cipher: None,
                     pqc,
                     server_dn,
-                    enable_codec: false,
-                    enable_expresslane: false,
-                    use_versioned_token: false,
                     root_ca: pki.root_ca(),
-                },
+                    ..Default::default()
+                }
             )
         )
     };
@@ -534,6 +514,7 @@ async fn server_nudge_rotates_both_ends_while_client_is_idle() {
             metrics: None,
             cert,
             key,
+            inside_mtu: None,
         },
     );
 
@@ -695,6 +676,7 @@ async fn expresslane_health_probe(
             metrics: server_metrics,
             cert,
             key,
+            inside_mtu: None,
         },
     );
 
@@ -961,13 +943,12 @@ async fn pmtud_reports_status_changes() {
             self.inner.peer_addr()
         }
 
-        // Unix datagram sockets have no DF bit; accept the probe bracket.
         fn enable_pmtud_probe(&self) -> std::io::Result<()> {
-            Ok(())
+            self.inner.enable_pmtud_probe()
         }
 
         fn disable_pmtud_probe(&self) -> std::io::Result<()> {
-            Ok(())
+            self.inner.disable_pmtud_probe()
         }
     }
 
@@ -1015,6 +996,7 @@ async fn pmtud_reports_status_changes() {
             metrics: None,
             cert,
             key,
+            inside_mtu: None,
         },
     ));
 
@@ -1155,4 +1137,254 @@ async fn pmtud_reports_status_changes() {
             other => panic!("expected the probe send right after {s:?}, found {other:?}"),
         }
     }
+}
+
+fn datagram_sock_pair() -> (Arc<TestDatagramSock>, Arc<TestDatagramSock>) {
+    let (client_sock, server_sock) = UnixDatagram::pair().expect("UnixDatagram");
+    let socket = socket2::SockRef::from(&client_sock);
+    socket.set_recv_buffer_size(1024 * 256).unwrap();
+    let socket = socket2::SockRef::from(&server_sock);
+    socket.set_recv_buffer_size(1024 * 256).unwrap();
+
+    (
+        Arc::new(TestDatagramSock(server_sock)),
+        Arc::new(TestDatagramSock(client_sock)),
+    )
+}
+
+fn no_pqc() -> PQCrypto {
+    PQCrypto {
+        server_pqc: false,
+        keyshare: None,
+    }
+}
+
+/// A server whose tun keeps the kernel default 1500 must not advertise an
+/// inside MTU no client can carry. `dtls_required_outside_mtu(1500)` is 1584,
+/// above `MAX_OUTSIDE_MTU`, so a PMTUD client rejects the auth response and the
+/// connection dies immediately after authenticating. The server must instead
+/// advertise what its own outside path can carry.
+#[tokio::test]
+async fn server_advertises_an_inside_mtu_a_client_can_carry() {
+    let (server_sock, client_sock) = datagram_sock_pair();
+    let (auth, _) = TestAuth::new();
+
+    // Take the shared test PKI before the timeout window (see run_test).
+    let pki = TestPki::get_valid(2, RsaKeySize::_2048);
+    let (cert, key) = pki.server_secrets();
+
+    let fatal_error = Arc::new(Mutex::new(None));
+    let params = TestClientConfig {
+        pqc: no_pqc(),
+        enable_pmtud: true,
+        fatal_error: Some(fatal_error.clone()),
+        root_ca: pki.root_ca(),
+        ..Default::default()
+    };
+
+    // `select!`, not `join!`: the server future only ever returns once its
+    // client is done, and a client that rejects the MTU gives up mid-auth.
+    let server_config = TestServerConfig {
+        auth,
+        pqc: no_pqc(),
+        expresslane: None,
+        conn_out: None,
+        metrics: None,
+        cert,
+        key,
+        inside_mtu: Some(MAX_INSIDE_MTU),
+    };
+    let test = async move {
+        tokio::select! {
+            _ = server(server_sock, server_config) => false,
+            _ = client(client_sock, params) => true,
+        }
+    };
+    let client_returned =
+        tokio::time::timeout(std::time::Duration::from_millis(get_test_timeout()), test)
+            .await
+            .expect("Timed out");
+
+    let err = fatal_error.lock().unwrap().take();
+    assert!(
+        err.is_none(),
+        "the server advertised an inside MTU the client cannot carry: {err:?}"
+    );
+    // `client` returns only after it went Online and round-tripped its
+    // message, or after it recorded a fatal error. Without this the test also
+    // passes when the server future wins the race and the client never
+    // authenticated at all.
+    assert!(client_returned, "the client never completed its exchange");
+}
+
+/// The smallest outside MTU a datagram connection accepts: enough to carry one
+/// byte of inside packet after IP/UDP/wire/DTLS overhead, plus the 3 bytes of
+/// `Data` frame around it. Spelled out because `dtls_required_outside_mtu` is
+/// crate-private; the sum is pinned by `dtls_required_outside_mtu_for_one_inside_byte`
+/// in `connection.rs`. Deliberately not `MIN_INSIDE_MTU`-derived: a datagram
+/// carrier's budget can depend on what its peer announces, so `accept` cannot
+/// know it.
+const MIN_DATAGRAM_OUTSIDE_MTU: usize = 1 + 20 + 8 + 16 + 37 + 3;
+
+/// A realistic per-frame budget for a carrier that frames Lightway inside its
+/// own datagrams, at the standard IPv4 path MTU: (1500 - 20 IP - 8 UDP) send
+/// ceiling, less 44 bytes of the carrier's own per-frame overhead. Such a
+/// carrier sizes its inside MTU to the `Data` frame budget of this, 1344.
+/// Pinned because `accept` must admit the value the carrier really passes.
+const NARROW_CARRIER_BUDGET: usize = 1428;
+
+/// [`ServerConnectionBuilder::with_outside_mtu`] must reject an MTU the carrier
+/// cannot actually use and accept values inside the usable range. The range is
+/// checked by `accept()`, the first step that can report an error.
+#[tokio::test]
+async fn with_outside_mtu_validates_range() {
+    let pki = TestPki::get_valid(2, RsaKeySize::_2048);
+    let (server_cert, server_key) = pki.server_secrets();
+    let (auth, _) = TestAuth::new();
+    let ip_pool = Arc::new(StaticIpPool);
+    let (tun, _) = ChannelTun::new();
+
+    let server_ctx = ServerContextBuilder::<ConnectionTicker>::new(
+        ConnectionType::Datagram,
+        server_cert,
+        server_key,
+        auth,
+        ip_pool,
+        Arc::new(tun),
+        connection_ticker_cb,
+    )
+    .unwrap()
+    .with_minimum_protocol_version(Version::MINIMUM)
+    .unwrap()
+    .with_maximum_protocol_version(Version::MAXIMUM)
+    .unwrap()
+    .build()
+    .unwrap();
+
+    let (_client_sock, server_sock) = UnixDatagram::pair().unwrap();
+    let server_sock = Arc::new(TestDatagramSock(server_sock));
+    let io = server_sock.clone().into_io_send_callback();
+
+    let accept_with_mtu = |outside_mtu| {
+        let (ticker, _ticker_task) = ConnectionTicker::new();
+        server_ctx
+            .start_accept(Version::MAXIMUM, io.clone())
+            .unwrap()
+            .with_outside_mtu(outside_mtu)
+            .accept(ticker)
+    };
+
+    for (label, outside_mtu) in [
+        ("below the datagram floor", MIN_DATAGRAM_OUTSIDE_MTU - 1),
+        // The RFC-791 IP minimum is 13 bytes short of the 81 bytes of overhead
+        // `max_dtls_mtu` subtracts, so it is not a usable datagram MTU at all.
+        ("the RFC-791 IP minimum", MIN_OUTSIDE_MTU),
+        ("above the wire MTU", MAX_OUTSIDE_MTU + 1),
+    ] {
+        let err = accept_with_mtu(outside_mtu)
+            .err()
+            .unwrap_or_else(|| panic!("expected an error for {label} ({outside_mtu})"));
+        assert!(
+            matches!(err, ConnectionBuilderError::UnsupportedOutsideMtu(_)),
+            "expected UnsupportedOutsideMtu for {label} ({outside_mtu}), got {err:?}"
+        );
+    }
+
+    assert!(
+        accept_with_mtu(NARROW_CARRIER_BUDGET).is_ok(),
+        "a narrow-budget carrier's real budget must be accepted, or it carries nothing"
+    );
+    assert!(
+        accept_with_mtu(MIN_DATAGRAM_OUTSIDE_MTU).is_ok(),
+        "expected the bottom of the usable datagram range to be accepted"
+    );
+    assert!(
+        accept_with_mtu(MAX_OUTSIDE_MTU).is_ok(),
+        "expected the full wire MTU to be accepted"
+    );
+}
+
+/// ChannelTun reports `mtu() = 1350`, so `dtls_required_outside_mtu(1350)` is
+/// 1350 + 20 + 8 + 16 + 37 + 3 = 1434. An `outside_mtu` of 1400 is below that (so
+/// the strict-MTU guard fires) but close enough to `MAX_OUTSIDE_MTU` that the
+/// DTLS handshake still completes normally.
+const INSUFFICIENT_OUTSIDE_MTU: usize = 1400;
+
+/// Classic PMTUD-off UDP with an `outside_mtu` too small for the
+/// server-negotiated inside MTU must still reach `Online`, relying on
+/// IP fragmentation. Without the `pmtud.is_some() || strict_mtu` guard this
+/// hard-fails every such connection instead of falling back to fragmentation.
+#[tokio::test]
+async fn test_datagram_insufficient_outside_mtu_without_pmtud_falls_back_to_fragmentation() {
+    let (server_sock, client_sock) = datagram_sock_pair();
+
+    run_test(
+        server_sock,
+        client_sock,
+        TestClientConfig {
+            pqc: no_pqc(),
+            outside_mtu: INSUFFICIENT_OUTSIDE_MTU,
+            // Classic UDP, which fragments instead.
+            strict_mtu: false,
+            ..Default::default()
+        },
+    )
+    .await;
+}
+
+/// The same undersized-`outside_mtu` scenario, but for a strict-MTU
+/// carrier, which has no IP-fragmentation fallback: this
+/// must still hard-fail at auth, since silently proceeding would mean
+/// packets that can never be delivered.
+#[tokio::test]
+async fn test_datagram_insufficient_outside_mtu_strict_mtu_hard_fails() {
+    let (server_sock, client_sock) = datagram_sock_pair();
+    let (auth, _) = TestAuth::new();
+
+    // Take the shared test PKI before the timeout window (see run_test).
+    let pki = TestPki::get_valid(2, RsaKeySize::_2048);
+    let (cert, key) = pki.server_secrets();
+
+    let fatal_error = Arc::new(Mutex::new(None));
+    let params = TestClientConfig {
+        pqc: no_pqc(),
+        outside_mtu: INSUFFICIENT_OUTSIDE_MTU,
+        // No fragmentation fallback.
+        strict_mtu: true,
+        fatal_error: Some(fatal_error.clone()),
+        root_ca: pki.root_ca(),
+        ..Default::default()
+    };
+
+    // `select!`, not `join!`: the server future only ever returns once its
+    // client is done, and this client gives up mid-auth.
+    let server_config = TestServerConfig {
+        auth,
+        pqc: no_pqc(),
+        expresslane: None,
+        conn_out: None,
+        metrics: None,
+        cert,
+        key,
+        inside_mtu: None,
+    };
+    let test = async move {
+        tokio::select! {
+            _ = server(server_sock, server_config) => {},
+            _ = client(client_sock, params) => {},
+        }
+    };
+    tokio::time::timeout(std::time::Duration::from_millis(get_test_timeout()), test)
+        .await
+        .expect("Timed out");
+
+    let err = fatal_error
+        .lock()
+        .unwrap()
+        .take()
+        .expect("the client must reject the server's inside MTU");
+    assert!(
+        matches!(err, ConnectionError::OutsideMtuTooSmallForInsideMtu { .. }),
+        "expected OutsideMtuTooSmallForInsideMtu, got {err:?}"
+    );
 }


### PR DESCRIPTION
## Description

A datagram connection sends each inside packet in one outside datagram, so the outside MTU sets a
limit on the inside MTU. This change makes both sides obey that limit:

- `ServerConnectionBuilder::with_outside_mtu()` sets the outside MTU for a carrier whose
  per-frame budget is less than the wire MTU. `accept()` does a range check on it, and the DTLS
  record size follows it.
- `Connection::advertised_inside_mtu()` decreases the advertised inside MTU to the value that
  the outside path can send. This decrease is a ceiling only. A stream carrier, and a datagram
  carrier that already fits, keep their value.
- `ClientConnectionBuilder::with_strict_mtu()` marks a carrier that cannot use IP fragmentation.
  Such a carrier stops with an error on an MTU that it cannot send.
- Error `ConnectionError::PathMtuDiscoveryRequired` becomes `OutsideMtuTooSmallForInsideMtu`,
  and it gives the actual outside MTU next to the required one.
- Helpers `max_dtls_mtu()` and `max_dtls_outside_mtu()` now saturate. An outside MTU of less
  than 81 bytes went below zero before, and gave a value near `usize::MAX`.

`docs/pmtu_discovery.md` explains the limit and calls `MIN_INSIDE_MTU` advisory.

## Motivation and Context

The server advertised the raw MTU of the inside IO. With the Tun driver and no explicit MTU, the TUN
keeps the kernel default of 1500 bytes. That value needs an outside MTU of 1584 bytes, which is more
than `MAX_OUTSIDE_MTU`, so the client stopped right after authentication. A deployment that configures an
explicit inside MTU small enough for its outside path is not affected.

A correction for this existed on an earlier branch, but it never came to `main`. This is recovered
work, not a new defect.

## How Has This Been Tested?

Environment: Linux x86_64, `nix develop .#default`.

| Command                                                 | Result               |
| ------------------------------------------------------- | -------------------- |
| `cargo nextest run -p lightway-core --lib`              | 507 passed, 0 failed |
| `cargo nextest run -p lightway-core --tests`            | 570 passed, 0 failed |
| `cargo clippy --workspace --all-targets -- -D warnings` | Clean                |

New tests: three unit tests for `advertised_inside_mtu()`, and four integration tests for the
handshake, the range check, the lenient path, and the strict path. The test harness gets a TUN MTU, a
PMTUD switch, a strict-MTU switch, and a sink for a fatal client error.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Downstream consumers `lightway-core`:

- The renamed error variant has a new `outside_mtu` field. No crate in this workspace uses the old
  name.
- If its outside path is too small, a datagram server now advertises a decreased inside MTU.

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`

